### PR TITLE
fix: memory-map runfiles manifest instead of copying it

### DIFF
--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -860,6 +860,85 @@ fn test_print_env(config: &TestConfig) -> Result<(), String> {
     Ok(())
 }
 
+/// Regression test for issue #35: a multi-megabyte manifest must not OOM.
+///
+/// The previous implementation copied the entire manifest into a growable `Vec`
+/// and re-allocated every line into owned `String`s, all served from the stub's
+/// 8 MiB static arena. Manifests larger than ~3 MiB exhausted the arena and the
+/// stub aborted with a silent `exit(1)`. The mmap-based loader scans the file in
+/// place with zero allocation, so arbitrarily large manifests work.
+fn test_large_manifest(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: large_manifest");
+
+    let test_dir = config.work_dir.join("test_large_manifest");
+    fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {}", e))?;
+
+    let mut runfiles = RunfilesSetup::new(&test_dir, "large_stub")
+        .map_err(|e| format!("Failed to create runfiles: {}", e))?;
+
+    // The single real entry we actually resolve.
+    let add_binary = config.test_binaries_dir.join(format!("add-numbers{}", EXE_EXT));
+    runfiles
+        .add_file(&format!("{}/bin/add-numbers{}", WORKSPACE_NAME, EXE_EXT), &add_binary)
+        .map_err(|e| format!("Failed to add add-numbers: {}", e))?;
+
+    // Write the normal manifest (workspace marker + the real entry), then append
+    // a large block of unused entries to push the file well past the old 8 MiB
+    // arena. These keys are never looked up and the values point nowhere; only
+    // the file's size matters for reproducing the OOM.
+    runfiles
+        .write_manifest()
+        .map_err(|e| format!("Failed to write manifest: {}", e))?;
+
+    {
+        // ~100k lines averaging ~84 bytes => ~8 MiB of padding.
+        let mut blob = String::with_capacity(9 * 1024 * 1024);
+        for i in 0..100_000u32 {
+            blob.push_str(&format!(
+                "{ws}/pad/unused_entry_number_{i:08} /tmp/nonexistent/padding/path/value_{i:08}\n",
+                ws = WORKSPACE_NAME,
+            ));
+        }
+        let mut f = fs::OpenOptions::new()
+            .append(true)
+            .open(&runfiles.manifest_path)
+            .map_err(|e| format!("Failed to open manifest for append: {}", e))?;
+        f.write_all(blob.as_bytes())
+            .map_err(|e| format!("Failed to append padding: {}", e))?;
+    }
+
+    let manifest_size = fs::metadata(&runfiles.manifest_path)
+        .map_err(|e| format!("Failed to stat manifest: {}", e))?
+        .len();
+    if manifest_size <= 5 * 1024 * 1024 {
+        return Err(format!(
+            "Padded manifest too small ({} bytes); expected > 5 MiB",
+            manifest_size
+        ));
+    }
+
+    // Finalize a stub that resolves the real binary plus two literal numbers.
+    let stub_path = test_dir.join(format!("large_stub{}", EXE_EXT));
+    let add_rlocation = format!("{}/bin/add-numbers{}", WORKSPACE_NAME, EXE_EXT);
+    finalize_stub(config, &stub_path, &[&add_rlocation, "40", "2"], &[0])?;
+
+    // Manifest mode: this is the path that OOM'd before the fix.
+    let (stdout, stderr, exit_code) = run_stub(&stub_path, &runfiles, &[], true)?;
+    if exit_code != 0 {
+        return Err(format!(
+            "Large-manifest stub failed with exit code {} (issue #35 regression).\nManifest size: {} bytes\nstdout: {}\nstderr: {}",
+            exit_code, manifest_size, stdout, stderr
+        ));
+    }
+    if !stdout.contains("SUM:42") {
+        return Err(format!("Unexpected output: {}. Expected 'SUM:42'", stdout));
+    }
+
+    println!("    PASS ({} byte manifest, manifest mode)", manifest_size);
+
+    Ok(())
+}
+
 fn main() -> ExitCode {
     println!("=== Runfiles Stub Test Suite ===");
     println!();
@@ -900,6 +979,7 @@ fn main() -> ExitCode {
         ("fallback_runfiles_dir", test_fallback_runfiles_dir),
         ("fallback_runfiles_manifest", test_fallback_runfiles_manifest),
         ("print_env", test_print_env),
+        ("large_manifest", test_large_manifest),
     ];
 
     let mut passed = 0;

--- a/runfiles-stub/src/linux.rs
+++ b/runfiles-stub/src/linux.rs
@@ -85,6 +85,8 @@ mod syscall_numbers {
     pub const SYS_WRITE: usize = 1;
     pub const SYS_OPEN: usize = 2;
     pub const SYS_CLOSE: usize = 3;
+    pub const SYS_LSEEK: usize = 8;
+    pub const SYS_MMAP: usize = 9;
     pub const SYS_ACCESS: usize = 21;
     pub const SYS_EXECVE: usize = 59;
     pub const SYS_EXIT: usize = 60;
@@ -96,6 +98,8 @@ mod syscall_numbers {
     pub const SYS_WRITE: usize = 64;
     pub const SYS_OPENAT: usize = 56;  // openat is used on aarch64
     pub const SYS_CLOSE: usize = 57;
+    pub const SYS_LSEEK: usize = 62;
+    pub const SYS_MMAP: usize = 222;
     pub const SYS_FACCESSAT: usize = 48;  // faccessat is used on aarch64
     pub const SYS_EXECVE: usize = 221;
     pub const SYS_EXIT: usize = 93;
@@ -109,14 +113,21 @@ mod syscall_numbers {
     pub const SYS_WRITE: usize = 4;
     pub const SYS_OPEN: usize = 5;
     pub const SYS_CLOSE: usize = 6;
+    pub const SYS_LSEEK: usize = 19;
     pub const SYS_EXECVE: usize = 11;
     pub const SYS_ACCESS: usize = 33;
+    pub const SYS_MMAP: usize = 90;
 }
 
 use syscall_numbers::*;
 
 const O_RDONLY: i32 = 0;
 const STDOUT: i32 = 1;
+
+// mmap parameters for read-only file mapping
+const PROT_READ: usize = 1;
+const MAP_PRIVATE: usize = 2;
+const SEEK_END: i32 = 2;
 
 #[cfg(target_arch = "x86_64")]
 fn exit(code: i32) -> ! {
@@ -343,6 +354,119 @@ fn close(fd: i32) {
     }
 }
 
+// Seek to the end of the file and return its size in bytes (lseek with SEEK_END).
+// Returns a negative value on error.
+#[cfg(target_arch = "x86_64")]
+fn lseek_end(fd: i32) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") SYS_LSEEK,
+            in("rdi") fd,
+            in("rsi") 0i64,      // offset
+            in("rdx") SEEK_END,  // whence
+            lateout("rax") ret,
+            lateout("rcx") _,
+            lateout("r11") _,
+        );
+    }
+    ret
+}
+
+#[cfg(target_arch = "aarch64")]
+fn lseek_end(fd: i32) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("x8") SYS_LSEEK,
+            in("x0") fd,
+            in("x1") 0i64,      // offset
+            in("x2") SEEK_END,  // whence
+            lateout("x0") ret,
+        );
+    }
+    ret
+}
+
+#[cfg(target_arch = "s390x")]
+fn lseek_end(fd: i32) -> i64 {
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "svc 0",
+            in("r1") SYS_LSEEK,
+            in("r2") fd,
+            in("r3") 0i64,      // offset
+            in("r4") SEEK_END,  // whence
+            lateout("r2") ret,
+        );
+    }
+    ret
+}
+
+// Memory-map `len` bytes of `fd` read-only (PROT_READ, MAP_PRIVATE, offset 0).
+// Returns a null pointer on error. The kernel returns a negative errno in
+// [-4095, -1] on failure; user-space addresses are positive on these arches.
+#[cfg(target_arch = "x86_64")]
+fn mmap_read(fd: i32, len: usize) -> *const u8 {
+    let ret: isize;
+    unsafe {
+        core::arch::asm!(
+            "syscall",
+            in("rax") SYS_MMAP,
+            in("rdi") 0usize,       // addr = NULL
+            in("rsi") len,          // length
+            in("rdx") PROT_READ,    // prot
+            in("r10") MAP_PRIVATE,  // flags (NOTE: r10, not rcx, for syscalls)
+            in("r8") fd,            // fd
+            in("r9") 0usize,        // offset
+            lateout("rax") ret,
+            lateout("rcx") _,
+            lateout("r11") _,
+        );
+    }
+    if ret < 0 { core::ptr::null() } else { ret as *const u8 }
+}
+
+#[cfg(target_arch = "aarch64")]
+fn mmap_read(fd: i32, len: usize) -> *const u8 {
+    let ret: isize;
+    unsafe {
+        core::arch::asm!(
+            "svc #0",
+            in("x8") SYS_MMAP,
+            in("x0") 0usize,       // addr = NULL
+            in("x1") len,          // length
+            in("x2") PROT_READ,    // prot
+            in("x3") MAP_PRIVATE,  // flags
+            in("x4") fd,           // fd
+            in("x5") 0usize,       // offset
+            lateout("x0") ret,
+        );
+    }
+    if ret < 0 { core::ptr::null() } else { ret as *const u8 }
+}
+
+#[cfg(target_arch = "s390x")]
+fn mmap_read(fd: i32, len: usize) -> *const u8 {
+    // s390x uses the old mmap convention: r2 holds a pointer to an array of
+    // 6 unsigned longs { addr, len, prot, flags, fd, offset }.
+    let args: [usize; 6] = [0, len, PROT_READ, MAP_PRIVATE, fd as usize, 0];
+    let ret: i64;
+    unsafe {
+        core::arch::asm!(
+            "svc 0",
+            in("r1") SYS_MMAP,
+            in("r2") args.as_ptr(),
+            lateout("r2") ret,
+            // No options(nomem): the kernel reads the args array through r2.
+        );
+    }
+    if ret < 0 { core::ptr::null() } else { ret as usize as *const u8 }
+}
+
 // Check if a path exists using access() syscall with F_OK (0)
 #[cfg(target_arch = "x86_64")]
 fn path_exists(path: &[u8]) -> bool {
@@ -525,32 +649,28 @@ fn get_env_var(name: &[u8]) -> Option<String> {
     None
 }
 
-// Manifest entry using String for UTF-8 paths
-struct ManifestEntry {
-    key: String,
-    value: String,
-}
-
+// Memory-mapped manifest: a pointer/length pair into the mapped file. The
+// manifest is scanned lazily on each lookup (O(n)), so no per-entry allocation
+// is needed and arbitrarily large manifests are supported. The kernel caches
+// the file's pages for us.
 struct Manifest {
-    entries: Vec<ManifestEntry>,
+    ptr: *const u8,
+    len: usize,
 }
 
 impl Manifest {
-    fn new() -> Self {
-        Self { entries: Vec::new() }
-    }
-
-    fn add_entry(&mut self, key: &str, value: &str) {
-        self.entries.push(ManifestEntry {
-            key: String::from(key),
-            value: String::from(value),
-        });
+    #[inline]
+    fn data(&self) -> &[u8] {
+        // Safety: ptr/len come from a successful mmap that we leak for the
+        // lifetime of the process (until execve replaces the address space).
+        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
     }
 
     fn lookup(&self, key: &str) -> Option<&str> {
-        for entry in &self.entries {
-            if entry.key == key {
-                return Some(&entry.value);
+        let key_bytes = key.as_bytes();
+        for (k, v) in ManifestLines::new(self.data()) {
+            if k == key_bytes {
+                return core::str::from_utf8(v).ok();
             }
         }
         None
@@ -559,58 +679,88 @@ impl Manifest {
     /// Find the longest manifest entry whose key is a prefix of `path` at a '/' boundary.
     /// Returns (resolved_value, suffix) where suffix includes the leading '/'.
     fn prefix_lookup<'a, 'b>(&'a self, path: &'b str) -> Option<(&'a str, &'b str)> {
-        let mut best: Option<(&str, &str)> = None;
+        let path_bytes = path.as_bytes();
+        let mut best: Option<(&'a str, &'b str)> = None;
         let mut best_len: usize = 0;
-        for entry in &self.entries {
-            let key = &entry.key;
-            if path.len() > key.len()
-                && path.starts_with(key.as_str())
-                && path.as_bytes()[key.len()] == b'/'
-                && key.len() > best_len
+        for (k, v) in ManifestLines::new(self.data()) {
+            if path_bytes.len() > k.len()
+                && k.len() > best_len
+                && &path_bytes[..k.len()] == k
+                && path_bytes[k.len()] == b'/'
             {
-                best_len = key.len();
-                best = Some((&entry.value, &path[key.len()..]));
+                // Values were owned UTF-8 Strings before; keep that guarantee by
+                // only considering candidates whose value is valid UTF-8.
+                if let Ok(value) = core::str::from_utf8(v) {
+                    best_len = k.len();
+                    best = Some((value, &path[k.len()..]));
+                }
             }
         }
         best
     }
 }
 
-// Load manifest file
+/// Iterator over `(key, value)` byte slices of a Bazel runfiles MANIFEST.
+/// Replicates `str::lines()` + `split_once(' ')`: split on '\n', strip one
+/// trailing '\r' (CRLF), and skip lines without a space (e.g. the
+/// "<workspace>/.runfile" marker).
+struct ManifestLines<'a> {
+    rest: &'a [u8],
+}
+
+impl<'a> ManifestLines<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { rest: data }
+    }
+}
+
+impl<'a> Iterator for ManifestLines<'a> {
+    type Item = (&'a [u8], &'a [u8]);
+
+    fn next(&mut self) -> Option<(&'a [u8], &'a [u8])> {
+        while !self.rest.is_empty() {
+            let (mut line, remainder) = match find_byte(self.rest, b'\n') {
+                Some(nl) => (&self.rest[..nl], &self.rest[nl + 1..]),
+                None => (self.rest, &self.rest[self.rest.len()..]),
+            };
+            self.rest = remainder;
+            // Strip one trailing '\r' (handles CRLF line endings).
+            if let Some((&b'\r', head)) = line.split_last() {
+                line = head;
+            }
+            if let Some(sp) = find_byte(line, b' ') {
+                return Some((&line[..sp], &line[sp + 1..]));
+            }
+            // No space -> skip this line and continue.
+        }
+        None
+    }
+}
+
+// Load manifest file by memory-mapping it read-only. Returns None on open
+// failure, empty file (mmap of zero bytes is invalid), or mmap failure.
 fn load_manifest(path: &[u8]) -> Option<Manifest> {
     let fd = open(path);
     if fd < 0 {
         return None;
     }
 
-    // Read file into Vec, reading in chunks
-    let mut file_data = Vec::new();
-    let mut chunk = [0u8; 8192];
-    loop {
-        let bytes_read = read(fd, &mut chunk);
-        if bytes_read <= 0 {
-            break;
-        }
-        file_data.extend_from_slice(&chunk[..bytes_read as usize]);
+    let size = lseek_end(fd);
+    if size <= 0 {
+        close(fd);
+        return None;
     }
-    close(fd);
+    let len = size as usize;
 
-    if file_data.is_empty() {
+    let ptr = mmap_read(fd, len);
+    // The mapping keeps its own reference to the file; the fd can be closed.
+    close(fd);
+    if ptr.is_null() {
         return None;
     }
 
-    // Convert to UTF-8 string for easier parsing
-    let file_str = String::from_utf8(file_data).ok()?;
-
-    let mut manifest = Manifest::new();
-
-    for line in file_str.lines() {
-        if let Some((key, value)) = line.split_once(' ') {
-            manifest.add_entry(key, value);
-        }
-    }
-
-    Some(manifest)
+    // Leak the mapping: execve replaces the address space.
+    Some(Manifest { ptr, len })
 }
 
 // Runfiles implementation using String for UTF-8 paths

--- a/runfiles-stub/src/macos.rs
+++ b/runfiles-stub/src/macos.rs
@@ -42,10 +42,13 @@ extern "C" {
     fn exit(code: i32) -> !;
     fn write(fd: i32, buf: *const u8, count: usize) -> isize;
     fn open(path: *const u8, flags: i32, ...) -> i32;
-    fn read(fd: i32, buf: *mut u8, count: usize) -> isize;
     fn close(fd: i32) -> i32;
     fn access(path: *const u8, mode: i32) -> i32;
     fn execve(path: *const u8, argv: *const *const u8, envp: *const *const u8) -> i32;
+
+    // Memory-map a file read-only (used for the runfiles manifest).
+    fn mmap(addr: *mut core::ffi::c_void, len: usize, prot: i32, flags: i32, fd: i32, offset: i64) -> *mut core::ffi::c_void;
+    fn lseek(fd: i32, offset: i64, whence: i32) -> i64;
 
     // Access to errno - macOS provides this via __error()
     // Returns a pointer to the thread-local errno variable
@@ -70,6 +73,12 @@ fn path_exists(path: &[u8]) -> bool {
 // File open flags
 const O_RDONLY: i32 = 0;
 const STDOUT: i32 = 1;
+
+// mmap parameters for read-only file mapping
+const PROT_READ: i32 = 1;
+const MAP_PRIVATE: i32 = 2;
+const SEEK_END: i32 = 2;
+const MAP_FAILED: *mut core::ffi::c_void = (-1isize) as *mut core::ffi::c_void;
 
 // String utilities
 fn print(s: &[u8]) {
@@ -167,32 +176,28 @@ fn get_env_var(name: &[u8]) -> Option<String> {
     None
 }
 
-// Manifest entry using String for UTF-8 paths (Bazel-generated)
-struct ManifestEntry {
-    key: String,
-    value: String,
-}
-
+// Memory-mapped manifest: a pointer/length pair into the mapped file. The
+// manifest is scanned lazily on each lookup (O(n)), so no per-entry allocation
+// is needed and arbitrarily large manifests are supported. The kernel caches
+// the file's pages for us.
 struct Manifest {
-    entries: Vec<ManifestEntry>,
+    ptr: *const u8,
+    len: usize,
 }
 
 impl Manifest {
-    fn new() -> Self {
-        Self { entries: Vec::new() }
-    }
-
-    fn add_entry(&mut self, key: &str, value: &str) {
-        self.entries.push(ManifestEntry {
-            key: String::from(key),
-            value: String::from(value),
-        });
+    #[inline]
+    fn data(&self) -> &[u8] {
+        // Safety: ptr/len come from a successful mmap that we leak for the
+        // lifetime of the process (until execve replaces the address space).
+        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
     }
 
     fn lookup(&self, key: &str) -> Option<&str> {
-        for entry in &self.entries {
-            if entry.key == key {
-                return Some(&entry.value);
+        let key_bytes = key.as_bytes();
+        for (k, v) in ManifestLines::new(self.data()) {
+            if k == key_bytes {
+                return core::str::from_utf8(v).ok();
             }
         }
         None
@@ -201,24 +206,66 @@ impl Manifest {
     /// Find the longest manifest entry whose key is a prefix of `path` at a '/' boundary.
     /// Returns (resolved_value, suffix) where suffix includes the leading '/'.
     fn prefix_lookup<'a, 'b>(&'a self, path: &'b str) -> Option<(&'a str, &'b str)> {
-        let mut best: Option<(&str, &str)> = None;
+        let path_bytes = path.as_bytes();
+        let mut best: Option<(&'a str, &'b str)> = None;
         let mut best_len: usize = 0;
-        for entry in &self.entries {
-            let key = &entry.key;
-            if path.len() > key.len()
-                && path.starts_with(key.as_str())
-                && path.as_bytes()[key.len()] == b'/'
-                && key.len() > best_len
+        for (k, v) in ManifestLines::new(self.data()) {
+            if path_bytes.len() > k.len()
+                && k.len() > best_len
+                && &path_bytes[..k.len()] == k
+                && path_bytes[k.len()] == b'/'
             {
-                best_len = key.len();
-                best = Some((&entry.value, &path[key.len()..]));
+                // Values were owned UTF-8 Strings before; keep that guarantee by
+                // only considering candidates whose value is valid UTF-8.
+                if let Ok(value) = core::str::from_utf8(v) {
+                    best_len = k.len();
+                    best = Some((value, &path[k.len()..]));
+                }
             }
         }
         best
     }
 }
 
-// Load manifest file
+/// Iterator over `(key, value)` byte slices of a Bazel runfiles MANIFEST.
+/// Replicates `str::lines()` + `split_once(' ')`: split on '\n', strip one
+/// trailing '\r' (CRLF), and skip lines without a space (e.g. the
+/// "<workspace>/.runfile" marker).
+struct ManifestLines<'a> {
+    rest: &'a [u8],
+}
+
+impl<'a> ManifestLines<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { rest: data }
+    }
+}
+
+impl<'a> Iterator for ManifestLines<'a> {
+    type Item = (&'a [u8], &'a [u8]);
+
+    fn next(&mut self) -> Option<(&'a [u8], &'a [u8])> {
+        while !self.rest.is_empty() {
+            let (mut line, remainder) = match find_byte(self.rest, b'\n') {
+                Some(nl) => (&self.rest[..nl], &self.rest[nl + 1..]),
+                None => (self.rest, &self.rest[self.rest.len()..]),
+            };
+            self.rest = remainder;
+            // Strip one trailing '\r' (handles CRLF line endings).
+            if let Some((&b'\r', head)) = line.split_last() {
+                line = head;
+            }
+            if let Some(sp) = find_byte(line, b' ') {
+                return Some((&line[..sp], &line[sp + 1..]));
+            }
+            // No space -> skip this line and continue.
+        }
+        None
+    }
+}
+
+// Load manifest file by memory-mapping it read-only. Returns None on open
+// failure, empty file (mmap of zero bytes is invalid), or mmap failure.
 fn load_manifest(path: &[u8]) -> Option<Manifest> {
     unsafe {
         let fd = open(path.as_ptr(), O_RDONLY);
@@ -226,34 +273,22 @@ fn load_manifest(path: &[u8]) -> Option<Manifest> {
             return None;
         }
 
-        // Read file into Vec, reading in chunks
-        let mut file_data = Vec::new();
-        let mut chunk = [0u8; 8192];
-        loop {
-            let bytes_read = read(fd, chunk.as_mut_ptr(), chunk.len());
-            if bytes_read <= 0 {
-                break;
-            }
-            file_data.extend_from_slice(&chunk[..bytes_read as usize]);
+        let size = lseek(fd, 0, SEEK_END);
+        if size <= 0 {
+            close(fd);
+            return None;
         }
-        close(fd);
+        let len = size as usize;
 
-        if file_data.is_empty() {
+        let addr = mmap(core::ptr::null_mut(), len, PROT_READ, MAP_PRIVATE, fd, 0);
+        // The mapping keeps its own reference to the file; the fd can be closed.
+        close(fd);
+        if addr == MAP_FAILED || addr.is_null() {
             return None;
         }
 
-        // Convert to UTF-8 string for easier parsing
-        let file_str = String::from_utf8(file_data).ok()?;
-
-        let mut manifest = Manifest::new();
-
-        for line in file_str.lines() {
-            if let Some((key, value)) = line.split_once(' ') {
-                manifest.add_entry(key, value);
-            }
-        }
-
-        Some(manifest)
+        // Leak the mapping: execve replaces the address space.
+        Some(Manifest { ptr: addr as *const u8, len })
     }
 }
 

--- a/runfiles-stub/src/windows.rs
+++ b/runfiles-stub/src/windows.rs
@@ -54,6 +54,11 @@ const FILE_ATTRIBUTE_NORMAL: DWORD = 0x80;
 const INFINITE: DWORD = 0xFFFFFFFF;
 const CREATE_UNICODE_ENVIRONMENT: DWORD = 0x00000400;
 
+// File sharing and memory-mapping parameters (for the runfiles manifest)
+const FILE_SHARE_READ: DWORD = 0x00000001;
+const PAGE_READONLY: DWORD = 0x02;
+const FILE_MAP_READ: DWORD = 0x04;
+
 // STARTUPINFOW structure (wide char version for CreateProcessW)
 #[repr(C)]
 struct STARTUPINFOW {
@@ -106,13 +111,22 @@ extern "system" {
         dwFlagsAndAttributes: DWORD,
         hTemplateFile: HANDLE,
     ) -> HANDLE;
-    fn ReadFile(
+    fn GetFileSizeEx(hFile: HANDLE, lpFileSize: *mut i64) -> BOOL;
+    fn CreateFileMappingA(
         hFile: HANDLE,
-        lpBuffer: LPVOID,
-        nNumberOfBytesToRead: DWORD,
-        lpNumberOfBytesRead: *mut DWORD,
-        lpOverlapped: LPVOID,
-    ) -> BOOL;
+        lpFileMappingAttributes: LPVOID,
+        flProtect: DWORD,
+        dwMaximumSizeHigh: DWORD,
+        dwMaximumSizeLow: DWORD,
+        lpName: LPCSTR,
+    ) -> HANDLE;
+    fn MapViewOfFile(
+        hFileMappingObject: HANDLE,
+        dwDesiredAccess: DWORD,
+        dwFileOffsetHigh: DWORD,
+        dwFileOffsetLow: DWORD,
+        dwNumberOfBytesToMap: usize,
+    ) -> LPVOID;
     fn CloseHandle(hObject: HANDLE) -> BOOL;
     fn GetEnvironmentVariableA(lpName: LPCSTR, lpBuffer: LPSTR, nSize: DWORD) -> DWORD;
     fn CreateProcessW(
@@ -313,32 +327,27 @@ fn get_env_var(name: &[u8]) -> Option<String> {
     }
 }
 
-// Manifest entry using String for UTF-8 paths (Bazel-generated)
-struct ManifestEntry {
-    key: String,
-    value: String,
-}
-
+// Memory-mapped manifest: a pointer/length pair into the mapped file view. The
+// manifest is scanned lazily on each lookup (O(n)), so no per-entry allocation
+// is needed and arbitrarily large manifests are supported.
 struct Manifest {
-    entries: Vec<ManifestEntry>,
+    ptr: *const u8,
+    len: usize,
 }
 
 impl Manifest {
-    fn new() -> Self {
-        Self { entries: Vec::new() }
-    }
-
-    fn add_entry(&mut self, key: &str, value: &str) {
-        self.entries.push(ManifestEntry {
-            key: String::from(key),
-            value: String::from(value),
-        });
+    #[inline]
+    fn data(&self) -> &[u8] {
+        // Safety: ptr/len come from a successful MapViewOfFile that we leak for
+        // the lifetime of the process (until ExitProcess reclaims it).
+        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
     }
 
     fn lookup(&self, key: &str) -> Option<&str> {
-        for entry in &self.entries {
-            if entry.key == key {
-                return Some(&entry.value);
+        let key_bytes = key.as_bytes();
+        for (k, v) in ManifestLines::new(self.data()) {
+            if k == key_bytes {
+                return core::str::from_utf8(v).ok();
             }
         }
         None
@@ -347,80 +356,121 @@ impl Manifest {
     /// Find the longest manifest entry whose key is a prefix of `path` at a '/' boundary.
     /// Returns (resolved_value, suffix) where suffix includes the leading '/'.
     fn prefix_lookup<'a, 'b>(&'a self, path: &'b str) -> Option<(&'a str, &'b str)> {
-        let mut best: Option<(&str, &str)> = None;
+        let path_bytes = path.as_bytes();
+        let mut best: Option<(&'a str, &'b str)> = None;
         let mut best_len: usize = 0;
-        for entry in &self.entries {
-            let key = &entry.key;
-            if path.len() > key.len()
-                && path.starts_with(key.as_str())
-                && path.as_bytes()[key.len()] == b'/'
-                && key.len() > best_len
+        for (k, v) in ManifestLines::new(self.data()) {
+            if path_bytes.len() > k.len()
+                && k.len() > best_len
+                && &path_bytes[..k.len()] == k
+                && path_bytes[k.len()] == b'/'
             {
-                best_len = key.len();
-                best = Some((&entry.value, &path[key.len()..]));
+                // Values were owned UTF-8 Strings before; keep that guarantee by
+                // only considering candidates whose value is valid UTF-8.
+                if let Ok(value) = core::str::from_utf8(v) {
+                    best_len = k.len();
+                    best = Some((value, &path[k.len()..]));
+                }
             }
         }
         best
     }
 }
 
-// Load manifest file
+/// Iterator over `(key, value)` byte slices of a Bazel runfiles MANIFEST.
+/// Replicates `str::lines()` + `split_once(' ')`: split on '\n', strip one
+/// trailing '\r' (CRLF), and skip lines without a space (e.g. the
+/// "<workspace>/.runfile" marker).
+struct ManifestLines<'a> {
+    rest: &'a [u8],
+}
+
+impl<'a> ManifestLines<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { rest: data }
+    }
+}
+
+impl<'a> Iterator for ManifestLines<'a> {
+    type Item = (&'a [u8], &'a [u8]);
+
+    fn next(&mut self) -> Option<(&'a [u8], &'a [u8])> {
+        while !self.rest.is_empty() {
+            let (mut line, remainder) = match find_byte(self.rest, b'\n') {
+                Some(nl) => (&self.rest[..nl], &self.rest[nl + 1..]),
+                None => (self.rest, &self.rest[self.rest.len()..]),
+            };
+            self.rest = remainder;
+            // Strip one trailing '\r' (handles CRLF line endings).
+            if let Some((&b'\r', head)) = line.split_last() {
+                line = head;
+            }
+            if let Some(sp) = find_byte(line, b' ') {
+                return Some((&line[..sp], &line[sp + 1..]));
+            }
+            // No space -> skip this line and continue.
+        }
+        None
+    }
+}
+
+// Load manifest file by memory-mapping it read-only. Returns None on open
+// failure, empty file (CreateFileMapping of zero bytes fails), or mapping
+// failure.
 fn load_manifest(path: &[u8]) -> Option<Manifest> {
     unsafe {
         // Ensure path is null-terminated
         let mut path_with_null = path.to_vec();
         path_with_null.push(0);
 
-        let handle = CreateFileA(
+        // FILE_SHARE_READ lets the child process (which inherits
+        // RUNFILES_MANIFEST_FILE) open the same manifest for reading.
+        let file = CreateFileA(
             path_with_null.as_ptr(),
             GENERIC_READ,
-            0,
+            FILE_SHARE_READ,
             core::ptr::null_mut(),
             OPEN_EXISTING,
             FILE_ATTRIBUTE_NORMAL,
             core::ptr::null_mut(),
         );
 
-        if handle == INVALID_HANDLE_VALUE {
+        if file == INVALID_HANDLE_VALUE {
             return None;
         }
 
-        // Read file into Vec, reading in chunks
-        let mut file_data = Vec::new();
-        let mut chunk = [0u8; 8192];
-        loop {
-            let mut bytes_read: DWORD = 0;
-            let success = ReadFile(
-                handle,
-                chunk.as_mut_ptr() as LPVOID,
-                chunk.len() as DWORD,
-                &mut bytes_read,
-                core::ptr::null_mut(),
-            );
-            if success == 0 || bytes_read == 0 {
-                break;
-            }
-            file_data.extend_from_slice(&chunk[..bytes_read as usize]);
+        let mut size: i64 = 0;
+        if GetFileSizeEx(file, &mut size) == 0 || size <= 0 {
+            CloseHandle(file);
+            return None;
         }
-        CloseHandle(handle);
+        let len = size as usize;
 
-        if file_data.is_empty() {
+        // CreateFileMappingA returns NULL (not INVALID_HANDLE_VALUE) on failure.
+        let mapping = CreateFileMappingA(
+            file,
+            core::ptr::null_mut(),
+            PAGE_READONLY,
+            0,
+            0,
+            core::ptr::null(),
+        );
+        if mapping.is_null() {
+            CloseHandle(file);
             return None;
         }
 
-        // Convert to UTF-8 string for easier parsing
-        let file_str = String::from_utf8(file_data).ok()?;
-
-        let mut manifest = Manifest::new();
-
-        for line in file_str.lines() {
-            // lines() automatically strips \r\n endings
-            if let Some((key, value)) = line.split_once(' ') {
-                manifest.add_entry(key, value);
-            }
+        let view = MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0);
+        // The view keeps its own reference to the section; both handles can be
+        // closed and the view stays valid.
+        CloseHandle(mapping);
+        CloseHandle(file);
+        if view.is_null() {
+            return None;
         }
 
-        Some(manifest)
+        // Leak the view: ExitProcess reclaims it.
+        Some(Manifest { ptr: view as *const u8, len })
     }
 }
 


### PR DESCRIPTION
load_manifest() previously read the whole manifest into a growable Vec and re-allocated every line into owned Strings, all served from the stub's 8 MiB static arena. Manifests larger than ~3 MiB exhausted the arena, so the no_std stub aborted via the panic handler with a silent exit(1).

Memory-map the manifest read-only at load time and scan it lazily (O(n)) on each lookup. load_manifest() is now zero-allocation and manifest size is bounded only by the address space; the kernel caches the file's pages. lookup() and prefix_lookup() keep identical signatures, so rlocation() is unchanged.

Per platform:
- linux.rs: raw mmap/lseek syscalls for x86_64, aarch64, and s390x (the latter uses the old single-pointer mmap convention; lseek=19).
- macos.rs: libc mmap/lseek; drop the now-unused read extern.
- windows.rs: CreateFileMapping + MapViewOfFile; drop ReadFile. Also open the manifest with FILE_SHARE_READ (was 0) so the child process can read it while the parent holds the mapping.

The mapping is leaked (reclaimed by execve / ExitProcess), matching the existing style. UTF-8 validation is now lazy/per-value instead of whole-file (strictly more permissive; Bazel manifests are UTF-8 in practice).

Add a >8 MiB large-manifest regression test to the integration suite, which reproduced the OOM before this change. Verified at runtime on macOS (host suite) and on aarch64 + x86_64 Linux (containerized); all 7 release triples compile.

Fixes #35.