### PR TITLE
fix: replace fixed-size buffers with dynamic allocation

### DIFF
--- a/runfiles-stub/.cargo/config.toml
+++ b/runfiles-stub/.cargo/config.toml
@@ -1,17 +1,17 @@
 [target.x86_64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-nostartfiles", "-C", "link-arg=-static", "-C", "link-arg=-no-pie", "-C", "relocation-model=static"]
+rustflags = ["-C", "panic=abort", "-C", "link-arg=-nostartfiles", "-C", "link-arg=-static", "-C", "link-arg=-no-pie", "-C", "relocation-model=static"]
 
 [target.aarch64-unknown-linux-gnu]
-rustflags = ["-C", "link-arg=-nostartfiles", "-C", "link-arg=-static", "-C", "link-arg=-no-pie", "-C", "relocation-model=static"]
+rustflags = ["-C", "panic=abort", "-C", "link-arg=-nostartfiles", "-C", "link-arg=-static", "-C", "link-arg=-no-pie", "-C", "relocation-model=static"]
 
 [target.x86_64-apple-darwin]
-rustflags = ["-C", "link-arg=-lSystem"]
+rustflags = ["-C", "panic=abort", "-C", "link-arg=-lSystem"]
 
 [target.aarch64-apple-darwin]
-rustflags = ["-C", "link-arg=-lSystem"]
+rustflags = ["-C", "panic=abort", "-C", "link-arg=-lSystem"]
 
 [target.x86_64-pc-windows-msvc]
-rustflags = []
+rustflags = ["-C", "panic=abort"]
 
 [target.x86_64-pc-windows-gnu]
-rustflags = []
+rustflags = ["-C", "panic=abort"]

--- a/runfiles-stub/Cargo.toml
+++ b/runfiles-stub/Cargo.toml
@@ -3,6 +3,11 @@ name = "runfiles-stub"
 version = "0.1.0"
 edition = "2021"
 
+[dependencies]
+# talc allocator configured for stable Rust (disable allocator and nightly_api features)
+# We wrap it manually since we're single-threaded and don't need lock_api
+talc = { version = "4", default-features = false }
+
 [profile.release]
 opt-level = "z"
 lto = true

--- a/runfiles-stub/src/linux.rs
+++ b/runfiles-stub/src/linux.rs
@@ -1,9 +1,43 @@
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::alloc::{GlobalAlloc, Layout};
+use core::cell::UnsafeCell;
 use core::panic::PanicInfo;
+use talc::{ClaimOnOom, Span, Talc};
+
+// Global allocator using talc with a static memory arena
+// 8 MiB should be plenty for manifest parsing, path resolution, and environment handling
+static mut ARENA: [u8; 8 * 1024 * 1024] = [0; 8 * 1024 * 1024];
+
+// Simple wrapper for single-threaded use (no locking needed)
+struct TalcAllocator(UnsafeCell<Talc<ClaimOnOom>>);
+unsafe impl Sync for TalcAllocator {}
+
+unsafe impl GlobalAlloc for TalcAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        (*self.0.get()).malloc(layout).map_or(core::ptr::null_mut(), |p| p.as_ptr())
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        (*self.0.get()).free(core::ptr::NonNull::new_unchecked(ptr), layout);
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: TalcAllocator = TalcAllocator(UnsafeCell::new(Talc::new(unsafe {
+    ClaimOnOom::new(Span::from_array(core::ptr::addr_of!(ARENA).cast_mut()))
+})));
 
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     exit(1);
 }
+
+// Required by alloc crate for exception handling (unused with panic=abort)
+#[no_mangle]
+extern "C" fn rust_eh_personality() {}
 
 // Compiler intrinsics (memcpy, memset)
 #[no_mangle]
@@ -360,26 +394,30 @@ fn find_byte(haystack: &[u8], needle: u8) -> Option<usize> {
     None
 }
 
-// Static buffer for reading environment during initialization
-// Using a static buffer here to avoid stack overflow from large stack allocation
-static mut GET_ENV_BUF: [u8; MAX_ENV_SIZE] = [0; MAX_ENV_SIZE];
-
-// Environment variable reading
-fn get_env_var(name: &[u8], buf: &mut [u8]) -> Option<usize> {
-    let environ_buf = unsafe { &mut GET_ENV_BUF };
+// Environment variable reading - returns the value as a String
+// Returns None if the variable doesn't exist or isn't valid UTF-8
+fn get_env_var(name: &[u8]) -> Option<String> {
     let fd = open(b"/proc/self/environ\0");
     if fd < 0 {
         return None;
     }
 
-    let bytes_read = read(fd, environ_buf);
+    // Read environment into Vec
+    let mut environ_data = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        let bytes_read = read(fd, &mut chunk);
+        if bytes_read <= 0 {
+            break;
+        }
+        environ_data.extend_from_slice(&chunk[..bytes_read as usize]);
+    }
     close(fd);
 
-    if bytes_read <= 0 {
+    if environ_data.is_empty() {
         return None;
     }
 
-    let environ_data = &environ_buf[..bytes_read as usize];
     let mut pos = 0;
 
     while pos < environ_data.len() {
@@ -394,9 +432,8 @@ fn get_env_var(name: &[u8], buf: &mut [u8]) -> Option<usize> {
             let value = &entry[eq_pos + 1..];
 
             if str_eq(key, name) {
-                let copy_len = value.len().min(buf.len());
-                buf[..copy_len].copy_from_slice(&value[..copy_len]);
-                return Some(copy_len);
+                // Convert to String, returning None if not valid UTF-8
+                return String::from_utf8(value.to_vec()).ok();
             }
         }
 
@@ -406,59 +443,32 @@ fn get_env_var(name: &[u8], buf: &mut [u8]) -> Option<usize> {
     None
 }
 
-// Manifest entry storage (simplified - using static arrays)
-const MAX_ENTRIES: usize = 1024;
-const MAX_PATH_LEN: usize = 256;
-
+// Manifest entry using String for UTF-8 paths
 struct ManifestEntry {
-    key: [u8; MAX_PATH_LEN],
-    key_len: usize,
-    value: [u8; MAX_PATH_LEN],
-    value_len: usize,
+    key: String,
+    value: String,
 }
 
 struct Manifest {
-    entries: [ManifestEntry; MAX_ENTRIES],
-    count: usize,
+    entries: Vec<ManifestEntry>,
 }
 
 impl Manifest {
     fn new() -> Self {
-        const EMPTY_ENTRY: ManifestEntry = ManifestEntry {
-            key: [0; MAX_PATH_LEN],
-            key_len: 0,
-            value: [0; MAX_PATH_LEN],
-            value_len: 0,
-        };
-
-        Self {
-            entries: [EMPTY_ENTRY; MAX_ENTRIES],
-            count: 0,
-        }
+        Self { entries: Vec::new() }
     }
 
-    fn add_entry(&mut self, key: &[u8], value: &[u8]) {
-        if self.count >= MAX_ENTRIES {
-            return;
-        }
-
-        let entry = &mut self.entries[self.count];
-        let key_len = key.len().min(MAX_PATH_LEN);
-        let value_len = value.len().min(MAX_PATH_LEN);
-
-        entry.key[..key_len].copy_from_slice(&key[..key_len]);
-        entry.key_len = key_len;
-        entry.value[..value_len].copy_from_slice(&value[..value_len]);
-        entry.value_len = value_len;
-
-        self.count += 1;
+    fn add_entry(&mut self, key: &str, value: &str) {
+        self.entries.push(ManifestEntry {
+            key: String::from(key),
+            value: String::from(value),
+        });
     }
 
-    fn lookup(&self, key: &[u8]) -> Option<&[u8]> {
-        for i in 0..self.count {
-            let entry = &self.entries[i];
-            if str_eq(&entry.key[..entry.key_len], key) {
-                return Some(&entry.value[..entry.value_len]);
+    fn lookup(&self, key: &str) -> Option<&str> {
+        for entry in &self.entries {
+            if entry.key == key {
+                return Some(&entry.value);
             }
         }
         None
@@ -472,65 +482,62 @@ fn load_manifest(path: &[u8]) -> Option<Manifest> {
         return None;
     }
 
-    let mut file_buf = [0u8; 65536];
-    let bytes_read = read(fd, &mut file_buf);
+    // Read file into Vec, reading in chunks
+    let mut file_data = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        let bytes_read = read(fd, &mut chunk);
+        if bytes_read <= 0 {
+            break;
+        }
+        file_data.extend_from_slice(&chunk[..bytes_read as usize]);
+    }
     close(fd);
 
-    if bytes_read <= 0 {
+    if file_data.is_empty() {
         return None;
     }
 
+    // Convert to UTF-8 string for easier parsing
+    let file_str = String::from_utf8(file_data).ok()?;
+
     let mut manifest = Manifest::new();
-    let data = &file_buf[..bytes_read as usize];
-    let mut pos = 0;
 
-    while pos < data.len() {
-        let line_start = pos;
-        while pos < data.len() && data[pos] != b'\n' {
-            pos += 1;
-        }
-
-        let line = &data[line_start..pos];
-
-        if let Some(space_pos) = find_byte(line, b' ') {
-            let key = &line[..space_pos];
-            let value = &line[space_pos + 1..];
+    for line in file_str.lines() {
+        if let Some((key, value)) = line.split_once(' ') {
             manifest.add_entry(key, value);
         }
-
-        pos += 1;
     }
 
     Some(manifest)
 }
 
-// Runfiles implementation
+// Runfiles implementation using String for UTF-8 paths
 enum RunfilesMode {
     ManifestBased(Manifest),
-    DirectoryBased([u8; MAX_PATH_LEN], usize),
+    DirectoryBased(String),
 }
 
 struct Runfiles {
     mode: RunfilesMode,
     // Paths for environment variables (when export_runfiles_env is true)
-    manifest_path: Option<([u8; MAX_PATH_LEN], usize)>, // RUNFILES_MANIFEST_FILE
-    dir_path: Option<([u8; MAX_PATH_LEN], usize)>,      // RUNFILES_DIR and JAVA_RUNFILES
+    manifest_path: Option<String>, // RUNFILES_MANIFEST_FILE
+    dir_path: Option<String>,      // RUNFILES_DIR and JAVA_RUNFILES
 }
 
 impl Runfiles {
     fn create(executable_path: Option<&[u8]>) -> Option<Self> {
-        let mut manifest_path = [0u8; MAX_PATH_LEN];
-
         // Try RUNFILES_MANIFEST_FILE first
-        if let Some(len) = get_env_var(b"RUNFILES_MANIFEST_FILE", &mut manifest_path) {
-            if len > 0 {
-                let mut path_with_null = [0u8; MAX_PATH_LEN + 1];
-                path_with_null[..len].copy_from_slice(&manifest_path[..len]);
+        if let Some(manifest_path) = get_env_var(b"RUNFILES_MANIFEST_FILE") {
+            if !manifest_path.is_empty() {
+                // Create null-terminated path for load_manifest
+                let mut path_with_null = Vec::from(manifest_path.as_bytes());
+                path_with_null.push(0);
 
-                if let Some(manifest) = load_manifest(&path_with_null[..len + 1]) {
+                if let Some(manifest) = load_manifest(&path_with_null) {
                     return Some(Self {
                         mode: RunfilesMode::ManifestBased(manifest),
-                        manifest_path: Some((manifest_path, len)),
+                        manifest_path: Some(manifest_path),
                         dir_path: None,
                     });
                 }
@@ -538,13 +545,12 @@ impl Runfiles {
         }
 
         // Try RUNFILES_DIR
-        let mut runfiles_dir = [0u8; MAX_PATH_LEN];
-        if let Some(len) = get_env_var(b"RUNFILES_DIR", &mut runfiles_dir) {
-            if len > 0 {
+        if let Some(runfiles_dir) = get_env_var(b"RUNFILES_DIR") {
+            if !runfiles_dir.is_empty() {
                 return Some(Self {
-                    mode: RunfilesMode::DirectoryBased(runfiles_dir, len),
+                    mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
                     manifest_path: None,
-                    dir_path: Some((runfiles_dir, len)),
+                    dir_path: Some(runfiles_dir),
                 });
             }
         }
@@ -555,60 +561,42 @@ impl Runfiles {
         if let Some(exe_path) = executable_path {
             let exe_len = str_len(exe_path);
             if exe_len > 0 {
+                // Convert executable path to string (if valid UTF-8)
+                let exe_str = core::str::from_utf8(&exe_path[..exe_len]).ok()?;
+
                 // Try <executable>.runfiles_manifest file first
-                if exe_len + 19 < MAX_PATH_LEN {  // +19 for ".runfiles_manifest\0"
-                    let mut manifest_file_path = [0u8; MAX_PATH_LEN + 1];
+                let manifest_file_path = String::from(exe_str) + ".runfiles_manifest";
 
-                    // Copy executable path
-                    manifest_file_path[..exe_len].copy_from_slice(&exe_path[..exe_len]);
+                // Add null terminator for syscall
+                let mut manifest_path_with_null = Vec::from(manifest_file_path.as_bytes());
+                manifest_path_with_null.push(0);
 
-                    // Append ".runfiles_manifest" (18 characters)
-                    manifest_file_path[exe_len..exe_len + 18].copy_from_slice(b".runfiles_manifest");
-                    let manifest_file_len = exe_len + 18;
+                // Try to load the manifest file
+                if let Some(manifest) = load_manifest(&manifest_path_with_null) {
+                    // Also determine the runfiles directory for RUNFILES_DIR envvar
+                    let dir_path = String::from(exe_str) + ".runfiles";
 
-                    // Try to load the manifest file
-                    if let Some(manifest) = load_manifest(&manifest_file_path[..manifest_file_len + 1]) {
-                        // Also determine the runfiles directory for RUNFILES_DIR envvar
-                        // The directory is <executable>.runfiles
-                        let mut dir_path = [0u8; MAX_PATH_LEN];
-                        let dir_len = if exe_len + 9 < MAX_PATH_LEN {
-                            dir_path[..exe_len].copy_from_slice(&exe_path[..exe_len]);
-                            dir_path[exe_len..exe_len + 9].copy_from_slice(b".runfiles");
-                            exe_len + 9
-                        } else {
-                            0
-                        };
-
-                        let mut manifest_path_without_null = [0u8; MAX_PATH_LEN];
-                        manifest_path_without_null[..manifest_file_len].copy_from_slice(&manifest_file_path[..manifest_file_len]);
-
-                        return Some(Self {
-                            mode: RunfilesMode::ManifestBased(manifest),
-                            manifest_path: Some((manifest_path_without_null, manifest_file_len)),
-                            dir_path: if dir_len > 0 { Some((dir_path, dir_len)) } else { None },
-                        });
-                    }
+                    return Some(Self {
+                        mode: RunfilesMode::ManifestBased(manifest),
+                        manifest_path: Some(manifest_file_path),
+                        dir_path: Some(dir_path),
+                    });
                 }
 
                 // Try <executable>.runfiles directory
-                if exe_len + 10 < MAX_PATH_LEN {  // +10 for ".runfiles\0"
-                    let mut runfiles_dir = [0u8; MAX_PATH_LEN];
+                let runfiles_dir = String::from(exe_str) + ".runfiles";
 
-                    // Copy executable path
-                    runfiles_dir[..exe_len].copy_from_slice(&exe_path[..exe_len]);
+                // Add null terminator for path_exists syscall
+                let mut dir_with_null = Vec::from(runfiles_dir.as_bytes());
+                dir_with_null.push(0);
 
-                    // Append ".runfiles"
-                    runfiles_dir[exe_len..exe_len + 9].copy_from_slice(b".runfiles");
-                    runfiles_dir[exe_len + 9] = 0; // null terminator
-
-                    // Check if directory exists using access() syscall
-                    if path_exists(&runfiles_dir[..exe_len + 10]) {
-                        return Some(Self {
-                            mode: RunfilesMode::DirectoryBased(runfiles_dir, exe_len + 9),
-                            manifest_path: None,
-                            dir_path: Some((runfiles_dir, exe_len + 9)),
-                        });
-                    }
+                // Check if directory exists using access() syscall
+                if path_exists(&dir_with_null) {
+                    return Some(Self {
+                        mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
+                        manifest_path: None,
+                        dir_path: Some(runfiles_dir),
+                    });
                 }
             }
         }
@@ -616,40 +604,29 @@ impl Runfiles {
         None
     }
 
-    fn rlocation(&self, path: &[u8]) -> Option<[u8; MAX_PATH_LEN]> {
+    fn rlocation(&self, path: &str) -> Option<String> {
         // If path is absolute, don't resolve through runfiles
-        if path.len() > 0 && path[0] == b'/' {
+        if path.starts_with('/') {
             return None;
         }
 
         match &self.mode {
             RunfilesMode::ManifestBased(manifest) => {
                 if let Some(resolved) = manifest.lookup(path) {
-                    let mut result = [0u8; MAX_PATH_LEN];
-                    let len = resolved.len().min(MAX_PATH_LEN);
-                    result[..len].copy_from_slice(&resolved[..len]);
-                    return Some(result);
+                    return Some(String::from(resolved));
                 }
                 None
             }
-            RunfilesMode::DirectoryBased(dir, dir_len) => {
-                let mut result = [0u8; MAX_PATH_LEN];
-                let mut pos = 0;
-
-                // Copy directory
-                let copy_len = (*dir_len).min(MAX_PATH_LEN);
-                result[..copy_len].copy_from_slice(&dir[..copy_len]);
-                pos += copy_len;
+            RunfilesMode::DirectoryBased(dir) => {
+                let mut result = dir.clone();
 
                 // Add separator if needed
-                if pos < MAX_PATH_LEN && pos > 0 && result[pos - 1] != b'/' {
-                    result[pos] = b'/';
-                    pos += 1;
+                if !result.ends_with('/') {
+                    result.push('/');
                 }
 
-                // Copy path
-                let path_len = path.len().min(MAX_PATH_LEN - pos);
-                result[pos..pos + path_len].copy_from_slice(&path[..path_len]);
+                // Append the path
+                result.push_str(path);
 
                 Some(result)
             }
@@ -730,222 +707,143 @@ fn is_template_placeholder(placeholder: &[u8]) -> bool {
     str_starts_with(placeholder, b"@@RUNFILES_")
 }
 
-// Environment variable storage
-// These limits are based on the Linux kernel's ARG_MAX and related limits for execve().
-// Linux supports up to 6 MiB total for argv + envp combined, with a 2 MiB per-string limit.
-// The actual limit is dynamic and derived from RLIMIT_STACK at execution time.
-// See: include/uapi/linux/binfmts.h in the Linux kernel source
-// Reference: https://gist.github.com/malt3/c1439aa16208a74194accb025ab1cc5b
-const MAX_ENV_SIZE: usize = 6291456;  // 6 MiB - matches Linux upper bound for total args+env
-const MAX_ENV_VARS: usize = 1024;     // Max number of environment variables
-
-static mut ENVIRON_DATA: [u8; MAX_ENV_SIZE] = [0; MAX_ENV_SIZE];
-static mut ENVIRON_PTRS: [*const u8; MAX_ENV_VARS + 1] = [core::ptr::null(); MAX_ENV_VARS + 1];
-
 // Read and parse environment variables from /proc/self/environ
-fn get_environ() -> *const *const u8 {
-    unsafe {
-        // Read environment from /proc/self/environ
-        let fd = open(b"/proc/self/environ\0");
-        if fd < 0 {
-            // If we can't read environ, return empty environment
-            ENVIRON_PTRS[0] = core::ptr::null();
-            return ENVIRON_PTRS.as_ptr();
-        }
+// Returns a tuple of (data_vec, pointers_vec) where pointers point into data_vec
+fn read_environ() -> (Vec<u8>, Vec<*const u8>) {
+    // Read environment from /proc/self/environ
+    let fd = open(b"/proc/self/environ\0");
+    if fd < 0 {
+        // If we can't read environ, return empty environment
+        return (Vec::new(), vec![core::ptr::null()]);
+    }
 
-        let bytes_read = read(fd, &mut ENVIRON_DATA);
-        close(fd);
-
+    // Read into Vec
+    let mut environ_data = Vec::new();
+    let mut chunk = [0u8; 8192];
+    loop {
+        let bytes_read = read(fd, &mut chunk);
         if bytes_read <= 0 {
-            ENVIRON_PTRS[0] = core::ptr::null();
-            return ENVIRON_PTRS.as_ptr();
+            break;
+        }
+        environ_data.extend_from_slice(&chunk[..bytes_read as usize]);
+    }
+    close(fd);
+
+    if environ_data.is_empty() {
+        return (Vec::new(), vec![core::ptr::null()]);
+    }
+
+    // Parse environment variables (null-separated entries)
+    let mut env_ptrs = Vec::new();
+    let mut pos = 0;
+    let data_len = environ_data.len();
+
+    while pos < data_len {
+        // Skip empty entries
+        if environ_data[pos] == 0 {
+            pos += 1;
+            continue;
         }
 
-        // Check if environment data was truncated
-        let data_len = bytes_read as usize;
-        if data_len >= MAX_ENV_SIZE {
-            print(b"ERROR: Environment data exceeds buffer limit of ");
-            print_number(MAX_ENV_SIZE);
-            print(b" bytes\n");
-            print(b"Environment was truncated. This indicates the total environment size is too large.\n");
-            print(b"Consider reducing the number or size of environment variables.\n");
-            exit(1);
-        }
+        // Mark start of this environment variable
+        env_ptrs.push(unsafe { environ_data.as_ptr().add(pos) });
 
-        // Parse environment variables (null-separated entries)
-        let mut env_count = 0;
-        let mut pos = 0;
-
-        while pos < data_len && env_count < MAX_ENV_VARS {
-            // Skip empty entries
-            if ENVIRON_DATA[pos] == 0 {
-                pos += 1;
-                continue;
-            }
-
-            // Mark start of this environment variable
-            ENVIRON_PTRS[env_count] = ENVIRON_DATA.as_ptr().add(pos);
-            env_count += 1;
-
-            // Find the end (null byte)
-            while pos < data_len && ENVIRON_DATA[pos] != 0 {
-                pos += 1;
-            }
-
-            // Move past the null byte
+        // Find the end (null byte)
+        while pos < data_len && environ_data[pos] != 0 {
             pos += 1;
         }
 
-        // Check if we hit the max number of environment variables
-        if env_count >= MAX_ENV_VARS && pos < data_len {
-            print(b"ERROR: Number of environment variables exceeds limit of ");
-            print_number(MAX_ENV_VARS);
-            print(b"\n");
-            print(b"Consider reducing the number of environment variables.\n");
-            exit(1);
-        }
-
-        // Null-terminate the pointer array
-        ENVIRON_PTRS[env_count] = core::ptr::null();
-
-        ENVIRON_PTRS.as_ptr()
+        // Move past the null byte
+        pos += 1;
     }
+
+    // Null-terminate the pointer array
+    env_ptrs.push(core::ptr::null());
+
+    (environ_data, env_ptrs)
 }
 
 // Build modified environment with runfiles variables
-// Storage for modified environment
-static mut MODIFIED_ENV_DATA: [u8; MAX_ENV_SIZE] = [0; MAX_ENV_SIZE];
-static mut MODIFIED_ENV_PTRS: [*const u8; MAX_ENV_VARS + 1] = [core::ptr::null(); MAX_ENV_VARS + 1];
+// Returns (data_vec, pointers_vec) - caller must keep data_vec alive while pointers are used
+fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u8>) {
+    let (base_data, base_ptrs) = read_environ();
 
-fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *const *const u8 {
-    unsafe {
-        let base_env = get_environ();
+    // If no runfiles info, just return base environment
+    let rf = match runfiles {
+        Some(r) => r,
+        None => return (base_data, base_ptrs),
+    };
 
-        // If no runfiles info, just return base environment
-        let rf = match runfiles {
-            Some(r) => r,
-            None => return base_env,
-        };
+    let mut env_data = Vec::new();
+    let mut env_ptrs = Vec::new();
 
-        let mut new_env_count = 0;
-        let mut data_pos = 0;
+    // Helper to add an environment variable to env_data and record pointer
+    let add_env_var = |data: &mut Vec<u8>, ptrs: &mut Vec<*const u8>, name: &[u8], value: &str| {
+        let start_pos = data.len();
+        data.extend_from_slice(name);
+        data.push(b'=');
+        data.extend_from_slice(value.as_bytes());
+        data.push(0); // null terminator
 
-        // Helper to add an environment variable
-        let mut add_env_var = |name: &[u8], value: &[u8]| {
-            if data_pos + name.len() + 1 + value.len() + 1 > MAX_ENV_SIZE {
-                return false; // Out of space
-            }
-            if new_env_count >= MAX_ENV_VARS {
-                return false; // Too many vars
-            }
+        // We'll fix up pointers after building the data
+        ptrs.push(start_pos as *const u8); // Temporarily store offset, fix up later
+    };
 
-            // Mark start of this var
-            MODIFIED_ENV_PTRS[new_env_count] = MODIFIED_ENV_DATA.as_ptr().add(data_pos);
-            new_env_count += 1;
-
-            // Copy name=value
-            MODIFIED_ENV_DATA[data_pos..data_pos + name.len()].copy_from_slice(name);
-            data_pos += name.len();
-            MODIFIED_ENV_DATA[data_pos] = b'=';
-            data_pos += 1;
-            MODIFIED_ENV_DATA[data_pos..data_pos + value.len()].copy_from_slice(value);
-            data_pos += value.len();
-            MODIFIED_ENV_DATA[data_pos] = 0;
-            data_pos += 1;
-
-            true
-        };
-
-        // Add runfiles environment variables first
-        if let Some((path, len)) = rf.manifest_path {
-            if !add_env_var(b"RUNFILES_MANIFEST_FILE", &path[..len]) {
-                print(b"ERROR: Failed to add RUNFILES_MANIFEST_FILE to environment\n");
-                print(b"Environment buffer limit exceeded. Total size limit: ");
-                print_number(MAX_ENV_SIZE);
-                print(b" bytes, max variables: ");
-                print_number(MAX_ENV_VARS);
-                print(b"\n");
-                exit(1);
-            }
-        }
-
-        if let Some((path, len)) = rf.dir_path {
-            if !add_env_var(b"RUNFILES_DIR", &path[..len]) {
-                print(b"ERROR: Failed to add RUNFILES_DIR to environment\n");
-                print(b"Environment buffer limit exceeded. Total size limit: ");
-                print_number(MAX_ENV_SIZE);
-                print(b" bytes, max variables: ");
-                print_number(MAX_ENV_VARS);
-                print(b"\n");
-                exit(1);
-            }
-            if !add_env_var(b"JAVA_RUNFILES", &path[..len]) {
-                print(b"ERROR: Failed to add JAVA_RUNFILES to environment\n");
-                print(b"Environment buffer limit exceeded. Total size limit: ");
-                print_number(MAX_ENV_SIZE);
-                print(b" bytes, max variables: ");
-                print_number(MAX_ENV_VARS);
-                print(b"\n");
-                exit(1);
-            }
-        }
-
-        // Copy existing environment (skip runfiles vars that we're setting)
-        let mut i = 0;
-        let mut env_dropped = false;
-        while !(*base_env.add(i)).is_null() {
-            let env_ptr = *base_env.add(i);
-            let mut env_len = 0;
-            while *env_ptr.add(env_len) != 0 {
-                env_len += 1;
-            }
-
-            let env_slice = core::slice::from_raw_parts(env_ptr, env_len);
-
-            // Skip if this is a runfiles var we're replacing
-            let is_runfiles_var = env_slice.starts_with(b"RUNFILES_MANIFEST_FILE=")
-                || env_slice.starts_with(b"RUNFILES_DIR=")
-                || env_slice.starts_with(b"JAVA_RUNFILES=");
-
-            if !is_runfiles_var {
-                if data_pos + env_len + 1 <= MAX_ENV_SIZE && new_env_count < MAX_ENV_VARS {
-                    MODIFIED_ENV_PTRS[new_env_count] = MODIFIED_ENV_DATA.as_ptr().add(data_pos);
-                    new_env_count += 1;
-
-                    MODIFIED_ENV_DATA[data_pos..data_pos + env_len].copy_from_slice(env_slice);
-                    data_pos += env_len;
-                    MODIFIED_ENV_DATA[data_pos] = 0;
-                    data_pos += 1;
-                } else {
-                    env_dropped = true;
-                }
-            }
-
-            i += 1;
-        }
-
-        // Check if any environment variables were dropped
-        if env_dropped {
-            print(b"ERROR: Failed to copy all environment variables\n");
-            print(b"Environment buffer limit exceeded. Total size limit: ");
-            print_number(MAX_ENV_SIZE);
-            print(b" bytes, max variables: ");
-            print_number(MAX_ENV_VARS);
-            print(b"\n");
-            print(b"Current usage: ");
-            print_number(data_pos);
-            print(b" bytes, ");
-            print_number(new_env_count);
-            print(b" variables\n");
-            print(b"Consider reducing the number or size of environment variables.\n");
-            exit(1);
-        }
-
-        // Null-terminate the pointer array
-        MODIFIED_ENV_PTRS[new_env_count] = core::ptr::null();
-
-        MODIFIED_ENV_PTRS.as_ptr()
+    // Add runfiles environment variables first
+    if let Some(ref path) = rf.manifest_path {
+        add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
     }
+
+    if let Some(ref path) = rf.dir_path {
+        add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_DIR", path);
+        add_env_var(&mut env_data, &mut env_ptrs, b"JAVA_RUNFILES", path);
+    }
+
+    // Copy existing environment (skip runfiles vars that we're setting)
+    // We need to iterate through the base data directly
+    let mut pos = 0;
+    while pos < base_data.len() {
+        // Skip empty entries
+        if base_data[pos] == 0 {
+            pos += 1;
+            continue;
+        }
+
+        // Find the end of this entry
+        let start = pos;
+        while pos < base_data.len() && base_data[pos] != 0 {
+            pos += 1;
+        }
+
+        let env_entry = &base_data[start..pos];
+
+        // Skip if this is a runfiles var we're replacing
+        let is_runfiles_var = env_entry.starts_with(b"RUNFILES_MANIFEST_FILE=")
+            || env_entry.starts_with(b"RUNFILES_DIR=")
+            || env_entry.starts_with(b"JAVA_RUNFILES=");
+
+        if !is_runfiles_var {
+            let start_pos = env_data.len();
+            env_data.extend_from_slice(env_entry);
+            env_data.push(0); // null terminator
+            env_ptrs.push(start_pos as *const u8); // Temporarily store offset
+        }
+
+        // Move past the null byte
+        pos += 1;
+    }
+
+    // Now fix up all the pointers to point to actual addresses in env_data
+    let base_ptr = env_data.as_ptr();
+    for ptr in env_ptrs.iter_mut() {
+        let offset = *ptr as usize;
+        *ptr = unsafe { base_ptr.add(offset) };
+    }
+
+    // Null-terminate the pointer array
+    env_ptrs.push(core::ptr::null());
+
+    (env_data, env_ptrs)
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -1049,7 +947,8 @@ pub extern "C" fn _start_rust(initial_sp: *const usize) -> ! {
         let executable_path = if runtime_argc > 0 {
             let argv0_ptr = *runtime_argv;
             let mut exe_len = 0;
-            while *argv0_ptr.add(exe_len) != 0 && exe_len < MAX_PATH_LEN {
+            // Safety limit of 1MB to prevent infinite loop
+            while *argv0_ptr.add(exe_len) != 0 && exe_len < 1048576 {
                 exe_len += 1;
             }
             if exe_len > 0 {
@@ -1088,10 +987,9 @@ pub extern "C" fn _start_rust(initial_sp: *const usize) -> ! {
             &ARG9_PLACEHOLDER,
         ];
 
-        // Storage for resolved paths (embedded args + runtime args)
-        let mut resolved_paths: [[u8; MAX_PATH_LEN]; 128] = [[0; MAX_PATH_LEN]; 128];
-        let mut resolved_ptrs: [*const u8; 129] = [core::ptr::null(); 129];
-        let mut total_argc = 0usize;
+        // Use Vec for dynamic path storage - no fixed size limits
+        // We store as Vec<u8> since we need null-terminated bytes for execve
+        let mut resolved_paths: Vec<Vec<u8>> = Vec::with_capacity(128);
 
         // Resolve embedded arguments
         for i in 0..argc {
@@ -1111,74 +1009,89 @@ pub extern "C" fn _start_rust(initial_sp: *const usize) -> ! {
             // Check if this argument should be transformed
             let should_transform = (transform_flags & (1 << i)) != 0;
 
-            if should_transform {
+            let resolved = if should_transform {
                 // Try to resolve through runfiles (which we know exists if we need transformation)
                 if let Some(ref rf) = runfiles {
-                    if let Some(resolved) = rf.rlocation(arg_slice) {
-                        resolved_paths[i] = resolved;
+                    // Convert argument to &str for rlocation (Bazel args are UTF-8)
+                    if let Ok(arg_str) = core::str::from_utf8(arg_slice) {
+                        if let Some(resolved_str) = rf.rlocation(arg_str) {
+                            // Convert back to bytes with null terminator
+                            let mut path = Vec::from(resolved_str.as_bytes());
+                            path.push(0);
+                            path
+                        } else {
+                            // If not found in runfiles, use the path as-is
+                            let mut path = arg_slice.to_vec();
+                            path.push(0);
+                            path
+                        }
                     } else {
-                        // If not found in runfiles, use the path as-is
-                        let copy_len = arg_len.min(MAX_PATH_LEN);
-                        resolved_paths[i][..copy_len].copy_from_slice(&arg_slice[..copy_len]);
+                        // Not valid UTF-8, use as-is
+                        let mut path = arg_slice.to_vec();
+                        path.push(0);
+                        path
                     }
                 } else {
                     // This should never happen - we checked needs_runfiles before
                     // But use path as-is for safety
-                    let copy_len = arg_len.min(MAX_PATH_LEN);
-                    resolved_paths[i][..copy_len].copy_from_slice(&arg_slice[..copy_len]);
+                    let mut path = arg_slice.to_vec();
+                    path.push(0);
+                    path
                 }
             } else {
                 // Use path as-is without transformation
-                let copy_len = arg_len.min(MAX_PATH_LEN);
-                resolved_paths[i][..copy_len].copy_from_slice(&arg_slice[..copy_len]);
-            }
+                let mut path = arg_slice.to_vec();
+                path.push(0);
+                path
+            };
 
-            resolved_ptrs[i] = resolved_paths[i].as_ptr();
+            resolved_paths.push(resolved);
         }
-        total_argc = argc;
 
         // Append runtime arguments (skip argv[0] which is the stub itself)
         if runtime_argc > 1 {
             for i in 1..runtime_argc {
-                if total_argc >= 128 {
-                    print(b"ERROR: Too many total arguments (embedded + runtime > 128)\n");
-                    exit(1);
-                }
-
                 // Get runtime argument
                 let runtime_arg_ptr = *runtime_argv.add(i);
 
-                // Find length of runtime argument
+                // Find length of runtime argument (scan until null, with safety limit)
                 let mut arg_len = 0;
-                while *runtime_arg_ptr.add(arg_len) != 0 && arg_len < MAX_PATH_LEN {
+                while *runtime_arg_ptr.add(arg_len) != 0 {
                     arg_len += 1;
+                    // Safety limit to prevent infinite loop on malformed input
+                    if arg_len > 1048576 {
+                        print(b"ERROR: Runtime argument exceeds 1MB limit\n");
+                        exit(1);
+                    }
                 }
 
-                // Copy runtime argument to resolved_paths
-                let copy_len = arg_len.min(MAX_PATH_LEN);
-                let runtime_arg_slice = core::slice::from_raw_parts(runtime_arg_ptr, copy_len);
-                resolved_paths[total_argc][..copy_len].copy_from_slice(runtime_arg_slice);
-
-                resolved_ptrs[total_argc] = resolved_paths[total_argc].as_ptr();
-                total_argc += 1;
+                // Copy runtime argument (include null terminator)
+                let runtime_arg_slice = core::slice::from_raw_parts(runtime_arg_ptr, arg_len + 1);
+                resolved_paths.push(runtime_arg_slice.to_vec());
             }
         }
 
+        // Build pointer array from the resolved paths
+        let mut resolved_ptrs: Vec<*const u8> = Vec::with_capacity(resolved_paths.len() + 1);
+        for path in &resolved_paths {
+            resolved_ptrs.push(path.as_ptr());
+        }
         // NULL-terminate the argv array
-        resolved_ptrs[total_argc] = core::ptr::null();
+        resolved_ptrs.push(core::ptr::null());
 
         // Get the executable path (first argument)
         let executable = resolved_ptrs[0];
 
         // Build environment (with runfiles vars if export_runfiles_env is true)
-        let envp = if export_runfiles_env {
+        // We need to keep the env_data alive until execve
+        let (_env_data, env_ptrs) = if export_runfiles_env {
             build_runfiles_environ(runfiles.as_ref())
         } else {
-            get_environ()
+            read_environ()
         };
 
         // Execute the target program
-        let ret = execve(executable, resolved_ptrs.as_ptr(), envp);
+        let ret = execve(executable, resolved_ptrs.as_ptr(), env_ptrs.as_ptr());
 
         // If execve returns, it failed
         print(b"ERROR: execve failed with code ");

--- a/runfiles-stub/src/macos.rs
+++ b/runfiles-stub/src/macos.rs
@@ -1,12 +1,46 @@
 // macOS-specific implementation using libc
 // Unlike Linux version, this uses libc and can link with libsystem
 
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::alloc::{GlobalAlloc, Layout};
+use core::cell::UnsafeCell;
 use core::panic::PanicInfo;
+use talc::{ClaimOnOom, Span, Talc};
+
+// Global allocator using talc with a static memory arena
+// 8 MiB should be plenty for manifest parsing, path resolution, and environment handling
+static mut ARENA: [u8; 8 * 1024 * 1024] = [0; 8 * 1024 * 1024];
+
+// Simple wrapper for single-threaded use (no locking needed)
+struct TalcAllocator(UnsafeCell<Talc<ClaimOnOom>>);
+unsafe impl Sync for TalcAllocator {}
+
+unsafe impl GlobalAlloc for TalcAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        (*self.0.get()).malloc(layout).map_or(core::ptr::null_mut(), |p| p.as_ptr())
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        (*self.0.get()).free(core::ptr::NonNull::new_unchecked(ptr), layout);
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: TalcAllocator = TalcAllocator(UnsafeCell::new(Talc::new(unsafe {
+    ClaimOnOom::new(Span::from_array(core::ptr::addr_of!(ARENA).cast_mut()))
+})));
 
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     unsafe { exit(1) }
 }
+
+// Required by alloc crate for exception handling (unused with panic=abort)
+#[no_mangle]
+extern "C" fn rust_eh_personality() {}
 
 // External libc functions
 extern "C" {
@@ -99,8 +133,8 @@ fn find_byte(haystack: &[u8], needle: u8) -> Option<usize> {
     None
 }
 
-// Environment variable reading via the environ pointer
-fn get_env_var(name: &[u8], buf: &mut [u8]) -> Option<usize> {
+// Environment variable reading via the environ pointer - returns String
+fn get_env_var(name: &[u8]) -> Option<String> {
     unsafe {
         let mut env_ptr = environ;
 
@@ -112,7 +146,7 @@ fn get_env_var(name: &[u8], buf: &mut [u8]) -> Option<usize> {
             let mut len = 0;
             while *entry_ptr.add(len) != 0 {
                 len += 1;
-                if len > 4096 {  // Safety limit
+                if len > 1048576 {  // Safety limit: 1MB
                     break;
                 }
             }
@@ -126,9 +160,8 @@ fn get_env_var(name: &[u8], buf: &mut [u8]) -> Option<usize> {
                 let value = &entry[eq_pos + 1..];
 
                 if str_eq(key, name) {
-                    let copy_len = value.len().min(buf.len());
-                    buf[..copy_len].copy_from_slice(&value[..copy_len]);
-                    return Some(copy_len);
+                    // Convert to String, returning None if not valid UTF-8
+                    return String::from_utf8(value.to_vec()).ok();
                 }
             }
 
@@ -139,59 +172,32 @@ fn get_env_var(name: &[u8], buf: &mut [u8]) -> Option<usize> {
     None
 }
 
-// Manifest entry storage
-const MAX_ENTRIES: usize = 1024;
-const MAX_PATH_LEN: usize = 256;
-
+// Manifest entry using String for UTF-8 paths (Bazel-generated)
 struct ManifestEntry {
-    key: [u8; MAX_PATH_LEN],
-    key_len: usize,
-    value: [u8; MAX_PATH_LEN],
-    value_len: usize,
+    key: String,
+    value: String,
 }
 
 struct Manifest {
-    entries: [ManifestEntry; MAX_ENTRIES],
-    count: usize,
+    entries: Vec<ManifestEntry>,
 }
 
 impl Manifest {
     fn new() -> Self {
-        const EMPTY_ENTRY: ManifestEntry = ManifestEntry {
-            key: [0; MAX_PATH_LEN],
-            key_len: 0,
-            value: [0; MAX_PATH_LEN],
-            value_len: 0,
-        };
-
-        Self {
-            entries: [EMPTY_ENTRY; MAX_ENTRIES],
-            count: 0,
-        }
+        Self { entries: Vec::new() }
     }
 
-    fn add_entry(&mut self, key: &[u8], value: &[u8]) {
-        if self.count >= MAX_ENTRIES {
-            return;
-        }
-
-        let entry = &mut self.entries[self.count];
-        let key_len = key.len().min(MAX_PATH_LEN);
-        let value_len = value.len().min(MAX_PATH_LEN);
-
-        entry.key[..key_len].copy_from_slice(&key[..key_len]);
-        entry.key_len = key_len;
-        entry.value[..value_len].copy_from_slice(&value[..value_len]);
-        entry.value_len = value_len;
-
-        self.count += 1;
+    fn add_entry(&mut self, key: &str, value: &str) {
+        self.entries.push(ManifestEntry {
+            key: String::from(key),
+            value: String::from(value),
+        });
     }
 
-    fn lookup(&self, key: &[u8]) -> Option<&[u8]> {
-        for i in 0..self.count {
-            let entry = &self.entries[i];
-            if str_eq(&entry.key[..entry.key_len], key) {
-                return Some(&entry.value[..entry.value_len]);
+    fn lookup(&self, key: &str) -> Option<&str> {
+        for entry in &self.entries {
+            if entry.key == key {
+                return Some(&entry.value);
             }
         }
         None
@@ -206,66 +212,63 @@ fn load_manifest(path: &[u8]) -> Option<Manifest> {
             return None;
         }
 
-        let mut file_buf = [0u8; 65536];
-        let bytes_read = read(fd, file_buf.as_mut_ptr(), file_buf.len());
+        // Read file into Vec, reading in chunks
+        let mut file_data = Vec::new();
+        let mut chunk = [0u8; 8192];
+        loop {
+            let bytes_read = read(fd, chunk.as_mut_ptr(), chunk.len());
+            if bytes_read <= 0 {
+                break;
+            }
+            file_data.extend_from_slice(&chunk[..bytes_read as usize]);
+        }
         close(fd);
 
-        if bytes_read <= 0 {
+        if file_data.is_empty() {
             return None;
         }
 
+        // Convert to UTF-8 string for easier parsing
+        let file_str = String::from_utf8(file_data).ok()?;
+
         let mut manifest = Manifest::new();
-        let data = &file_buf[..bytes_read as usize];
-        let mut pos = 0;
 
-        while pos < data.len() {
-            let line_start = pos;
-            while pos < data.len() && data[pos] != b'\n' {
-                pos += 1;
-            }
-
-            let line = &data[line_start..pos];
-
-            if let Some(space_pos) = find_byte(line, b' ') {
-                let key = &line[..space_pos];
-                let value = &line[space_pos + 1..];
+        for line in file_str.lines() {
+            if let Some((key, value)) = line.split_once(' ') {
                 manifest.add_entry(key, value);
             }
-
-            pos += 1;
         }
 
         Some(manifest)
     }
 }
 
-// Runfiles implementation
+// Runfiles implementation using String for dynamic path storage
 enum RunfilesMode {
     ManifestBased(Manifest),
-    DirectoryBased([u8; MAX_PATH_LEN], usize),
+    DirectoryBased(String),
 }
 
 struct Runfiles {
     mode: RunfilesMode,
     // Paths for environment variables (when export_runfiles_env is true)
-    manifest_path: Option<([u8; MAX_PATH_LEN], usize)>, // RUNFILES_MANIFEST_FILE
-    dir_path: Option<([u8; MAX_PATH_LEN], usize)>,      // RUNFILES_DIR and JAVA_RUNFILES
+    manifest_path: Option<String>, // RUNFILES_MANIFEST_FILE
+    dir_path: Option<String>,      // RUNFILES_DIR and JAVA_RUNFILES
 }
 
 impl Runfiles {
     fn create(executable_path: Option<&[u8]>) -> Option<Self> {
-        let mut manifest_path = [0u8; MAX_PATH_LEN];
-
         // Try RUNFILES_MANIFEST_FILE first
-        if let Some(len) = get_env_var(b"RUNFILES_MANIFEST_FILE", &mut manifest_path) {
-            if len > 0 {
-                let mut path_with_null = [0u8; MAX_PATH_LEN + 1];
-                path_with_null[..len].copy_from_slice(&manifest_path[..len]);
+        if let Some(manifest_path) = get_env_var(b"RUNFILES_MANIFEST_FILE") {
+            if !manifest_path.is_empty() {
+                // Create null-terminated path for load_manifest
+                let mut path_with_null = Vec::from(manifest_path.as_bytes());
+                path_with_null.push(0);
 
-                if let Some(manifest) = load_manifest(&path_with_null[..len + 1]) {
+                if let Some(manifest) = load_manifest(&path_with_null) {
                     return Some(Self {
                         mode: RunfilesMode::ManifestBased(manifest),
-                        manifest_path: Some((manifest_path, len)),
+                        manifest_path: Some(manifest_path),
                         dir_path: None,
                     });
                 }
@@ -273,13 +276,12 @@ impl Runfiles {
         }
 
         // Try RUNFILES_DIR
-        let mut runfiles_dir = [0u8; MAX_PATH_LEN];
-        if let Some(len) = get_env_var(b"RUNFILES_DIR", &mut runfiles_dir) {
-            if len > 0 {
+        if let Some(runfiles_dir) = get_env_var(b"RUNFILES_DIR") {
+            if !runfiles_dir.is_empty() {
                 return Some(Self {
-                    mode: RunfilesMode::DirectoryBased(runfiles_dir, len),
+                    mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
                     manifest_path: None,
-                    dir_path: Some((runfiles_dir, len)),
+                    dir_path: Some(runfiles_dir),
                 });
             }
         }
@@ -290,60 +292,43 @@ impl Runfiles {
         if let Some(exe_path) = executable_path {
             let exe_len = strlen(exe_path);
             if exe_len > 0 {
+                // Convert executable path to string (if valid UTF-8)
+                let exe_str = core::str::from_utf8(&exe_path[..exe_len]).ok()?;
+
                 // Try <executable>.runfiles_manifest file first
-                if exe_len + 19 < MAX_PATH_LEN {  // +19 for ".runfiles_manifest\0"
-                    let mut manifest_file_path = [0u8; MAX_PATH_LEN + 1];
+                let manifest_file_path = String::from(exe_str) + ".runfiles_manifest";
 
-                    // Copy executable path
-                    manifest_file_path[..exe_len].copy_from_slice(&exe_path[..exe_len]);
+                // Add null terminator for syscall
+                let mut manifest_path_with_null = Vec::from(manifest_file_path.as_bytes());
+                manifest_path_with_null.push(0);
 
-                    // Append ".runfiles_manifest" (18 characters)
-                    manifest_file_path[exe_len..exe_len + 18].copy_from_slice(b".runfiles_manifest");
-                    let manifest_file_len = exe_len + 18;
+                // Try to load the manifest file
+                if let Some(manifest) = load_manifest(&manifest_path_with_null) {
+                    // Also determine the runfiles directory for RUNFILES_DIR envvar
+                    // The directory is <executable>.runfiles
+                    let dir_path = String::from(exe_str) + ".runfiles";
 
-                    // Try to load the manifest file
-                    if let Some(manifest) = load_manifest(&manifest_file_path[..manifest_file_len + 1]) {
-                        // Also determine the runfiles directory for RUNFILES_DIR envvar
-                        // The directory is <executable>.runfiles
-                        let mut dir_path = [0u8; MAX_PATH_LEN];
-                        let dir_len = if exe_len + 9 < MAX_PATH_LEN {
-                            dir_path[..exe_len].copy_from_slice(&exe_path[..exe_len]);
-                            dir_path[exe_len..exe_len + 9].copy_from_slice(b".runfiles");
-                            exe_len + 9
-                        } else {
-                            0
-                        };
-
-                        let mut manifest_path_without_null = [0u8; MAX_PATH_LEN];
-                        manifest_path_without_null[..manifest_file_len].copy_from_slice(&manifest_file_path[..manifest_file_len]);
-
-                        return Some(Self {
-                            mode: RunfilesMode::ManifestBased(manifest),
-                            manifest_path: Some((manifest_path_without_null, manifest_file_len)),
-                            dir_path: if dir_len > 0 { Some((dir_path, dir_len)) } else { None },
-                        });
-                    }
+                    return Some(Self {
+                        mode: RunfilesMode::ManifestBased(manifest),
+                        manifest_path: Some(manifest_file_path),
+                        dir_path: Some(dir_path),
+                    });
                 }
 
                 // Try <executable>.runfiles directory
-                if exe_len + 10 < MAX_PATH_LEN {  // +10 for ".runfiles\0"
-                    let mut runfiles_dir = [0u8; MAX_PATH_LEN];
+                let runfiles_dir = String::from(exe_str) + ".runfiles";
 
-                    // Copy executable path
-                    runfiles_dir[..exe_len].copy_from_slice(&exe_path[..exe_len]);
+                // Add null terminator for path_exists syscall
+                let mut dir_with_null = Vec::from(runfiles_dir.as_bytes());
+                dir_with_null.push(0);
 
-                    // Append ".runfiles"
-                    runfiles_dir[exe_len..exe_len + 9].copy_from_slice(b".runfiles");
-                    runfiles_dir[exe_len + 9] = 0; // null terminator
-
-                    // Check if directory exists using access() syscall
-                    if path_exists(&runfiles_dir[..exe_len + 10]) {
-                        return Some(Self {
-                            mode: RunfilesMode::DirectoryBased(runfiles_dir, exe_len + 9),
-                            manifest_path: None,
-                            dir_path: Some((runfiles_dir, exe_len + 9)),
-                        });
-                    }
+                // Check if directory exists using access() syscall
+                if path_exists(&dir_with_null) {
+                    return Some(Self {
+                        mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
+                        manifest_path: None,
+                        dir_path: Some(runfiles_dir),
+                    });
                 }
             }
         }
@@ -351,40 +336,29 @@ impl Runfiles {
         None
     }
 
-    fn rlocation(&self, path: &[u8]) -> Option<[u8; MAX_PATH_LEN]> {
+    fn rlocation(&self, path: &str) -> Option<String> {
         // If path is absolute, don't resolve through runfiles
-        if path.len() > 0 && path[0] == b'/' {
+        if path.starts_with('/') {
             return None;
         }
 
         match &self.mode {
             RunfilesMode::ManifestBased(manifest) => {
                 if let Some(resolved) = manifest.lookup(path) {
-                    let mut result = [0u8; MAX_PATH_LEN];
-                    let len = resolved.len().min(MAX_PATH_LEN);
-                    result[..len].copy_from_slice(&resolved[..len]);
-                    return Some(result);
+                    return Some(String::from(resolved));
                 }
                 None
             }
-            RunfilesMode::DirectoryBased(dir, dir_len) => {
-                let mut result = [0u8; MAX_PATH_LEN];
-                let mut pos = 0;
-
-                // Copy directory
-                let copy_len = (*dir_len).min(MAX_PATH_LEN);
-                result[..copy_len].copy_from_slice(&dir[..copy_len]);
-                pos += copy_len;
+            RunfilesMode::DirectoryBased(dir) => {
+                let mut result = dir.clone();
 
                 // Add separator if needed
-                if pos < MAX_PATH_LEN && pos > 0 && result[pos - 1] != b'/' {
-                    result[pos] = b'/';
-                    pos += 1;
+                if !result.ends_with('/') {
+                    result.push('/');
                 }
 
-                // Copy path
-                let path_len = path.len().min(MAX_PATH_LEN - pos);
-                result[pos..pos + path_len].copy_from_slice(&path[..path_len]);
+                // Append the path
+                result.push_str(path);
 
                 Some(result)
             }
@@ -392,109 +366,48 @@ impl Runfiles {
     }
 }
 
-// Environment building for export mode
-// These limits are based on macOS's ARG_MAX, which defines the maximum
-// combined size of argv + envp that can be passed to execve(). Modern macOS
-// systems (macOS 26.1+) have a 1 MiB limit, older kernels have 256 KiB.
-// This limit is fixed (not dynamic like Linux).
-// See: sysctl kern.argmax or getconf ARG_MAX
-// Reference: https://gist.github.com/malt3/c1439aa16208a74194accb025ab1cc5b
-const MAX_ENV_SIZE: usize = 1048576;  // 1 MiB - matches modern macOS ARG_MAX limit
-const MAX_ENV_VARS: usize = 1024;     // Max number of environment variables
+// Build modified environment with runfiles variables using Vec
+// Returns (data_vec, pointers_vec) - caller must keep data_vec alive while pointers are used
+fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u8>) {
+    let mut env_data = Vec::new();
+    let mut env_ptrs = Vec::new();
 
-static mut MODIFIED_ENV_DATA: [u8; MAX_ENV_SIZE] = [0; MAX_ENV_SIZE];
-static mut MODIFIED_ENV_PTRS: [*const u8; MAX_ENV_VARS + 1] = [core::ptr::null(); MAX_ENV_VARS + 1];
+    // Helper to add an environment variable to env_data and record offset
+    let add_env_var = |data: &mut Vec<u8>, ptrs: &mut Vec<*const u8>, name: &[u8], value: &str| {
+        let start_pos = data.len();
+        data.extend_from_slice(name);
+        data.push(b'=');
+        data.extend_from_slice(value.as_bytes());
+        data.push(0); // null terminator
 
-fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *const *const u8 {
+        // Temporarily store offset, fix up later
+        ptrs.push(start_pos as *const u8);
+    };
+
+    // Add runfiles environment variables first
+    if let Some(rf) = runfiles {
+        if let Some(ref path) = rf.manifest_path {
+            add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
+        }
+        if let Some(ref path) = rf.dir_path {
+            add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_DIR", path);
+            add_env_var(&mut env_data, &mut env_ptrs, b"JAVA_RUNFILES", path);
+        }
+    }
+
+    // Copy existing environment, filtering out runfiles vars
     unsafe {
-        let mut data_pos = 0usize;
-        let mut ptr_idx = 0usize;
-
-        // Helper to add an environment variable
-        let mut add_env_var = |key: &[u8], value: &[u8]| {
-            if ptr_idx >= MAX_ENV_VARS {
-                return false;
-            }
-
-            let entry_len = key.len() + 1 + value.len() + 1; // "KEY=VALUE\0"
-            if data_pos + entry_len > MAX_ENV_SIZE {
-                return false;
-            }
-
-            let entry_start = data_pos;
-
-            // Copy key
-            MODIFIED_ENV_DATA[data_pos..data_pos + key.len()].copy_from_slice(key);
-            data_pos += key.len();
-
-            // Add '='
-            MODIFIED_ENV_DATA[data_pos] = b'=';
-            data_pos += 1;
-
-            // Copy value
-            MODIFIED_ENV_DATA[data_pos..data_pos + value.len()].copy_from_slice(value);
-            data_pos += value.len();
-
-            // Null terminate
-            MODIFIED_ENV_DATA[data_pos] = 0;
-            data_pos += 1;
-
-            // Store pointer
-            MODIFIED_ENV_PTRS[ptr_idx] = MODIFIED_ENV_DATA.as_ptr().add(entry_start);
-            ptr_idx += 1;
-
-            true
-        };
-
-        // Add RUNFILES_MANIFEST_FILE if we have it
-        if let Some(rf) = runfiles {
-            if let Some((ref path, len)) = rf.manifest_path {
-                if !add_env_var(b"RUNFILES_MANIFEST_FILE", &path[..len]) {
-                    print(b"ERROR: Failed to add RUNFILES_MANIFEST_FILE to environment\n");
-                    print(b"Environment buffer limit exceeded. Total size limit: ");
-                    print_number(MAX_ENV_SIZE);
-                    print(b" bytes, max variables: ");
-                    print_number(MAX_ENV_VARS);
-                    print(b"\n");
-                    exit(1);
-                }
-            }
-        }
-
-        // Add RUNFILES_DIR if we have it
-        if let Some(rf) = runfiles {
-            if let Some((ref path, len)) = rf.dir_path {
-                if !add_env_var(b"RUNFILES_DIR", &path[..len]) {
-                    print(b"ERROR: Failed to add RUNFILES_DIR to environment\n");
-                    print(b"Environment buffer limit exceeded. Total size limit: ");
-                    print_number(MAX_ENV_SIZE);
-                    print(b" bytes, max variables: ");
-                    print_number(MAX_ENV_VARS);
-                    print(b"\n");
-                    exit(1);
-                }
-                if !add_env_var(b"JAVA_RUNFILES", &path[..len]) {
-                    print(b"ERROR: Failed to add JAVA_RUNFILES to environment\n");
-                    print(b"Environment buffer limit exceeded. Total size limit: ");
-                    print_number(MAX_ENV_SIZE);
-                    print(b" bytes, max variables: ");
-                    print_number(MAX_ENV_VARS);
-                    print(b"\n");
-                    exit(1);
-                }
-            }
-        }
-
-        // Copy existing environment, filtering out runfiles vars
         let mut env_ptr = environ;
-        let mut env_dropped = false;
-        while !(*env_ptr).is_null() && ptr_idx < MAX_ENV_VARS {
+        while !(*env_ptr).is_null() {
             let entry_ptr = *env_ptr;
 
             // Find length of this entry
             let mut len = 0;
-            while *entry_ptr.add(len) != 0 && len < 4096 {
+            while *entry_ptr.add(len) != 0 {
                 len += 1;
+                if len > 1048576 {  // Safety limit: 1MB
+                    break;
+                }
             }
 
             let entry = core::slice::from_raw_parts(entry_ptr, len);
@@ -505,45 +418,27 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *const *const u8 {
                 || str_starts_with(entry, b"JAVA_RUNFILES=");
 
             if !should_skip {
-                // Copy this environment variable
-                if data_pos + len + 1 <= MAX_ENV_SIZE {
-                    MODIFIED_ENV_DATA[data_pos..data_pos + len].copy_from_slice(entry);
-                    MODIFIED_ENV_DATA[data_pos + len] = 0;
-
-                    MODIFIED_ENV_PTRS[ptr_idx] = MODIFIED_ENV_DATA.as_ptr().add(data_pos);
-                    ptr_idx += 1;
-
-                    data_pos += len + 1;
-                } else {
-                    env_dropped = true;
-                }
+                let start_pos = env_data.len();
+                env_data.extend_from_slice(entry);
+                env_data.push(0); // null terminator
+                env_ptrs.push(start_pos as *const u8); // Temporarily store offset
             }
 
             env_ptr = env_ptr.add(1);
         }
-
-        // Check if any environment variables were dropped
-        if env_dropped {
-            print(b"ERROR: Failed to copy all environment variables\n");
-            print(b"Environment buffer limit exceeded. Total size limit: ");
-            print_number(MAX_ENV_SIZE);
-            print(b" bytes, max variables: ");
-            print_number(MAX_ENV_VARS);
-            print(b"\n");
-            print(b"Current usage: ");
-            print_number(data_pos);
-            print(b" bytes, ");
-            print_number(ptr_idx);
-            print(b" variables\n");
-            print(b"Consider reducing the number or size of environment variables.\n");
-            exit(1);
-        }
-
-        // Null-terminate the pointer array
-        MODIFIED_ENV_PTRS[ptr_idx] = core::ptr::null();
-
-        MODIFIED_ENV_PTRS.as_ptr()
     }
+
+    // Fix up all the pointers to point to actual addresses in env_data
+    let base_ptr = env_data.as_ptr();
+    for ptr in env_ptrs.iter_mut() {
+        let offset = *ptr as usize;
+        *ptr = unsafe { base_ptr.add(offset) };
+    }
+
+    // Null-terminate the pointer array
+    env_ptrs.push(core::ptr::null());
+
+    (env_data, env_ptrs)
 }
 
 // Placeholders for stub runner (will be replaced in final binary)
@@ -698,7 +593,11 @@ pub extern "C" fn main(runtime_argc: i32, runtime_argv: *const *const u8) -> ! {
         // Get executable path from runtime argv[0] for runfiles fallback
         let executable_path = if runtime_argc > 0 {
             let argv0_ptr = *runtime_argv;
-            let exe_len = strlen(core::slice::from_raw_parts(argv0_ptr, MAX_PATH_LEN));
+            let mut exe_len = 0;
+            // Safety limit of 1MB to prevent infinite loop
+            while *argv0_ptr.add(exe_len) != 0 && exe_len < 1048576 {
+                exe_len += 1;
+            }
             if exe_len > 0 {
                 Some(core::slice::from_raw_parts(argv0_ptr, exe_len))
             } else {
@@ -735,11 +634,8 @@ pub extern "C" fn main(runtime_argc: i32, runtime_argv: *const *const u8) -> ! {
             &ARG9_PLACEHOLDER,
         ];
 
-        // Storage for resolved paths (embedded args + runtime args)
-        // We need space for embedded args (up to 10) plus runtime args (runtime_argc - 1, excluding stub path)
-        let mut resolved_paths: [[u8; MAX_PATH_LEN]; 128] = [[0; MAX_PATH_LEN]; 128];
-        let mut resolved_ptrs: [*const u8; 129] = [core::ptr::null(); 129];
-        let mut total_argc = 0usize;
+        // Use Vec for dynamic path storage - no fixed size limits
+        let mut resolved_paths: Vec<Vec<u8>> = Vec::with_capacity(128);
 
         // Resolve embedded arguments
         for i in 0..argc {
@@ -759,73 +655,97 @@ pub extern "C" fn main(runtime_argc: i32, runtime_argv: *const *const u8) -> ! {
             // Check if this argument should be transformed
             let should_transform = (transform_flags & (1 << i)) != 0;
 
-            if should_transform {
-                // Try to resolve through runfiles
+            let resolved = if should_transform {
+                // Try to resolve through runfiles (which we know exists if we need transformation)
                 if let Some(ref rf) = runfiles {
-                    if let Some(resolved) = rf.rlocation(arg_slice) {
-                        resolved_paths[i] = resolved;
+                    // Convert argument to &str for rlocation (Bazel args are UTF-8)
+                    if let Ok(arg_str) = core::str::from_utf8(arg_slice) {
+                        if let Some(resolved_str) = rf.rlocation(arg_str) {
+                            // Convert back to bytes with null terminator
+                            let mut path = Vec::from(resolved_str.as_bytes());
+                            path.push(0);
+                            path
+                        } else {
+                            // If not found in runfiles, use the path as-is
+                            let mut path = arg_slice.to_vec();
+                            path.push(0);
+                            path
+                        }
                     } else {
-                        // If not found in runfiles, use the path as-is
-                        let copy_len = arg_len.min(MAX_PATH_LEN);
-                        resolved_paths[i][..copy_len].copy_from_slice(&arg_slice[..copy_len]);
+                        // Not valid UTF-8, use as-is
+                        let mut path = arg_slice.to_vec();
+                        path.push(0);
+                        path
                     }
                 } else {
-                    // Use path as-is
-                    let copy_len = arg_len.min(MAX_PATH_LEN);
-                    resolved_paths[i][..copy_len].copy_from_slice(&arg_slice[..copy_len]);
+                    // This should never happen - we checked needs_runfiles before
+                    // But use path as-is for safety
+                    let mut path = arg_slice.to_vec();
+                    path.push(0);
+                    path
                 }
             } else {
                 // Use path as-is without transformation
-                let copy_len = arg_len.min(MAX_PATH_LEN);
-                resolved_paths[i][..copy_len].copy_from_slice(&arg_slice[..copy_len]);
-            }
+                let mut path = arg_slice.to_vec();
+                path.push(0);
+                path
+            };
 
-            resolved_ptrs[i] = resolved_paths[i].as_ptr();
+            resolved_paths.push(resolved);
         }
-        total_argc = argc;
 
         // Append runtime arguments (skip argv[0] which is the stub itself)
         if runtime_argc > 1 {
             for i in 1..runtime_argc as usize {
-                if total_argc >= 128 {
-                    print(b"ERROR: Too many total arguments (embedded + runtime > 128)\n");
-                    exit(1);
-                }
-
                 // Get runtime argument
                 let runtime_arg_ptr = *runtime_argv.add(i);
 
-                // Find length of runtime argument
+                // Find length of runtime argument (scan until null, with safety limit)
                 let mut arg_len = 0;
-                while *runtime_arg_ptr.add(arg_len) != 0 && arg_len < MAX_PATH_LEN {
+                while *runtime_arg_ptr.add(arg_len) != 0 {
                     arg_len += 1;
+                    // Safety limit to prevent infinite loop on malformed input
+                    if arg_len > 1048576 {
+                        print(b"ERROR: Runtime argument exceeds 1MB limit\n");
+                        exit(1);
+                    }
                 }
 
-                // Copy runtime argument to resolved_paths
-                let copy_len = arg_len.min(MAX_PATH_LEN);
-                let runtime_arg_slice = core::slice::from_raw_parts(runtime_arg_ptr, copy_len);
-                resolved_paths[total_argc][..copy_len].copy_from_slice(runtime_arg_slice);
-
-                resolved_ptrs[total_argc] = resolved_paths[total_argc].as_ptr();
-                total_argc += 1;
+                // Copy runtime argument (include null terminator)
+                let runtime_arg_slice = core::slice::from_raw_parts(runtime_arg_ptr, arg_len + 1);
+                resolved_paths.push(runtime_arg_slice.to_vec());
             }
         }
 
+        // Build pointer array from the resolved paths
+        let mut resolved_ptrs: Vec<*const u8> = Vec::with_capacity(resolved_paths.len() + 1);
+        for path in &resolved_paths {
+            resolved_ptrs.push(path.as_ptr());
+        }
         // NULL-terminate the argv array
-        resolved_ptrs[total_argc] = core::ptr::null();
+        resolved_ptrs.push(core::ptr::null());
 
         // Get the executable path (first argument)
         let executable = resolved_ptrs[0];
 
-        // Build environment with runfiles variables if export is enabled
-        let envp = if export_runfiles_env {
+        // Build environment (with runfiles vars if export_runfiles_env is true)
+        // We need to keep the env_data alive until execve
+        let (_env_data, env_ptrs) = if export_runfiles_env {
             build_runfiles_environ(runfiles.as_ref())
         } else {
-            environ
+            // Return environ directly wrapped in expected format
+            let mut ptrs = Vec::new();
+            let mut env_ptr = environ;
+            while !(*env_ptr).is_null() {
+                ptrs.push(*env_ptr);
+                env_ptr = env_ptr.add(1);
+            }
+            ptrs.push(core::ptr::null());
+            (Vec::new(), ptrs)
         };
 
         // Execute the target program
-        let ret = execve(executable, resolved_ptrs.as_ptr(), envp);
+        let ret = execve(executable, resolved_ptrs.as_ptr(), env_ptrs.as_ptr());
 
         // If execve returns, it failed
         // On macOS, libc's execve() returns -1 on failure and sets errno

--- a/runfiles-stub/src/windows.rs
+++ b/runfiles-stub/src/windows.rs
@@ -1,12 +1,46 @@
 // Windows-specific implementation using Windows API
 // Uses kernel32.dll functions
 
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec;
+use alloc::vec::Vec;
+use core::alloc::{GlobalAlloc, Layout};
+use core::cell::UnsafeCell;
 use core::panic::PanicInfo;
+use talc::{ClaimOnOom, Span, Talc};
+
+// Global allocator using talc with a static memory arena
+// 8 MiB should be plenty for manifest parsing, path resolution, and environment handling
+static mut ARENA: [u8; 8 * 1024 * 1024] = [0; 8 * 1024 * 1024];
+
+// Simple wrapper for single-threaded use (no locking needed)
+struct TalcAllocator(UnsafeCell<Talc<ClaimOnOom>>);
+unsafe impl Sync for TalcAllocator {}
+
+unsafe impl GlobalAlloc for TalcAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        (*self.0.get()).malloc(layout).map_or(core::ptr::null_mut(), |p| p.as_ptr())
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        (*self.0.get()).free(core::ptr::NonNull::new_unchecked(ptr), layout);
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: TalcAllocator = TalcAllocator(UnsafeCell::new(Talc::new(unsafe {
+    ClaimOnOom::new(Span::from_array(core::ptr::addr_of!(ARENA).cast_mut()))
+})));
 
 #[panic_handler]
 fn panic(_info: &PanicInfo) -> ! {
     unsafe { ExitProcess(1) }
 }
+
+// Required by alloc crate for exception handling (unused with panic=abort)
+#[no_mangle]
+extern "C" fn rust_eh_personality() {}
 
 // Windows API types
 type DWORD = u32;
@@ -248,102 +282,80 @@ fn find_byte(haystack: &[u8], needle: u8) -> Option<usize> {
     None
 }
 
-// Environment variable reading
-fn get_env_var(name: &[u8], buf: &mut [u8]) -> Option<usize> {
+// Environment variable reading - returns String
+fn get_env_var(name: &[u8]) -> Option<String> {
     unsafe {
         // Ensure name is null-terminated
-        let mut name_with_null = [0u8; 256];
-        let name_len = name.len().min(255);
-        name_with_null[..name_len].copy_from_slice(&name[..name_len]);
-        name_with_null[name_len] = 0;
+        let mut name_with_null = name.to_vec();
+        name_with_null.push(0);
 
+        // First call to get required size
         let size = GetEnvironmentVariableA(
+            name_with_null.as_ptr(),
+            core::ptr::null_mut(),
+            0,
+        );
+
+        if size == 0 {
+            return None;
+        }
+
+        // Allocate buffer and get value
+        let mut buf = vec![0u8; size as usize];
+        let actual_size = GetEnvironmentVariableA(
             name_with_null.as_ptr(),
             buf.as_mut_ptr(),
             buf.len() as DWORD,
         );
 
-        if size > 0 && size < buf.len() as DWORD {
-            Some(size as usize)
+        if actual_size > 0 && actual_size < buf.len() as DWORD {
+            buf.truncate(actual_size as usize);
+            // Convert to String, returning None if not valid UTF-8
+            String::from_utf8(buf).ok()
         } else {
             None
         }
     }
 }
 
-// Manifest entry storage - use static buffers to avoid stack overflow
-// Windows has a default 1MB stack limit, so we store large data in .bss
-const MAX_ENTRIES: usize = 256;  // Reduced from 1024 to save memory
-const MAX_PATH_LEN: usize = 512; // Increased to support longer Windows paths
-
-// Static storage for manifest data (in .bss segment, not stack)
-static mut MANIFEST_KEYS: [[u8; MAX_PATH_LEN]; MAX_ENTRIES] = [[0; MAX_PATH_LEN]; MAX_ENTRIES];
-static mut MANIFEST_VALUES: [[u8; MAX_PATH_LEN]; MAX_ENTRIES] = [[0; MAX_PATH_LEN]; MAX_ENTRIES];
-static mut MANIFEST_KEY_LENS: [usize; MAX_ENTRIES] = [0; MAX_ENTRIES];
-static mut MANIFEST_VALUE_LENS: [usize; MAX_ENTRIES] = [0; MAX_ENTRIES];
-static mut MANIFEST_COUNT: usize = 0;
-
-// Static storage for file buffer
-static mut FILE_BUF: [u8; 65536] = [0; 65536];
-
-// Static storage for resolved paths
-static mut RESOLVED_PATHS: [[u8; MAX_PATH_LEN]; 128] = [[0; MAX_PATH_LEN]; 128];
+// Manifest entry using String for UTF-8 paths (Bazel-generated)
+struct ManifestEntry {
+    key: String,
+    value: String,
+}
 
 struct Manifest {
-    // Empty struct - all data is in statics
+    entries: Vec<ManifestEntry>,
 }
 
 impl Manifest {
-    fn reset() {
-        unsafe {
-            MANIFEST_COUNT = 0;
-            // No need to zero the arrays - we track lengths
-        }
+    fn new() -> Self {
+        Self { entries: Vec::new() }
     }
 
-    fn add_entry(key: &[u8], value: &[u8]) {
-        unsafe {
-            if MANIFEST_COUNT >= MAX_ENTRIES {
-                return;
-            }
-
-            let idx = MANIFEST_COUNT;
-            let key_len = key.len().min(MAX_PATH_LEN);
-            let value_len = value.len().min(MAX_PATH_LEN);
-
-            MANIFEST_KEYS[idx][..key_len].copy_from_slice(&key[..key_len]);
-            MANIFEST_KEY_LENS[idx] = key_len;
-            MANIFEST_VALUES[idx][..value_len].copy_from_slice(&value[..value_len]);
-            MANIFEST_VALUE_LENS[idx] = value_len;
-
-            MANIFEST_COUNT += 1;
-        }
+    fn add_entry(&mut self, key: &str, value: &str) {
+        self.entries.push(ManifestEntry {
+            key: String::from(key),
+            value: String::from(value),
+        });
     }
 
-    fn lookup(key: &[u8]) -> Option<&'static [u8]> {
-        unsafe {
-            for i in 0..MANIFEST_COUNT {
-                let entry_key = &MANIFEST_KEYS[i][..MANIFEST_KEY_LENS[i]];
-                if str_eq(entry_key, key) {
-                    return Some(&MANIFEST_VALUES[i][..MANIFEST_VALUE_LENS[i]]);
-                }
+    fn lookup(&self, key: &str) -> Option<&str> {
+        for entry in &self.entries {
+            if entry.key == key {
+                return Some(&entry.value);
             }
-            None
         }
+        None
     }
 }
 
-// Load manifest file - uses static FILE_BUF to avoid stack overflow
+// Load manifest file
 fn load_manifest(path: &[u8]) -> Option<Manifest> {
     unsafe {
-        // Reset manifest state
-        Manifest::reset();
-
         // Ensure path is null-terminated
-        let mut path_with_null = [0u8; 1024];
-        let path_len = path.len().min(1023);
-        path_with_null[..path_len].copy_from_slice(&path[..path_len]);
-        path_with_null[path_len] = 0;
+        let mut path_with_null = path.to_vec();
+        path_with_null.push(0);
 
         let handle = CreateFileA(
             path_with_null.as_ptr(),
@@ -359,75 +371,71 @@ fn load_manifest(path: &[u8]) -> Option<Manifest> {
             return None;
         }
 
-        // Use static FILE_BUF instead of stack allocation
-        let mut bytes_read: DWORD = 0;
-        let success = ReadFile(
-            handle,
-            FILE_BUF.as_mut_ptr() as LPVOID,
-            FILE_BUF.len() as DWORD,
-            &mut bytes_read,
-            core::ptr::null_mut(),
-        );
+        // Read file into Vec, reading in chunks
+        let mut file_data = Vec::new();
+        let mut chunk = [0u8; 8192];
+        loop {
+            let mut bytes_read: DWORD = 0;
+            let success = ReadFile(
+                handle,
+                chunk.as_mut_ptr() as LPVOID,
+                chunk.len() as DWORD,
+                &mut bytes_read,
+                core::ptr::null_mut(),
+            );
+            if success == 0 || bytes_read == 0 {
+                break;
+            }
+            file_data.extend_from_slice(&chunk[..bytes_read as usize]);
+        }
         CloseHandle(handle);
 
-        if success == 0 || bytes_read == 0 {
+        if file_data.is_empty() {
             return None;
         }
 
-        let data = &FILE_BUF[..bytes_read as usize];
-        let mut pos = 0;
+        // Convert to UTF-8 string for easier parsing
+        let file_str = String::from_utf8(file_data).ok()?;
 
-        while pos < data.len() {
-            let line_start = pos;
-            while pos < data.len() && data[pos] != b'\n' {
-                pos += 1;
+        let mut manifest = Manifest::new();
+
+        for line in file_str.lines() {
+            // lines() automatically strips \r\n endings
+            if let Some((key, value)) = line.split_once(' ') {
+                manifest.add_entry(key, value);
             }
-
-            let line = &data[line_start..pos];
-
-            if let Some(space_pos) = find_byte(line, b' ') {
-                let key = &line[..space_pos];
-                let mut value = &line[space_pos + 1..];
-
-                // Strip trailing \r if present (Windows line endings)
-                if !value.is_empty() && value[value.len() - 1] == b'\r' {
-                    value = &value[..value.len() - 1];
-                }
-
-                Manifest::add_entry(key, value);
-            }
-
-            pos += 1;
         }
 
-        Some(Manifest {})
+        Some(manifest)
     }
 }
 
-// Runfiles implementation
+// Runfiles implementation using String for dynamic path storage
 enum RunfilesMode {
     ManifestBased(Manifest),
-    DirectoryBased([u8; MAX_PATH_LEN], usize),
+    DirectoryBased(String),
 }
 
 struct Runfiles {
     mode: RunfilesMode,
     // Paths for environment variables (when export_runfiles_env is true)
-    manifest_path: Option<([u8; MAX_PATH_LEN], usize)>, // RUNFILES_MANIFEST_FILE
-    dir_path: Option<([u8; MAX_PATH_LEN], usize)>,      // RUNFILES_DIR and JAVA_RUNFILES
+    manifest_path: Option<String>, // RUNFILES_MANIFEST_FILE
+    dir_path: Option<String>,      // RUNFILES_DIR and JAVA_RUNFILES
 }
 
 impl Runfiles {
     fn create(executable_path: Option<&[u8]>) -> Option<Self> {
-        let mut manifest_path = [0u8; MAX_PATH_LEN];
-
         // Step 1: Try RUNFILES_MANIFEST_FILE envvar first
-        if let Some(len) = get_env_var(b"RUNFILES_MANIFEST_FILE", &mut manifest_path) {
-            if len > 0 {
-                if let Some(manifest) = load_manifest(&manifest_path[..len]) {
+        if let Some(manifest_path) = get_env_var(b"RUNFILES_MANIFEST_FILE") {
+            if !manifest_path.is_empty() {
+                // Create null-terminated path for load_manifest
+                let mut path_with_null = Vec::from(manifest_path.as_bytes());
+                path_with_null.push(0);
+
+                if let Some(manifest) = load_manifest(&path_with_null) {
                     return Some(Self {
                         mode: RunfilesMode::ManifestBased(manifest),
-                        manifest_path: Some((manifest_path, len)),
+                        manifest_path: Some(manifest_path),
                         dir_path: None,
                     });
                 }
@@ -435,13 +443,12 @@ impl Runfiles {
         }
 
         // Step 2: Try RUNFILES_DIR envvar
-        let mut runfiles_dir = [0u8; MAX_PATH_LEN];
-        if let Some(len) = get_env_var(b"RUNFILES_DIR", &mut runfiles_dir) {
-            if len > 0 {
+        if let Some(runfiles_dir) = get_env_var(b"RUNFILES_DIR") {
+            if !runfiles_dir.is_empty() {
                 return Some(Self {
-                    mode: RunfilesMode::DirectoryBased(runfiles_dir, len),
+                    mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
                     manifest_path: None,
-                    dir_path: Some((runfiles_dir, len)),
+                    dir_path: Some(runfiles_dir),
                 });
             }
         }
@@ -452,74 +459,55 @@ impl Runfiles {
         if let Some(exe_path) = executable_path {
             let exe_len = strlen(exe_path);
             if exe_len > 0 {
+                // Convert executable path to string (if valid UTF-8)
+                let exe_str = core::str::from_utf8(&exe_path[..exe_len]).ok()?;
+
                 // Try <executable>.runfiles_manifest file first
-                if exe_len + 19 < MAX_PATH_LEN {  // +19 for ".runfiles_manifest\0"
-                    let mut manifest_file_path = [0u8; MAX_PATH_LEN];
+                let manifest_file_path = String::from(exe_str) + ".runfiles_manifest";
 
-                    // Copy executable path
-                    manifest_file_path[..exe_len].copy_from_slice(&exe_path[..exe_len]);
+                // Add null terminator for syscall
+                let mut manifest_path_with_null = Vec::from(manifest_file_path.as_bytes());
+                manifest_path_with_null.push(0);
 
-                    // Append ".runfiles_manifest" (18 characters)
-                    manifest_file_path[exe_len..exe_len + 18].copy_from_slice(b".runfiles_manifest");
-                    let manifest_file_len = exe_len + 18;
+                // Try to load the manifest file
+                if let Some(manifest) = load_manifest(&manifest_path_with_null) {
+                    // Also determine the runfiles directory for RUNFILES_DIR envvar
+                    // The directory is <executable>.runfiles
+                    let dir_path = String::from(exe_str) + ".runfiles";
 
-                    // Try to load the manifest file
-                    if let Some(manifest) = load_manifest(&manifest_file_path[..manifest_file_len]) {
-                        // Also determine the runfiles directory for RUNFILES_DIR envvar
-                        // The directory is <executable>.runfiles
-                        let mut dir_path = [0u8; MAX_PATH_LEN];
-                        if exe_len + 9 < MAX_PATH_LEN {
-                            dir_path[..exe_len].copy_from_slice(&exe_path[..exe_len]);
-                            dir_path[exe_len..exe_len + 9].copy_from_slice(b".runfiles");
-                            let dir_len = exe_len + 9;
-
-                            return Some(Self {
-                                mode: RunfilesMode::ManifestBased(manifest),
-                                manifest_path: Some((manifest_file_path, manifest_file_len)),
-                                dir_path: Some((dir_path, dir_len)),
-                            });
-                        } else {
-                            return Some(Self {
-                                mode: RunfilesMode::ManifestBased(manifest),
-                                manifest_path: Some((manifest_file_path, manifest_file_len)),
-                                dir_path: None,
-                            });
-                        }
-                    }
+                    return Some(Self {
+                        mode: RunfilesMode::ManifestBased(manifest),
+                        manifest_path: Some(manifest_file_path),
+                        dir_path: Some(dir_path),
+                    });
                 }
 
                 // Try <executable>.runfiles directory
-                if exe_len + 9 < MAX_PATH_LEN {  // +9 for ".runfiles\0"
-                    let mut runfiles_dir = [0u8; MAX_PATH_LEN];
+                let runfiles_dir = String::from(exe_str) + ".runfiles";
 
-                    // Copy executable path
-                    runfiles_dir[..exe_len].copy_from_slice(&exe_path[..exe_len]);
+                // Add null terminator for CreateFileA
+                let mut dir_with_null = Vec::from(runfiles_dir.as_bytes());
+                dir_with_null.push(0);
 
-                    // Append ".runfiles"
-                    runfiles_dir[exe_len..exe_len + 9].copy_from_slice(b".runfiles");
-                    runfiles_dir[exe_len + 9] = 0; // null terminator
-
-                    // Check if directory exists by trying to open it
-                    unsafe {
-                        const FILE_FLAG_BACKUP_SEMANTICS: DWORD = 0x02000000;  // Needed to open directories
-                        let handle = CreateFileA(
-                            runfiles_dir.as_ptr(),
-                            GENERIC_READ,
-                            0,
-                            core::ptr::null_mut(),
-                            OPEN_EXISTING,
-                            FILE_FLAG_BACKUP_SEMANTICS,
-                            core::ptr::null_mut(),
-                        );
-                        if handle != INVALID_HANDLE_VALUE {
-                            CloseHandle(handle);
-                            // Remove null terminator for internal storage
-                            return Some(Self {
-                                mode: RunfilesMode::DirectoryBased(runfiles_dir, exe_len + 9),
-                                manifest_path: None,
-                                dir_path: Some((runfiles_dir, exe_len + 9)),
-                            });
-                        }
+                // Check if directory exists by trying to open it
+                unsafe {
+                    const FILE_FLAG_BACKUP_SEMANTICS: DWORD = 0x02000000;  // Needed to open directories
+                    let handle = CreateFileA(
+                        dir_with_null.as_ptr(),
+                        GENERIC_READ,
+                        0,
+                        core::ptr::null_mut(),
+                        OPEN_EXISTING,
+                        FILE_FLAG_BACKUP_SEMANTICS,
+                        core::ptr::null_mut(),
+                    );
+                    if handle != INVALID_HANDLE_VALUE {
+                        CloseHandle(handle);
+                        return Some(Self {
+                            mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
+                            manifest_path: None,
+                            dir_path: Some(runfiles_dir),
+                        });
                     }
                 }
             }
@@ -528,55 +516,33 @@ impl Runfiles {
         None
     }
 
-    fn rlocation(&self, path: &[u8], result_idx: usize) -> Option<&'static [u8]> {
+    fn rlocation(&self, path: &str) -> Option<String> {
         // If path is absolute (Windows: starts with drive letter or \\), don't resolve
-        if path.len() >= 2 && ((path[0].is_ascii_alphabetic() && path[1] == b':') || (path[0] == b'\\' && path[1] == b'\\')) {
+        let path_bytes = path.as_bytes();
+        if path_bytes.len() >= 2 && ((path_bytes[0].is_ascii_alphabetic() && path_bytes[1] == b':') || (path_bytes[0] == b'\\' && path_bytes[1] == b'\\')) {
             return None;
         }
 
         match &self.mode {
-            RunfilesMode::ManifestBased(_manifest) => {
-                // Use static lookup
-                if let Some(resolved) = Manifest::lookup(path) {
-                    unsafe {
-                        let len = resolved.len().min(MAX_PATH_LEN);
-                        // Copy path, converting forward slashes to backslashes
-                        // Manifest values may contain Unix-style paths (forward slashes)
-                        for i in 0..len {
-                            RESOLVED_PATHS[result_idx][i] = if resolved[i] == b'/' { b'\\' } else { resolved[i] };
-                        }
-                        RESOLVED_PATHS[result_idx][len] = 0; // null terminate
-                        return Some(&RESOLVED_PATHS[result_idx][..len]);
-                    }
+            RunfilesMode::ManifestBased(manifest) => {
+                if let Some(resolved) = manifest.lookup(path) {
+                    // Convert forward slashes to backslashes
+                    return Some(resolved.replace('/', "\\"));
                 }
                 None
             }
-            RunfilesMode::DirectoryBased(dir, dir_len) => {
-                unsafe {
-                    let mut pos = 0;
+            RunfilesMode::DirectoryBased(dir) => {
+                let mut result = dir.clone();
 
-                    // Copy directory
-                    let copy_len = (*dir_len).min(MAX_PATH_LEN);
-                    RESOLVED_PATHS[result_idx][..copy_len].copy_from_slice(&dir[..copy_len]);
-                    pos += copy_len;
-
-                    // Add separator if needed
-                    if pos < MAX_PATH_LEN && pos > 0 && RESOLVED_PATHS[result_idx][pos - 1] != b'\\' && RESOLVED_PATHS[result_idx][pos - 1] != b'/' {
-                        RESOLVED_PATHS[result_idx][pos] = b'\\';
-                        pos += 1;
-                    }
-
-                    // Copy path, converting forward slashes to backslashes
-                    // Input is always Unix-style (a/b/c), output should be Windows-style (a\b\c)
-                    let path_len = path.len().min(MAX_PATH_LEN - pos);
-                    for i in 0..path_len {
-                        RESOLVED_PATHS[result_idx][pos + i] = if path[i] == b'/' { b'\\' } else { path[i] };
-                    }
-                    let total_len = pos + path_len;
-                    RESOLVED_PATHS[result_idx][total_len] = 0; // null terminate
-
-                    Some(&RESOLVED_PATHS[result_idx][..total_len])
+                // Add separator if needed
+                if !result.ends_with('\\') && !result.ends_with('/') {
+                    result.push('\\');
                 }
+
+                // Append path, converting forward slashes to backslashes
+                result.push_str(&path.replace('/', "\\"));
+
+                Some(result)
             }
         }
     }
@@ -613,8 +579,9 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
         let env_block = GetEnvironmentStringsW();
         if env_block.is_null() {
             // No parent environment, just add runfiles vars in sorted order
-            let mut add_env = |key: &[u8], value: &[u8]| -> bool {
-                let total_len = key.len() + 1 + value.len() + 1; // key + '=' + value + '\0'
+            let mut add_env = |key: &[u8], value: &str| -> bool {
+                let value_bytes = value.as_bytes();
+                let total_len = key.len() + 1 + value_bytes.len() + 1; // key + '=' + value + '\0'
                 if !check_bounds(data_pos, total_len) {
                     return false;
                 }
@@ -625,7 +592,7 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
                 }
                 MODIFIED_ENV_DATA[data_pos] = b'=' as u16;
                 data_pos += 1;
-                for &b in value {
+                for &b in value_bytes {
                     MODIFIED_ENV_DATA[data_pos] = b as u16;
                     data_pos += 1;
                 }
@@ -635,15 +602,15 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
             };
 
             if let Some(rf) = runfiles {
-                if let Some((ref path, len)) = rf.dir_path {
-                    if !add_env(b"JAVA_RUNFILES", &path[..len]) {
+                if let Some(ref path) = rf.dir_path {
+                    if !add_env(b"JAVA_RUNFILES", path) {
                         print(b"ERROR: Failed to add JAVA_RUNFILES to environment\r\n");
                         print(b"Environment buffer limit exceeded. Total size limit: ");
                         print_number(MAX_ENV_SIZE);
                         print(b" bytes\r\n");
                         ExitProcess(1);
                     }
-                    if !add_env(b"RUNFILES_DIR", &path[..len]) {
+                    if !add_env(b"RUNFILES_DIR", path) {
                         print(b"ERROR: Failed to add RUNFILES_DIR to environment\r\n");
                         print(b"Environment buffer limit exceeded. Total size limit: ");
                         print_number(MAX_ENV_SIZE);
@@ -651,8 +618,8 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
                         ExitProcess(1);
                     }
                 }
-                if let Some((ref path, len)) = rf.manifest_path {
-                    if !add_env(b"RUNFILES_MANIFEST_FILE", &path[..len]) {
+                if let Some(ref path) = rf.manifest_path {
+                    if !add_env(b"RUNFILES_MANIFEST_FILE", path) {
                         print(b"ERROR: Failed to add RUNFILES_MANIFEST_FILE to environment\r\n");
                         print(b"Environment buffer limit exceeded. Total size limit: ");
                         print_number(MAX_ENV_SIZE);
@@ -743,8 +710,9 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
                     // Insert JAVA_RUNFILES if needed
                     if !java_runfiles_inserted && var_comes_after(b"JAVA_RUNFILES") {
                         if let Some(rf) = runfiles {
-                            if let Some((ref path, len)) = rf.dir_path {
-                                let total_len = 14 + len + 1; // "JAVA_RUNFILES=" + value + '\0'
+                            if let Some(ref path) = rf.dir_path {
+                                let path_bytes = path.as_bytes();
+                                let total_len = 14 + path_bytes.len() + 1; // "JAVA_RUNFILES=" + value + '\0'
                                 if !check_bounds(data_pos, total_len) {
                                     env_dropped = true;
                                 } else {
@@ -752,8 +720,8 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
                                         MODIFIED_ENV_DATA[data_pos] = b as u16;
                                         data_pos += 1;
                                     }
-                                    for i in 0..len {
-                                        MODIFIED_ENV_DATA[data_pos] = path[i] as u16;
+                                    for &b in path_bytes {
+                                        MODIFIED_ENV_DATA[data_pos] = b as u16;
                                         data_pos += 1;
                                     }
                                     MODIFIED_ENV_DATA[data_pos] = 0;
@@ -767,8 +735,9 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
                     // Insert RUNFILES_DIR if needed
                     if !runfiles_dir_inserted && var_comes_after(b"RUNFILES_DIR") {
                         if let Some(rf) = runfiles {
-                            if let Some((ref path, len)) = rf.dir_path {
-                                let total_len = 13 + len + 1; // "RUNFILES_DIR=" + value + '\0'
+                            if let Some(ref path) = rf.dir_path {
+                                let path_bytes = path.as_bytes();
+                                let total_len = 13 + path_bytes.len() + 1; // "RUNFILES_DIR=" + value + '\0'
                                 if !check_bounds(data_pos, total_len) {
                                     env_dropped = true;
                                 } else {
@@ -776,8 +745,8 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
                                         MODIFIED_ENV_DATA[data_pos] = b as u16;
                                         data_pos += 1;
                                     }
-                                    for i in 0..len {
-                                        MODIFIED_ENV_DATA[data_pos] = path[i] as u16;
+                                    for &b in path_bytes {
+                                        MODIFIED_ENV_DATA[data_pos] = b as u16;
                                         data_pos += 1;
                                     }
                                     MODIFIED_ENV_DATA[data_pos] = 0;
@@ -791,8 +760,9 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
                     // Insert RUNFILES_MANIFEST_FILE if needed
                     if !runfiles_manifest_inserted && var_comes_after(b"RUNFILES_MANIFEST_FILE") {
                         if let Some(rf) = runfiles {
-                            if let Some((ref path, len)) = rf.manifest_path {
-                                let total_len = 23 + len + 1; // "RUNFILES_MANIFEST_FILE=" + value + '\0'
+                            if let Some(ref path) = rf.manifest_path {
+                                let path_bytes = path.as_bytes();
+                                let total_len = 23 + path_bytes.len() + 1; // "RUNFILES_MANIFEST_FILE=" + value + '\0'
                                 if !check_bounds(data_pos, total_len) {
                                     env_dropped = true;
                                 } else {
@@ -800,8 +770,8 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
                                         MODIFIED_ENV_DATA[data_pos] = b as u16;
                                         data_pos += 1;
                                     }
-                                    for i in 0..len {
-                                        MODIFIED_ENV_DATA[data_pos] = path[i] as u16;
+                                    for &b in path_bytes {
+                                        MODIFIED_ENV_DATA[data_pos] = b as u16;
                                         data_pos += 1;
                                     }
                                     MODIFIED_ENV_DATA[data_pos] = 0;
@@ -830,8 +800,9 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
             // Add any remaining runfiles vars that weren't inserted yet
             if !java_runfiles_inserted {
                 if let Some(rf) = runfiles {
-                    if let Some((ref path, len)) = rf.dir_path {
-                        let total_len = 14 + len + 1;
+                    if let Some(ref path) = rf.dir_path {
+                        let path_bytes = path.as_bytes();
+                        let total_len = 14 + path_bytes.len() + 1;
                         if !check_bounds(data_pos, total_len) {
                             env_dropped = true;
                         } else {
@@ -839,8 +810,8 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
                                 MODIFIED_ENV_DATA[data_pos] = b as u16;
                                 data_pos += 1;
                             }
-                            for i in 0..len {
-                                MODIFIED_ENV_DATA[data_pos] = path[i] as u16;
+                            for &b in path_bytes {
+                                MODIFIED_ENV_DATA[data_pos] = b as u16;
                                 data_pos += 1;
                             }
                             MODIFIED_ENV_DATA[data_pos] = 0;
@@ -851,8 +822,9 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
             }
             if !runfiles_dir_inserted {
                 if let Some(rf) = runfiles {
-                    if let Some((ref path, len)) = rf.dir_path {
-                        let total_len = 13 + len + 1;
+                    if let Some(ref path) = rf.dir_path {
+                        let path_bytes = path.as_bytes();
+                        let total_len = 13 + path_bytes.len() + 1;
                         if !check_bounds(data_pos, total_len) {
                             env_dropped = true;
                         } else {
@@ -860,8 +832,8 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
                                 MODIFIED_ENV_DATA[data_pos] = b as u16;
                                 data_pos += 1;
                             }
-                            for i in 0..len {
-                                MODIFIED_ENV_DATA[data_pos] = path[i] as u16;
+                            for &b in path_bytes {
+                                MODIFIED_ENV_DATA[data_pos] = b as u16;
                                 data_pos += 1;
                             }
                             MODIFIED_ENV_DATA[data_pos] = 0;
@@ -872,8 +844,9 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
             }
             if !runfiles_manifest_inserted {
                 if let Some(rf) = runfiles {
-                    if let Some((ref path, len)) = rf.manifest_path {
-                        let total_len = 23 + len + 1;
+                    if let Some(ref path) = rf.manifest_path {
+                        let path_bytes = path.as_bytes();
+                        let total_len = 23 + path_bytes.len() + 1;
                         if !check_bounds(data_pos, total_len) {
                             env_dropped = true;
                         } else {
@@ -881,8 +854,8 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void
                                 MODIFIED_ENV_DATA[data_pos] = b as u16;
                                 data_pos += 1;
                             }
-                            for i in 0..len {
-                                MODIFIED_ENV_DATA[data_pos] = path[i] as u16;
+                            for &b in path_bytes {
+                                MODIFIED_ENV_DATA[data_pos] = b as u16;
                                 data_pos += 1;
                             }
                             MODIFIED_ENV_DATA[data_pos] = 0;
@@ -1110,8 +1083,7 @@ pub extern "C" fn main() -> ! {
         // Parse argv[0] from command line manually
         // Command line format: either "path\to\exe" args... or path\to\exe args...
         // We extract the first token (argv[0]) for runfiles fallback
-        let mut exe_path_buf = [0u8; MAX_PATH_LEN];
-        let mut exe_len = 0;
+        let mut exe_path_buf = Vec::new();
         let mut pos = 0usize;
 
         // Skip leading whitespace
@@ -1125,8 +1097,8 @@ pub extern "C" fn main() -> ! {
             pos += 1; // Skip opening quote
         }
 
-        // Extract argv[0]
-        while exe_len < MAX_PATH_LEN && *cmdline.add(pos) != 0 {
+        // Extract argv[0] (with 1MB safety limit)
+        while exe_path_buf.len() < 1048576 && *cmdline.add(pos) != 0 {
             let wchar = *cmdline.add(pos);
 
             // Check for end of argv[0]
@@ -1141,13 +1113,12 @@ pub extern "C" fn main() -> ! {
             }
 
             // Simple UTF-16 to ASCII conversion
-            exe_path_buf[exe_len] = (wchar & 0xFF) as u8;
-            exe_len += 1;
+            exe_path_buf.push((wchar & 0xFF) as u8);
             pos += 1;
         }
 
-        let executable_path = if exe_len > 0 {
-            Some(&exe_path_buf[..exe_len] as &[u8])
+        let executable_path: Option<&[u8]> = if !exe_path_buf.is_empty() {
+            Some(&exe_path_buf)
         } else {
             None
         };
@@ -1179,7 +1150,10 @@ pub extern "C" fn main() -> ! {
             &ARG9_PLACEHOLDER,
         ];
 
-        // Resolve embedded arguments - uses static RESOLVED_PATHS
+        // Use Vec for dynamic path storage - no fixed size limits
+        let mut resolved_paths: Vec<Vec<u8>> = Vec::with_capacity(128);
+
+        // Resolve embedded arguments
         for i in 0..argc {
             let arg_data = arg_placeholders[i];
             let arg_len = strlen(arg_data);
@@ -1197,62 +1171,62 @@ pub extern "C" fn main() -> ! {
             // Check if this argument should be transformed
             let should_transform = (transform_flags & (1 << i)) != 0;
 
-            if should_transform {
+            let resolved = if should_transform {
                 // Try to resolve through runfiles
                 if let Some(ref rf) = runfiles {
-                    if rf.rlocation(arg_slice, i).is_none() {
-                        // If not found in runfiles, use the path as-is
-                        let copy_len = arg_len.min(MAX_PATH_LEN);
-                        RESOLVED_PATHS[i][..copy_len].copy_from_slice(&arg_slice[..copy_len]);
-                        RESOLVED_PATHS[i][copy_len] = 0;
+                    // Convert argument to &str for rlocation (Bazel args are UTF-8)
+                    if let Ok(arg_str) = core::str::from_utf8(arg_slice) {
+                        if let Some(resolved_str) = rf.rlocation(arg_str) {
+                            // Convert back to bytes
+                            Vec::from(resolved_str.as_bytes())
+                        } else {
+                            // If not found in runfiles, use the path as-is
+                            arg_slice.to_vec()
+                        }
+                    } else {
+                        // Not valid UTF-8, use as-is
+                        arg_slice.to_vec()
                     }
-                    // else: rlocation already wrote to RESOLVED_PATHS[i]
                 } else {
                     // Use path as-is
-                    let copy_len = arg_len.min(MAX_PATH_LEN);
-                    RESOLVED_PATHS[i][..copy_len].copy_from_slice(&arg_slice[..copy_len]);
-                    RESOLVED_PATHS[i][copy_len] = 0;
+                    arg_slice.to_vec()
                 }
             } else {
                 // Use path as-is without transformation
-                let copy_len = arg_len.min(MAX_PATH_LEN);
-                RESOLVED_PATHS[i][..copy_len].copy_from_slice(&arg_slice[..copy_len]);
-                RESOLVED_PATHS[i][copy_len] = 0;
-            }
+                arg_slice.to_vec()
+            };
+
+            resolved_paths.push(resolved);
         }
 
         // Build command line for CreateProcessW (UTF-16)
         // Command line includes embedded args + runtime args
-        let mut cmdline_wide = [0u16; 8192]; // Large buffer for UTF-16
-        let mut cmdline_pos = 0usize;
+        let mut cmdline_wide: Vec<u16> = Vec::with_capacity(8192);
 
         // Add embedded arguments (convert from UTF-8 to UTF-16)
         for i in 0..argc {
-            let arg_len = strlen(&RESOLVED_PATHS[i]);
-            let arg_slice = &RESOLVED_PATHS[i][..arg_len];
+            let arg_slice = &resolved_paths[i];
 
             // Always quote the first argument (executable path) following Bazel's approach
             // For other arguments, only quote if they contain spaces
             let needs_quotes = i == 0 || find_byte(arg_slice, b' ').is_some();
 
-            if needs_quotes && cmdline_pos < cmdline_wide.len() {
-                cmdline_wide[cmdline_pos] = b'"' as u16;
-                cmdline_pos += 1;
+            if needs_quotes {
+                cmdline_wide.push(b'"' as u16);
             }
 
             // Convert UTF-8 to UTF-16 and copy
-            let converted_len = utf8_to_wide(arg_slice, &mut cmdline_wide[cmdline_pos..]);
-            cmdline_pos += converted_len;
+            for &b in arg_slice {
+                cmdline_wide.push(b as u16);
+            }
 
-            if needs_quotes && cmdline_pos < cmdline_wide.len() {
-                cmdline_wide[cmdline_pos] = b'"' as u16;
-                cmdline_pos += 1;
+            if needs_quotes {
+                cmdline_wide.push(b'"' as u16);
             }
 
             // Add space between arguments
-            if (i < argc - 1 || runtime_args_count > 0) && cmdline_pos < cmdline_wide.len() {
-                cmdline_wide[cmdline_pos] = b' ' as u16;
-                cmdline_pos += 1;
+            if i < argc - 1 || runtime_args_count > 0 {
+                cmdline_wide.push(b' ' as u16);
             }
         }
 
@@ -1270,34 +1244,27 @@ pub extern "C" fn main() -> ! {
                 }
             }
 
-            if needs_quotes && cmdline_pos < cmdline_wide.len() {
-                cmdline_wide[cmdline_pos] = b'"' as u16;
-                cmdline_pos += 1;
+            if needs_quotes {
+                cmdline_wide.push(b'"' as u16);
             }
 
             // Copy wide string
-            let copy_len = arg_len.min(cmdline_wide.len() - cmdline_pos);
-            for j in 0..copy_len {
-                cmdline_wide[cmdline_pos + j] = *runtime_arg.add(j);
+            for j in 0..arg_len {
+                cmdline_wide.push(*runtime_arg.add(j));
             }
-            cmdline_pos += copy_len;
 
-            if needs_quotes && cmdline_pos < cmdline_wide.len() {
-                cmdline_wide[cmdline_pos] = b'"' as u16;
-                cmdline_pos += 1;
+            if needs_quotes {
+                cmdline_wide.push(b'"' as u16);
             }
 
             // Add space between arguments (except after last)
-            if i < runtime_args_count - 1 && cmdline_pos < cmdline_wide.len() {
-                cmdline_wide[cmdline_pos] = b' ' as u16;
-                cmdline_pos += 1;
+            if i < runtime_args_count - 1 {
+                cmdline_wide.push(b' ' as u16);
             }
         }
 
         // Null-terminate command line
-        if cmdline_pos < cmdline_wide.len() {
-            cmdline_wide[cmdline_pos] = 0;
-        }
+        cmdline_wide.push(0);
 
         // Build environment with runfiles variables if export is enabled
         let envp = if export_runfiles_env {


### PR DESCRIPTION
## Summary
- Replace all fixed-size path buffers with dynamically allocated `Vec` and `String` types
- Add talc allocator for no_std dynamic memory allocation (8 MiB arena)
- Use `String` for Bazel-generated paths (manifest entries, runfiles paths) with UTF-8 validation
- Use `Vec<u8>` for runtime data that may contain arbitrary bytes
- Simplify manifest parsing with String methods (`lines()`, `split_once()`)

## Problem
Bazel sandbox paths can easily exceed 256 bytes, causing buffer overflows when resolving runfiles paths. This resulted in corrupted argv strings where adjacent arguments would bleed into each other (e.g., `img_linux_amd64` + `deploy` becoming `img_linux_amd6deploy`).

Instead of just increasing `MAX_PATH_LEN`, this PR eliminates all fixed-size path buffers entirely by introducing a memory allocator, removing any path length limitations.

## Test plan
- [x] Code compiles for all platforms (Linux verified, macOS/Windows targets not installed)
- [x] CI passes
- [x] Test with long Bazel sandbox paths that previously caused corruption

Work towards https://github.com/bazel-contrib/rules_img/issues/377