### PR TITLE
Skip BCR presubmit on Bazel 7

### DIFF
--- a/.bcr/presubmit.yml
+++ b/.bcr/presubmit.yml
@@ -2,7 +2,7 @@ bcr_test_module:
   module_path: "e2e/bzlmod"
   matrix:
     platform: ["debian11", "ubuntu2004", "macos", "macos_arm64", "windows"]
-    bazel: [7.x, 8.x, 9.x]
+    bazel: [8.x, 9.x]
   tasks:
     run_tests:
       name: "Run test module"


### PR DESCRIPTION
Bazel 7 doesn't have incompatible_locations_prefers_executable. This makes the launcher_binary rule unusable.