### PR TITLE
ci: report binary size diff on pull requests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -39,6 +39,81 @@ jobs:
           path: artifacts/
           retention-days: 7
 
+  size-report:
+    name: Binary size report
+    runs-on: ubuntu-latest
+    if: github.event_name == 'pull_request'
+    permissions:
+      pull-requests: write
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.base.sha }}
+      - name: Configure BuildBuddy RBE
+        env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          if [ -n "${BUILDBUDDY_API_KEY}" ]; then
+            cat >> ~/.bazelrc << EOF
+          common:cache --remote_cache=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --remote_cache_compression
+          common:cache --experimental_remote_downloader=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --bes_results_url=https://app.buildbuddy.io/invocation/
+          common:cache --bes_backend=grpcs://hermetic-launcher.buildbuddy.io
+          common:cache --remote_header=x-buildbuddy-api-key=${BUILDBUDDY_API_KEY}
+          common:remote --config=cache
+          common:remote --extra_execution_platforms=//:rbe_platform
+          common:remote --remote_executor=grpcs://hermetic-launcher.buildbuddy.io
+          common:remote --noexperimental_throttle_remote_action_building
+          EOF
+            echo "common --config=remote" >> ~/.bazelrc
+          fi
+      - name: Build base binaries
+        run: bash tools/build-release-binaries.sh /tmp/artifacts-base
+      - name: Record base sizes
+        run: |
+          shopt -s nullglob
+          for f in /tmp/artifacts-base/runfiles-stub-* /tmp/artifacts-base/finalize-stub-*; do
+            [ -f "$f" ] || continue
+            printf '%s %d\n' "$(basename "$f")" "$(stat -c%s "$f")"
+          done > /tmp/sizes-base.txt
+          rm -rf /tmp/artifacts-base
+      - uses: actions/checkout@v4
+        with:
+          ref: ${{ github.event.pull_request.head.sha }}
+      - name: Build PR binaries
+        run: bash tools/build-release-binaries.sh /tmp/artifacts-pr
+      - name: Record PR sizes
+        run: |
+          shopt -s nullglob
+          for f in /tmp/artifacts-pr/runfiles-stub-* /tmp/artifacts-pr/finalize-stub-*; do
+            [ -f "$f" ] || continue
+            printf '%s %d\n' "$(basename "$f")" "$(stat -c%s "$f")"
+          done > /tmp/sizes-pr.txt
+          rm -rf /tmp/artifacts-pr
+      - name: Generate size report
+        env:
+          BASE_SHA: ${{ github.event.pull_request.base.sha }}
+          PR_SHA: ${{ github.event.pull_request.head.sha }}
+        run: |
+          python3 tools/binary-size-report.py \
+            /tmp/sizes-base.txt /tmp/sizes-pr.txt \
+            "$BASE_SHA" "$PR_SHA" | tee /tmp/size-report.md
+          cat /tmp/size-report.md >> "$GITHUB_STEP_SUMMARY"
+      - name: Post PR comment
+        env:
+          GH_TOKEN: ${{ github.token }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+        run: |
+          EXISTING_ID=$(gh api "repos/$GITHUB_REPOSITORY/issues/$PR_NUMBER/comments" \
+            --jq 'map(select(.body | startswith("<!-- binary-size-report -->"))) | first | .id // empty')
+          if [ -n "$EXISTING_ID" ]; then
+            gh api "repos/$GITHUB_REPOSITORY/issues/comments/$EXISTING_ID" \
+              -X PATCH -f body="$(cat /tmp/size-report.md)"
+          else
+            gh pr comment "$PR_NUMBER" --body "$(cat /tmp/size-report.md)"
+          fi
+
   test-query:
     name: Query test
     runs-on: ubuntu-latest

--- a/tools/binary-size-report.py
+++ b/tools/binary-size-report.py
@@ -1,0 +1,78 @@
+#!/usr/bin/env python3
+"""Generate a binary size comparison report in Markdown format.
+
+Usage: binary-size-report.py <sizes-base.txt> <sizes-pr.txt> [base-sha] [pr-sha]
+
+Each size file contains lines of the form: <filename> <bytes>
+"""
+import sys
+
+
+def read_sizes(path):
+    sizes = {}
+    with open(path) as f:
+        for line in f:
+            parts = line.strip().split()
+            if len(parts) == 2:
+                sizes[parts[0]] = int(parts[1])
+    return sizes
+
+
+def fmt_size(n):
+    if n < 1024:
+        return f"{n:,} B"
+    elif n < 1024 * 1024:
+        return f"{n / 1024:.1f} KiB"
+    else:
+        return f"{n / 1024 / 1024:.2f} MiB"
+
+
+def fmt_delta(delta, base):
+    if delta == 0:
+        return "—"
+    sign = "+" if delta > 0 else ""
+    pct = delta / base * 100 if base else 0
+    return f"{sign}{fmt_size(delta)} ({sign}{pct:.2f}%)"
+
+
+def main():
+    if len(sys.argv) < 3:
+        print(f"Usage: {sys.argv[0]} <sizes-base.txt> <sizes-pr.txt> [base-sha] [pr-sha]", file=sys.stderr)
+        sys.exit(1)
+
+    base_file, pr_file = sys.argv[1], sys.argv[2]
+    base_sha = sys.argv[3][:8] if len(sys.argv) > 3 else "base"
+    pr_sha = sys.argv[4][:8] if len(sys.argv) > 4 else "pr"
+
+    base = read_sizes(base_file)
+    pr = read_sizes(pr_file)
+    names = sorted(set(base) | set(pr))
+
+    lines = [
+        "<!-- binary-size-report -->",
+        "## Binary Size Report",
+        "",
+        f"Comparing `{base_sha}` (base) → `{pr_sha}` (PR)",
+        "",
+        "| Binary | Base | PR | Change |",
+        "|--------|------|----|--------|",
+    ]
+
+    total_base = total_pr = 0
+    for name in names:
+        b = base.get(name, 0)
+        p = pr.get(name, 0)
+        total_base += b
+        total_pr += p
+        lines.append(f"| `{name}` | {fmt_size(b)} | {fmt_size(p)} | {fmt_delta(p - b, b)} |")
+
+    total_delta = total_pr - total_base
+    lines += [
+        "",
+        f"**Total: {fmt_size(total_base)} → {fmt_size(total_pr)} ({fmt_delta(total_delta, total_base)})**",
+    ]
+
+    print("\n".join(lines))
+
+
+main()


### PR DESCRIPTION
Adds a size-report job that builds release binaries at both the PR base and head, then posts a markdown table as a PR comment and step summary showing per-binary and total size changes.