### PR TITLE
feat: add Linux s390x (IBM Z) platform support

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -41,6 +41,7 @@ jobs:
           ### Templates
           - `runfiles-stub-x86_64-linux`
           - `runfiles-stub-aarch64-linux`
+          - `runfiles-stub-s390x-linux` (IBM Z)
           - `runfiles-stub-x86_64-macos`
           - `runfiles-stub-aarch64-macos`
           - `runfiles-stub-x86_64-windows.exe`
@@ -49,6 +50,7 @@ jobs:
           ### Finalizers
           - `finalize-stub-x86_64-linux`
           - `finalize-stub-aarch64-linux`
+          - `finalize-stub-s390x-linux` (IBM Z)
           - `finalize-stub-x86_64-macos`
           - `finalize-stub-aarch64-macos`
           - `finalize-stub-x86_64-windows.exe`

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -48,6 +48,7 @@ RUST_TRIPLES = [
     "aarch64-apple-darwin",
     "aarch64-pc-windows-gnullvm",
     "aarch64-pc-windows-msvc",
+    "s390x-unknown-linux-gnu",
     "x86_64-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
     "x86_64-apple-darwin",
@@ -88,6 +89,12 @@ crate.annotation(
 inject_repo(crate, "bzip2")
 
 bazel_dep(name = "xz", version = "5.4.5.bcr.8")
+single_version_override(
+    module_name = "xz",
+    patch_strip = 1,
+    patches = ["//patches:xz-s390x-support.patch"],
+    version = "5.4.5.bcr.8",
+)
 
 crate.annotation(
     crate = "lzma-sys",

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -234,40 +234,8 @@
             "repoRuleId": "@@aspect_tools_telemetry+//:extension.bzl%tel_repository",
             "attributes": {
               "deps": {
-                "abseil-cpp": "20250814.1",
-                "apple_support": "1.24.2",
-                "aspect_tools_telemetry": "0.3.2",
-                "bazel_features": "1.45.0",
-                "bazel_lib": "3.2.2",
-                "bazel_skylib": "1.9.0",
-                "buildozer": "8.5.1",
-                "bzip2": "1.0.8.bcr.3",
-                "gawk": "5.3.2.bcr.3",
-                "googletest": "1.17.0",
-                "jsoncpp": "1.9.6",
-                "llvm": "0.7.5",
-                "package_metadata": "0.0.7",
-                "platforms": "1.0.0",
-                "protobuf": "34.0.bcr.1",
-                "pybind11_bazel": "2.12.0",
-                "re2": "2024-07-02.bcr.1",
-                "rules_android": "0.1.1",
-                "rules_cc": "0.2.18",
-                "rules_java": "9.1.0",
-                "rules_jvm_external": "6.7",
-                "rules_kotlin": "1.9.6",
-                "rules_license": "1.0.0",
-                "rules_pkg": "1.0.1",
-                "rules_platform": "0.1.0",
-                "rules_proto": "7.1.0",
-                "rules_python": "1.7.0",
-                "rules_rs": "0.0.62",
-                "rules_shell": "0.6.1",
-                "stardoc": "0.7.2",
-                "tar.bzl": "0.9.0",
-                "with_cfg.bzl": "0.12.0",
-                "xz": "5.4.5.bcr.8",
-                "zlib": "1.3.1.bcr.5"
+                "rules_rs": "0.0.64",
+                "aspect_tools_telemetry": "0.3.2"
               }
             }
           }

--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ This enables Bazel rules to create tiny, platform-agnostic entrypoints that work
 
 ## Features
 
-- **Cross-platform**: Linux (x86_64, aarch64), macOS (x86_64, aarch64), Windows (x86_64)
+- **Cross-platform**: Linux (x86_64, aarch64, s390x), macOS (x86_64, aarch64), Windows (x86_64)
 - **True cross-compilation**: Finalize launcher for **any target platform** from **any build platform**
   - Build on Linux → create Windows/macOS launcher
   - Build on macOS → create Linux/Windows launcher
@@ -140,12 +140,12 @@ This is crucial for Bazel: your **exec platform** (where the build runs) can cre
 
 | Platform | Architectures | Template Size | Notes |
 |----------|--------------|---------------|-------|
-| **Linux** | x86_64, aarch64 | 10-68KB | Fully static, no dependencies |
+| **Linux** | x86_64, aarch64, s390x | 10-68KB | Fully static, no dependencies |
 | **macOS** | x86_64, aarch64 | 13-49KB | Links with libSystem |
 | **Windows** | x86_64 | 22KB | Links with kernel32.dll, shell32.dll |
 
 **Finalizers** (the tool that patches templates):
-- Linux: x86_64, aarch64 (static musl binaries)
+- Linux: x86_64, aarch64 (static musl binaries), s390x (gnu)
 - macOS: x86_64, aarch64
 - Windows: x86_64
 

--- a/defs.bzl
+++ b/defs.bzl
@@ -5,6 +5,7 @@ TRIPLES = [
     "aarch64-unknown-linux-musl",
     "aarch64-apple-darwin",
     "aarch64-pc-windows-gnullvm",
+    "s390x-unknown-linux-gnu",
     "x86_64-unknown-linux-musl",
     "x86_64-apple-darwin",
     "x86_64-pc-windows-gnullvm",

--- a/launcher/private/platform_config_settings/BUILD.bazel
+++ b/launcher/private/platform_config_settings/BUILD.bazel
@@ -19,6 +19,14 @@ selects.config_setting_group(
 )
 
 selects.config_setting_group(
+    name = "s390x_linux",
+    match_all = [
+        "@platforms//cpu:s390x",
+        "@platforms//os:linux",
+    ],
+)
+
+selects.config_setting_group(
     name = "x86_64_linux",
     match_all = [
         "@platforms//cpu:x86_64",

--- a/launcher/private/platform_config_settings/BUILD.bazel
+++ b/launcher/private/platform_config_settings/BUILD.bazel
@@ -1,42 +1,48 @@
-load("@bazel_skylib//lib:selects.bzl", "selects")
-
 package(default_visibility = ["//visibility:public"])
 
-selects.config_setting_group(
+config_setting(
     name = "aarch64_linux",
-    match_all = [
+    constraint_values = [
         "@platforms//cpu:aarch64",
         "@platforms//os:linux",
     ],
 )
 
-selects.config_setting_group(
+config_setting(
     name = "aarch64_macos",
-    match_all = [
+    constraint_values = [
         "@platforms//cpu:aarch64",
         "@platforms//os:macos",
     ],
 )
 
-selects.config_setting_group(
+config_setting(
+    name = "s390x_linux",
+    constraint_values = [
+        "@platforms//cpu:s390x",
+        "@platforms//os:linux",
+    ],
+)
+
+config_setting(
     name = "x86_64_linux",
-    match_all = [
+    constraint_values = [
         "@platforms//cpu:x86_64",
         "@platforms//os:linux",
     ],
 )
 
-selects.config_setting_group(
+config_setting(
     name = "x86_64_macos",
-    match_all = [
+    constraint_values = [
         "@platforms//cpu:x86_64",
         "@platforms//os:macos",
     ],
 )
 
-selects.config_setting_group(
+config_setting(
     name = "x86_64_windows",
-    match_all = [
+    constraint_values = [
         "@platforms//cpu:x86_64",
         "@platforms//os:windows",
     ],

--- a/patches/BUILD.bazel
+++ b/patches/BUILD.bazel
@@ -1,4 +1,5 @@
 exports_files([
     "rules-rust-skip-unused-cc-runtime.patch",
     "rules-rs-windows-rust-linker.patch",
+    "xz-s390x-support.patch",
 ])

--- a/patches/xz-s390x-support.patch
+++ b/patches/xz-s390x-support.patch
@@ -1,0 +1,44 @@
+diff --git a/BUILD.bazel b/BUILD.bazel
+--- a/BUILD.bazel
++++ b/BUILD.bazel
+@@ -52,6 +52,14 @@
+     ],
+ )
+ 
++config_setting(
++    name = "linux_s390x",
++    constraint_values = [
++        "@platforms//os:linux",
++        "@platforms//cpu:s390x",
++    ],
++)
++
+ config_setting(
+     name = "wasm32",
+     constraint_values = [
+@@ -82,6 +90,17 @@
+     template = "config.lzma-linux.h",
+ )
+ 
++expand_template(
++    name = "config_linux_s390x",
++    out = "config.lzma-linux-s390x.h",
++    substitutions = {
++        "{HAVE_IMMINTRIN_H}": "#undef HAVE_IMMINTRIN_H",
++        "{HAVE_CPUID_H}": "#undef HAVE_CPUID_H",
++        "{HAVE_USABLE_CLMUL}": "#undef HAVE_USABLE_CLMUL",
++    },
++    template = "config.lzma-linux.h",
++)
++
+ expand_template(
+     name = "config_linux_x86_64",
+     out = "config.lzma-linux-x86_64.h",
+@@ -105,6 +124,7 @@
+         ":linux_arm64": "config.lzma-linux-arm64.h",
+         ":linux_riscv64": "config.lzma-linux-riscv64.h",
+         ":linux_x86_64": "config.lzma-linux-x86_64.h",
++        ":linux_s390x": "config.lzma-linux-s390x.h",
+         ":osx_arm64": "config.lzma-osx-arm64.h",
+         ":osx_x86_64": "config.lzma-osx-x86_64.h",
+         ":wasm32": "config.lzma-wasm32.h",

--- a/runfiles-stub/src/linux.rs
+++ b/runfiles-stub/src/linux.rs
@@ -102,6 +102,17 @@ mod syscall_numbers {
     pub const AT_FDCWD: i32 = -100;  // Special fd for openat/faccessat to work like open/access
 }
 
+#[cfg(target_arch = "s390x")]
+mod syscall_numbers {
+    pub const SYS_EXIT: usize = 1;
+    pub const SYS_READ: usize = 3;
+    pub const SYS_WRITE: usize = 4;
+    pub const SYS_OPEN: usize = 5;
+    pub const SYS_CLOSE: usize = 6;
+    pub const SYS_EXECVE: usize = 11;
+    pub const SYS_ACCESS: usize = 33;
+}
+
 use syscall_numbers::*;
 
 const O_RDONLY: i32 = 0;
@@ -126,6 +137,18 @@ fn exit(code: i32) -> ! {
             "svc #0",
             in("x8") SYS_EXIT,
             in("x0") code,
+            options(noreturn)
+        );
+    }
+}
+
+#[cfg(target_arch = "s390x")]
+fn exit(code: i32) -> ! {
+    unsafe {
+        core::arch::asm!(
+            "svc 0",
+            in("r1") SYS_EXIT,
+            in("r2") code,
             options(noreturn)
         );
     }
@@ -160,6 +183,22 @@ fn write(fd: i32, buf: &[u8]) -> isize {
             in("x1") buf.as_ptr(),
             in("x2") buf.len(),
             lateout("x0") ret,
+        );
+    }
+    ret
+}
+
+#[cfg(target_arch = "s390x")]
+fn write(fd: i32, buf: &[u8]) -> isize {
+    let ret: isize;
+    unsafe {
+        core::arch::asm!(
+            "svc 0",
+            in("r1") SYS_WRITE,
+            in("r2") fd,
+            in("r3") buf.as_ptr(),
+            in("r4") buf.len(),
+            lateout("r2") ret,
         );
     }
     ret
@@ -200,6 +239,22 @@ fn open(path: &[u8]) -> i32 {
     ret
 }
 
+#[cfg(target_arch = "s390x")]
+fn open(path: &[u8]) -> i32 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "svc 0",
+            in("r1") SYS_OPEN,
+            in("r2") path.as_ptr(),
+            in("r3") O_RDONLY,
+            in("r4") 0i64,
+            lateout("r2") ret,
+        );
+    }
+    ret as i32
+}
+
 #[cfg(target_arch = "x86_64")]
 fn read(fd: i32, buf: &mut [u8]) -> isize {
     let ret: isize;
@@ -234,6 +289,22 @@ fn read(fd: i32, buf: &mut [u8]) -> isize {
     ret
 }
 
+#[cfg(target_arch = "s390x")]
+fn read(fd: i32, buf: &mut [u8]) -> isize {
+    let ret: isize;
+    unsafe {
+        core::arch::asm!(
+            "svc 0",
+            in("r1") SYS_READ,
+            in("r2") fd,
+            in("r3") buf.as_ptr(),
+            in("r4") buf.len(),
+            lateout("r2") ret,
+        );
+    }
+    ret
+}
+
 #[cfg(target_arch = "x86_64")]
 fn close(fd: i32) {
     unsafe {
@@ -256,6 +327,18 @@ fn close(fd: i32) {
             in("x8") SYS_CLOSE,
             in("x0") fd,
             lateout("x0") _,
+        );
+    }
+}
+
+#[cfg(target_arch = "s390x")]
+fn close(fd: i32) {
+    unsafe {
+        core::arch::asm!(
+            "svc 0",
+            in("r1") SYS_CLOSE,
+            in("r2") fd,
+            lateout("r2") _,
         );
     }
 }
@@ -295,6 +378,21 @@ fn path_exists(path: &[u8]) -> bool {
     ret == 0
 }
 
+#[cfg(target_arch = "s390x")]
+fn path_exists(path: &[u8]) -> bool {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "svc 0",
+            in("r1") SYS_ACCESS,
+            in("r2") path.as_ptr(),
+            in("r3") 0i64,  // F_OK = 0 (check existence)
+            lateout("r2") ret,
+        );
+    }
+    ret == 0
+}
+
 #[cfg(target_arch = "x86_64")]
 fn execve(filename: *const u8, argv: *const *const u8, envp: *const *const u8) -> i32 {
     let ret: i32;
@@ -327,6 +425,22 @@ fn execve(filename: *const u8, argv: *const *const u8, envp: *const *const u8) -
         );
     }
     ret
+}
+
+#[cfg(target_arch = "s390x")]
+fn execve(filename: *const u8, argv: *const *const u8, envp: *const *const u8) -> i32 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "svc 0",
+            in("r1") SYS_EXECVE,
+            in("r2") filename,
+            in("r3") argv,
+            in("r4") envp,
+            lateout("r2") ret,
+        );
+    }
+    ret as i32
 }
 
 // String utilities
@@ -853,6 +967,15 @@ core::arch::global_asm!(
     "_start:",
     "mov x0, sp",                   // Pass stack pointer as first argument
     "b _start_rust",                // Jump to the actual start function
+);
+
+#[cfg(target_arch = "s390x")]
+core::arch::global_asm!(
+    ".global _start",
+    "_start:",
+    "lgr %r2, %r15",               // Pass stack pointer as first argument
+    "aghi %r15, -160",             // Allocate mandatory register save area
+    "brasl %r14, _start_rust",     // Call the actual start function
 );
 
 #[no_mangle]

--- a/tools/build-release-binaries.sh
+++ b/tools/build-release-binaries.sh
@@ -6,12 +6,14 @@ bazel_cmd="${BAZEL:-bazel}"
 
 targets=(
   //runfiles-stub:runfiles-stub_aarch64-unknown-linux-musl
+  //runfiles-stub:runfiles-stub_s390x-unknown-linux-gnu
   //runfiles-stub:runfiles-stub_x86_64-unknown-linux-musl
   //runfiles-stub:runfiles-stub_aarch64-apple-darwin
   //runfiles-stub:runfiles-stub_x86_64-apple-darwin
   //runfiles-stub:runfiles-stub_aarch64-pc-windows-gnullvm
   //runfiles-stub:runfiles-stub_x86_64-pc-windows-gnullvm
   //finalize-stub:finalize-stub_aarch64-unknown-linux-musl
+  //finalize-stub:finalize-stub_s390x-unknown-linux-gnu
   //finalize-stub:finalize-stub_x86_64-unknown-linux-musl
   //finalize-stub:finalize-stub_aarch64-apple-darwin
   //finalize-stub:finalize-stub_x86_64-apple-darwin
@@ -33,12 +35,14 @@ copy() {
 }
 
 copy "runfiles-stub/runfiles-stub_aarch64-unknown-linux-musl" "runfiles-stub-aarch64-linux"
+copy "runfiles-stub/runfiles-stub_s390x-unknown-linux-gnu" "runfiles-stub-s390x-linux"
 copy "runfiles-stub/runfiles-stub_x86_64-unknown-linux-musl" "runfiles-stub-x86_64-linux"
 copy "runfiles-stub/runfiles-stub_aarch64-apple-darwin" "runfiles-stub-aarch64-macos"
 copy "runfiles-stub/runfiles-stub_x86_64-apple-darwin" "runfiles-stub-x86_64-macos"
 copy "runfiles-stub/runfiles-stub_aarch64-pc-windows-gnullvm" "runfiles-stub-aarch64-windows.exe"
 copy "runfiles-stub/runfiles-stub_x86_64-pc-windows-gnullvm" "runfiles-stub-x86_64-windows.exe"
 copy "finalize-stub/finalize-stub_aarch64-unknown-linux-musl" "finalize-stub-aarch64-linux"
+copy "finalize-stub/finalize-stub_s390x-unknown-linux-gnu" "finalize-stub-s390x-linux"
 copy "finalize-stub/finalize-stub_x86_64-unknown-linux-musl" "finalize-stub-x86_64-linux"
 copy "finalize-stub/finalize-stub_aarch64-apple-darwin" "finalize-stub-aarch64-macos"
 copy "finalize-stub/finalize-stub_x86_64-apple-darwin" "finalize-stub-x86_64-macos"


### PR DESCRIPTION
## Summary
Add Linux s390x (IBM Z) platform support to hermetic-launcher.

- Implement s390x syscall wrappers and `_start` entry point in `linux.rs` using `svc 0` with the s390x calling convention and 160-byte register save area
- Add `s390x-unknown-linux-gnu` cross-compilation to CI and release workflows using `gcc-s390x-linux-gnu`
- Add `s390x_linux` Bazel platform config setting
- Update README supported platforms
- Patch the BCR xz module (5.4.5.bcr.8) to add s390x support — adds a linux_s390x config_setting and generates an s390x-specific lzma config header with x86 intrinsics (HAVE_IMMINTRIN_H, HAVE_CPUID_H, HAVE_USABLE_CLMUL) disabled
- Update the llvm toolchain dependency to include s390x target platform support with the SystemZ backend

The s390x finalizer uses gnu rather than musl because `s390x-unknown-linux-musl` is a [Tier 3 Rust target](https://doc.rust-lang.org/rustc/platform-support/s390x-unknown-linux-musl.html) without prebuilt standard library artifacts.

Bazel prebuilt toolchain wiring (`extensions.bzl`, `prebuilt/BUILD.bazel`, `template/BUILD.bazel`) is intentionally deferred to a follow-up PR after the first upstream release produces s390x binaries.

## Test plan

- [x] CI builds `runfiles-stub-s390x-linux` and `finalize-stub-s390x-linux` via cross-compilation
- [x] Cross-platform finalization tests verify the x86_64/macOS/Windows finalizers can patch the s390x template deterministically
- [x] Locally verified: built s390x binary is `ELF 64-bit MSB executable, IBM S/390, statically linked` (20KB)
- [x] Locally verified: Bazel integration with rules_img produces a valid s390x launcher binary when targeting `--platforms=linux_s390x`