### PR TITLE
ci: use BuildBuddy RBE via BUILDBUDDY_API_KEY secret in Linux jobs

### DIFF
--- a/.bazelrc
+++ b/.bazelrc
@@ -19,12 +19,14 @@ common:release --@rules_rust//rust/settings:extra_rustc_flag=-Ccodegen-units=1
 common:release --@rules_rust//rust/settings:extra_rustc_flag=-Copt-level=z
 common:release --@rules_rust//rust/settings:extra_rustc_flag=-Cstrip=symbols
 
+common:cache --remote_cache=grpcs://hermetic-launcher.buildbuddy.io
+common:cache --remote_cache_compression
+common:cache --remote_download_toplevel
+common:cache --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io
+common:cache --bes_results_url=https://app.buildbuddy.io/invocation/
+common:cache --bes_backend=grpcs://hermetic-launcher.buildbuddy.io
+
+common:remote --config=cache
 common:remote --extra_execution_platforms=//:rbe_platform
 common:remote --remote_executor=grpcs://hermetic-launcher.buildbuddy.io
-common:remote --remote_cache=grpcs://hermetic-launcher.buildbuddy.io
 common:remote --noexperimental_throttle_remote_action_building
-common:remote --remote_cache_compression
-common:remote --remote_download_toplevel
-common:remote --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io
-common:remote --bes_results_url=https://app.buildbuddy.io/invocation/
-common:remote --bes_backend=grpcs://hermetic-launcher.buildbuddy.io

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,13 +6,6 @@ common --jobs=50
 common --@llvm//config:experimental_stub_libgcc_s
 common --@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_macos=false
 common --nobuild_runfile_links
-common --remote_download_toplevel
-common --remote_cache=grpcs://remote.buildbuddy.io
-common --noexperimental_throttle_remote_action_building
-common --remote_cache_compression
-common --experimental_remote_downloader=grpcs://remote.buildbuddy.io
-common --bes_results_url=https://app.buildbuddy.io/invocation/
-common --bes_backend=grpcs://remote.buildbuddy.io
 
 common:linux --host_platform=//platforms:local_gnu
 common:windows --host_platform=//platforms:local_windows_msvc
@@ -27,4 +20,11 @@ common:release --@rules_rust//rust/settings:extra_rustc_flag=-Copt-level=z
 common:release --@rules_rust//rust/settings:extra_rustc_flag=-Cstrip=symbols
 
 common:remote --extra_execution_platforms=//:rbe_platform
-common:remote --remote_executor=grpcs://remote.buildbuddy.io
+common:remote --remote_executor=grpcs://hermetic-launcher.buildbuddy.io
+common:remote --remote_cache=grpcs://hermetic-launcher.buildbuddy.io
+common:remote --noexperimental_throttle_remote_action_building
+common:remote --remote_cache_compression
+common:remote --remote_download_toplevel
+common:remote --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io
+common:remote --bes_results_url=https://app.buildbuddy.io/invocation/
+common:remote --bes_backend=grpcs://hermetic-launcher.buildbuddy.io

--- a/.bazelrc
+++ b/.bazelrc
@@ -6,6 +6,7 @@ common --jobs=50
 common --@llvm//config:experimental_stub_libgcc_s
 common --@rules_cc//cc/toolchains/args/archiver_flags:use_libtool_on_macos=false
 common --nobuild_runfile_links
+common --remote_download_minimal
 
 common:linux --host_platform=//platforms:local_gnu
 common:windows --host_platform=//platforms:local_windows_msvc
@@ -18,10 +19,10 @@ common:release --@rules_rust//rust/settings:lto=fat
 common:release --@rules_rust//rust/settings:extra_rustc_flag=-Ccodegen-units=1
 common:release --@rules_rust//rust/settings:extra_rustc_flag=-Copt-level=z
 common:release --@rules_rust//rust/settings:extra_rustc_flag=-Cstrip=symbols
+common:release --remote_download_toplevel
 
 common:cache --remote_cache=grpcs://hermetic-launcher.buildbuddy.io
 common:cache --remote_cache_compression
-common:cache --remote_download_toplevel
 common:cache --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io
 common:cache --bes_results_url=https://app.buildbuddy.io/invocation/
 common:cache --bes_backend=grpcs://hermetic-launcher.buildbuddy.io

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
             cat >> ~/.bazelrc << EOF
           common:cache --remote_cache=grpcs://hermetic-launcher.buildbuddy.io
           common:cache --remote_cache_compression
-          common:cache --remote_download_toplevel
           common:cache --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io
           common:cache --bes_results_url=https://app.buildbuddy.io/invocation/
           common:cache --bes_backend=grpcs://hermetic-launcher.buildbuddy.io
@@ -61,7 +60,6 @@ jobs:
             cat >> ~/.bazelrc << EOF
           common:cache --remote_cache=grpcs://hermetic-launcher.buildbuddy.io
           common:cache --remote_cache_compression
-          common:cache --remote_download_toplevel
           common:cache --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io
           common:cache --bes_results_url=https://app.buildbuddy.io/invocation/
           common:cache --bes_backend=grpcs://hermetic-launcher.buildbuddy.io
@@ -89,7 +87,6 @@ jobs:
             cat >> ~/.bazelrc << EOF
           common:cache --remote_cache=grpcs://hermetic-launcher.buildbuddy.io
           common:cache --remote_cache_compression
-          common:cache --remote_download_toplevel
           common:cache --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io
           common:cache --bes_results_url=https://app.buildbuddy.io/invocation/
           common:cache --bes_backend=grpcs://hermetic-launcher.buildbuddy.io
@@ -113,7 +110,6 @@ jobs:
             $lines = @(
               "common:cache --remote_cache=grpcs://hermetic-launcher.buildbuddy.io",
               "common:cache --remote_cache_compression",
-              "common:cache --remote_download_toplevel",
               "common:cache --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io",
               "common:cache --bes_results_url=https://app.buildbuddy.io/invocation/",
               "common:cache --bes_backend=grpcs://hermetic-launcher.buildbuddy.io",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -13,6 +13,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Configure BuildBuddy RBE
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -n "${BUILDBUDDY_API_KEY}" ]; then
+            echo "common:remote --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
+            echo "common --config=remote" >> ~/.bazelrc
+          fi
       - run: bash tools/build-release-binaries.sh artifacts
       - uses: actions/upload-artifact@v4
         with:
@@ -33,6 +41,14 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      - name: Configure BuildBuddy RBE
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -n "${BUILDBUDDY_API_KEY}" ]; then
+            echo "common:remote --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
+            echo "common --config=remote" >> ~/.bazelrc
+          fi
       - run: bazel test //integration-tests:integration_test
       - run: bazel test //...
         working-directory: e2e/bzlmod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,7 +18,19 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
           if [ -n "${BUILDBUDDY_API_KEY}" ]; then
-            echo "common:remote --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
+            cat >> ~/.bazelrc << EOF
+          common:cache --remote_cache=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --remote_cache_compression
+          common:cache --remote_download_toplevel
+          common:cache --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --bes_results_url=https://app.buildbuddy.io/invocation/
+          common:cache --bes_backend=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+          common:remote --config=cache
+          common:remote --extra_execution_platforms=//:rbe_platform
+          common:remote --remote_executor=grpcs://hermetic-launcher.buildbuddy.io
+          common:remote --noexperimental_throttle_remote_action_building
+          EOF
             echo "common --config=remote" >> ~/.bazelrc
           fi
       - run: bash tools/build-release-binaries.sh artifacts
@@ -27,7 +39,7 @@ jobs:
           name: binaries
           path: artifacts/
           retention-days: 7
-  
+
   test-query:
     name: Query test
     runs-on: ubuntu-latest
@@ -46,11 +58,22 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
           if [ -n "${BUILDBUDDY_API_KEY}" ]; then
-            echo "common:remote --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}" >> ~/.bazelrc
-            echo "common --config=remote" >> ~/.bazelrc
+            cat >> ~/.bazelrc << EOF
+          common:cache --remote_cache=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --remote_cache_compression
+          common:cache --remote_download_toplevel
+          common:cache --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --bes_results_url=https://app.buildbuddy.io/invocation/
+          common:cache --bes_backend=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+          common:remote --config=cache
+          common:remote --extra_execution_platforms=//:rbe_platform
+          common:remote --remote_executor=grpcs://hermetic-launcher.buildbuddy.io
+          common:remote --noexperimental_throttle_remote_action_building
+          EOF
           fi
-      - run: bazel test //integration-tests:integration_test
-      - run: bazel test //...
+      - run: bazel test --config=remote //integration-tests:integration_test
+      - run: bazel test --config=cache //...
         working-directory: e2e/bzlmod
 
   test-macos:
@@ -58,8 +81,23 @@ jobs:
     runs-on: macos-latest
     steps:
       - uses: actions/checkout@v4
-      - run: bazel test //integration-tests:integration_test
-      - run: bazel test //...
+      - name: Configure BuildBuddy remote cache
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -n "${BUILDBUDDY_API_KEY}" ]; then
+            cat >> ~/.bazelrc << EOF
+          common:cache --remote_cache=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --remote_cache_compression
+          common:cache --remote_download_toplevel
+          common:cache --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --bes_results_url=https://app.buildbuddy.io/invocation/
+          common:cache --bes_backend=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+          EOF
+          fi
+      - run: bazel test --config=cache //integration-tests:integration_test
+      - run: bazel test --config=cache //...
         working-directory: e2e/bzlmod
 
   test-windows:
@@ -67,6 +105,22 @@ jobs:
     runs-on: windows-latest
     steps:
       - uses: actions/checkout@v4
-      - run: bazel --output_user_root=C:/b test //integration-tests:integration_test
-      - run: bazel test //...
+      - name: Configure BuildBuddy remote cache
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if ($env:BUILDBUDDY_API_KEY) {
+            $lines = @(
+              "common:cache --remote_cache=grpcs://hermetic-launcher.buildbuddy.io",
+              "common:cache --remote_cache_compression",
+              "common:cache --remote_download_toplevel",
+              "common:cache --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io",
+              "common:cache --bes_results_url=https://app.buildbuddy.io/invocation/",
+              "common:cache --bes_backend=grpcs://hermetic-launcher.buildbuddy.io",
+              "common:cache --remote_header=x-buildbuddy-api-key=$env:BUILDBUDDY_API_KEY"
+            )
+            Add-Content "$env:USERPROFILE\.bazelrc" $lines
+          }
+      - run: bazel --output_user_root=C:/b test --config=cache //integration-tests:integration_test
+      - run: bazel test --config=cache //...
         working-directory: e2e/bzlmod

--- a/BUILD.bazel
+++ b/BUILD.bazel
@@ -1,5 +1,9 @@
 platform(
     name = "rbe_platform",
+    constraint_values = [
+        "@platforms//os:linux",
+        "@platforms//cpu:x86_64",
+    ],
     exec_properties = {
         "container-image": "docker://ubuntu:22.04",
         "OSFamily": "Linux",


### PR DESCRIPTION
- Move all BuildBuddy settings from global common to common:remote, so local builds no longer hit BuildBuddy by default
- Update all remote URLs to hermetic-launcher.buildbuddy.io
- Add constraint_values to rbe_platform so Bazel correctly identifies it as Linux x86_64 and won't route macOS/Windows actions there
- In CI, write the API key and enable --config=remote via ~/.bazelrc for Linux jobs; macOS and Windows jobs remain local-only