### PR TITLE
refactor: share runfiles-stub logic across platforms, shrink unsafe

### DIFF
--- a/runfiles-stub/src/allocator.rs
+++ b/runfiles-stub/src/allocator.rs
@@ -1,0 +1,26 @@
+// Global allocator shared by all platforms: talc over a static memory arena.
+// 8 MiB is plenty for manifest parsing, path resolution, and environment handling.
+// Single-threaded use, so no locking is needed.
+
+use core::alloc::{GlobalAlloc, Layout};
+use core::cell::UnsafeCell;
+use talc::{ClaimOnOom, Span, Talc};
+
+static mut ARENA: [u8; 8 * 1024 * 1024] = [0; 8 * 1024 * 1024];
+
+struct TalcAllocator(UnsafeCell<Talc<ClaimOnOom>>);
+unsafe impl Sync for TalcAllocator {}
+
+unsafe impl GlobalAlloc for TalcAllocator {
+    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
+        (*self.0.get()).malloc(layout).map_or(core::ptr::null_mut(), |p| p.as_ptr())
+    }
+    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
+        (*self.0.get()).free(core::ptr::NonNull::new_unchecked(ptr), layout);
+    }
+}
+
+#[global_allocator]
+static ALLOCATOR: TalcAllocator = TalcAllocator(UnsafeCell::new(Talc::new(unsafe {
+    ClaimOnOom::new(Span::from_array(core::ptr::addr_of!(ARENA).cast_mut()))
+})));

--- a/runfiles-stub/src/common.rs
+++ b/runfiles-stub/src/common.rs
@@ -1,0 +1,128 @@
+// Platform-agnostic helpers shared by every backend: small byte utilities and the
+// memory-mapped runfiles MANIFEST parser.
+
+extern crate alloc;
+
+use crate::platform;
+
+/// Length of a NUL-terminated byte string stored in a fixed-size buffer:
+/// the offset of the first NUL, or the full length if there is none.
+pub fn cstr_len(s: &[u8]) -> usize {
+    s.iter().position(|&b| b == 0).unwrap_or(s.len())
+}
+
+/// Print a decimal number to stdout (used in diagnostics).
+#[allow(dead_code)] // only some backends print numeric diagnostics
+pub fn print_number(mut n: usize) {
+    if n == 0 {
+        platform::print(b"0");
+        return;
+    }
+    let mut buf = [0u8; 20]; // enough for 64-bit numbers
+    let mut i = 0;
+    while n > 0 {
+        buf[i] = b'0' + (n % 10) as u8;
+        n /= 10;
+        i += 1;
+    }
+    while i > 0 {
+        i -= 1;
+        platform::print(&buf[i..i + 1]);
+    }
+}
+
+// Memory-mapped manifest: a pointer/length pair into the mapped file. The
+// manifest is scanned lazily on each lookup (O(n)), so no per-entry allocation
+// is needed and arbitrarily large manifests are supported. The kernel caches
+// the file's pages for us.
+pub struct Manifest {
+    ptr: *const u8,
+    len: usize,
+}
+
+impl Manifest {
+    /// Construct from a mapping that lives for the rest of the process.
+    ///
+    /// # Safety
+    /// `ptr`/`len` must come from a successful read-only mapping that is leaked
+    /// for the lifetime of the process (until execve/ExitProcess reclaims it).
+    pub unsafe fn from_mapping(ptr: *const u8, len: usize) -> Self {
+        Manifest { ptr, len }
+    }
+
+    #[inline]
+    fn data(&self) -> &[u8] {
+        // Safety: ptr/len come from a leaked, process-lifetime mapping (see `from_mapping`).
+        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
+    }
+
+    pub fn lookup(&self, key: &str) -> Option<&str> {
+        let key_bytes = key.as_bytes();
+        for (k, v) in ManifestLines::new(self.data()) {
+            if k == key_bytes {
+                return core::str::from_utf8(v).ok();
+            }
+        }
+        None
+    }
+
+    /// Find the longest manifest entry whose key is a prefix of `path` at a '/' boundary.
+    /// Returns (resolved_value, suffix) where suffix includes the leading '/'.
+    pub fn prefix_lookup<'a, 'b>(&'a self, path: &'b str) -> Option<(&'a str, &'b str)> {
+        let path_bytes = path.as_bytes();
+        let mut best: Option<(&'a str, &'b str)> = None;
+        let mut best_len: usize = 0;
+        for (k, v) in ManifestLines::new(self.data()) {
+            if path_bytes.len() > k.len()
+                && k.len() > best_len
+                && &path_bytes[..k.len()] == k
+                && path_bytes[k.len()] == b'/'
+            {
+                // Values were owned UTF-8 Strings before; keep that guarantee by
+                // only considering candidates whose value is valid UTF-8.
+                if let Ok(value) = core::str::from_utf8(v) {
+                    best_len = k.len();
+                    best = Some((value, &path[k.len()..]));
+                }
+            }
+        }
+        best
+    }
+}
+
+/// Iterator over `(key, value)` byte slices of a Bazel runfiles MANIFEST.
+/// Replicates `str::lines()` + `split_once(' ')`: split on '\n', strip one
+/// trailing '\r' (CRLF), and skip lines without a space (e.g. the
+/// "<workspace>/.runfile" marker).
+struct ManifestLines<'a> {
+    rest: &'a [u8],
+}
+
+impl<'a> ManifestLines<'a> {
+    fn new(data: &'a [u8]) -> Self {
+        Self { rest: data }
+    }
+}
+
+impl<'a> Iterator for ManifestLines<'a> {
+    type Item = (&'a [u8], &'a [u8]);
+
+    fn next(&mut self) -> Option<(&'a [u8], &'a [u8])> {
+        while !self.rest.is_empty() {
+            let (mut line, remainder) = match self.rest.iter().position(|&b| b == b'\n') {
+                Some(nl) => (&self.rest[..nl], &self.rest[nl + 1..]),
+                None => (self.rest, &self.rest[self.rest.len()..]),
+            };
+            self.rest = remainder;
+            // Strip one trailing '\r' (handles CRLF line endings).
+            if let Some((&b'\r', head)) = line.split_last() {
+                line = head;
+            }
+            if let Some(sp) = line.iter().position(|&b| b == b' ') {
+                return Some((&line[..sp], &line[sp + 1..]));
+            }
+            // No space -> skip this line and continue.
+        }
+        None
+    }
+}

--- a/runfiles-stub/src/linux.rs
+++ b/runfiles-stub/src/linux.rs
@@ -1,41 +1,17 @@
-extern crate alloc;
+// Linux backend: raw syscalls (no libc), a custom `_start` entry, and an
+// execve-based launch. The per-architecture syscall asm and the compiler-intrinsic
+// symbols stay here; everything above the syscall layer is shared.
 
-use alloc::string::String;
 use alloc::vec;
+use alloc::string::String;
 use alloc::vec::Vec;
-use core::alloc::{GlobalAlloc, Layout};
-use core::cell::UnsafeCell;
-use core::panic::PanicInfo;
-use talc::{ClaimOnOom, Span, Talc};
 
-// Global allocator using talc with a static memory arena
-// 8 MiB should be plenty for manifest parsing, path resolution, and environment handling
-static mut ARENA: [u8; 8 * 1024 * 1024] = [0; 8 * 1024 * 1024];
+use crate::common::Manifest;
+use crate::run::Launch;
+use crate::runfiles::Runfiles;
 
-// Simple wrapper for single-threaded use (no locking needed)
-struct TalcAllocator(UnsafeCell<Talc<ClaimOnOom>>);
-unsafe impl Sync for TalcAllocator {}
-
-unsafe impl GlobalAlloc for TalcAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        (*self.0.get()).malloc(layout).map_or(core::ptr::null_mut(), |p| p.as_ptr())
-    }
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        (*self.0.get()).free(core::ptr::NonNull::new_unchecked(ptr), layout);
-    }
-}
-
-#[global_allocator]
-static ALLOCATOR: TalcAllocator = TalcAllocator(UnsafeCell::new(Talc::new(unsafe {
-    ClaimOnOom::new(Span::from_array(core::ptr::addr_of!(ARENA).cast_mut()))
-})));
-
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    exit(1);
-}
-
-// Compiler intrinsics (memcpy, memset)
+// Compiler intrinsics and glibc-compat symbols. These are needed because we link
+// without crt startup files (-nostartfiles) and provide our own _start.
 #[no_mangle]
 pub unsafe extern "C" fn memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
     let mut i = 0;
@@ -129,486 +105,251 @@ const PROT_READ: usize = 1;
 const MAP_PRIVATE: usize = 2;
 const SEEK_END: i32 = 2;
 
+// --- path semantics ---
+pub const SEP: char = '/';
+pub const NEWLINE: &[u8] = b"\n";
+
+pub fn is_absolute(path: &str) -> bool {
+    path.starts_with('/')
+}
+
+pub fn to_native_path(s: &str) -> String {
+    String::from(s)
+}
+
+// --- syscall instruction layer ---
+//
+// One macro per (arch, arity), cfg-gated so exactly one set is compiled. Each
+// expansion is token-identical to the previous hand-written per-syscall asm (same
+// instruction, registers, clobbers, operand types and return type), so the generated
+// machine code is unchanged — this only removes the 3x per-arch source duplication.
+// `_noreturn` is for exit; `_void` discards the return register (close); the rest
+// return a value of the caller-specified type.
+
 #[cfg(target_arch = "x86_64")]
-fn exit(code: i32) -> ! {
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") SYS_EXIT,
-            in("rdi") code,
-            options(noreturn)
-        );
+mod sc {
+    macro_rules! syscall_noreturn {
+        ($nr:expr, $a1:expr) => {
+            core::arch::asm!("syscall", in("rax") $nr, in("rdi") $a1, options(noreturn))
+        };
     }
+    macro_rules! syscall_void {
+        ($nr:expr, $a1:expr) => {
+            core::arch::asm!("syscall", in("rax") $nr, in("rdi") $a1,
+                lateout("rax") _, lateout("rcx") _, lateout("r11") _)
+        };
+    }
+    macro_rules! syscall2 {
+        ($ty:ty; $nr:expr, $a1:expr, $a2:expr) => {{
+            let ret: $ty;
+            core::arch::asm!("syscall", in("rax") $nr, in("rdi") $a1, in("rsi") $a2,
+                lateout("rax") ret, lateout("rcx") _, lateout("r11") _);
+            ret
+        }};
+    }
+    macro_rules! syscall3 {
+        ($ty:ty; $nr:expr, $a1:expr, $a2:expr, $a3:expr) => {{
+            let ret: $ty;
+            core::arch::asm!("syscall", in("rax") $nr, in("rdi") $a1, in("rsi") $a2, in("rdx") $a3,
+                lateout("rax") ret, lateout("rcx") _, lateout("r11") _);
+            ret
+        }};
+    }
+    macro_rules! syscall6 {
+        ($ty:ty; $nr:expr, $a1:expr, $a2:expr, $a3:expr, $a4:expr, $a5:expr, $a6:expr) => {{
+            let ret: $ty;
+            core::arch::asm!("syscall", in("rax") $nr, in("rdi") $a1, in("rsi") $a2, in("rdx") $a3,
+                in("r10") $a4, in("r8") $a5, in("r9") $a6,
+                lateout("rax") ret, lateout("rcx") _, lateout("r11") _);
+            ret
+        }};
+    }
+    pub(super) use {syscall2, syscall3, syscall6, syscall_noreturn, syscall_void};
 }
 
 #[cfg(target_arch = "aarch64")]
-fn exit(code: i32) -> ! {
-    unsafe {
-        core::arch::asm!(
-            "svc #0",
-            in("x8") SYS_EXIT,
-            in("x0") code,
-            options(noreturn)
-        );
+mod sc {
+    macro_rules! syscall_noreturn {
+        ($nr:expr, $a1:expr) => {
+            core::arch::asm!("svc #0", in("x8") $nr, in("x0") $a1, options(noreturn))
+        };
     }
+    macro_rules! syscall_void {
+        ($nr:expr, $a1:expr) => {
+            core::arch::asm!("svc #0", in("x8") $nr, in("x0") $a1, lateout("x0") _)
+        };
+    }
+    macro_rules! syscall3 {
+        ($ty:ty; $nr:expr, $a1:expr, $a2:expr, $a3:expr) => {{
+            let ret: $ty;
+            core::arch::asm!("svc #0", in("x8") $nr, in("x0") $a1, in("x1") $a2, in("x2") $a3,
+                lateout("x0") ret);
+            ret
+        }};
+    }
+    macro_rules! syscall4 {
+        ($ty:ty; $nr:expr, $a1:expr, $a2:expr, $a3:expr, $a4:expr) => {{
+            let ret: $ty;
+            core::arch::asm!("svc #0", in("x8") $nr, in("x0") $a1, in("x1") $a2, in("x2") $a3,
+                in("x3") $a4, lateout("x0") ret);
+            ret
+        }};
+    }
+    macro_rules! syscall6 {
+        ($ty:ty; $nr:expr, $a1:expr, $a2:expr, $a3:expr, $a4:expr, $a5:expr, $a6:expr) => {{
+            let ret: $ty;
+            core::arch::asm!("svc #0", in("x8") $nr, in("x0") $a1, in("x1") $a2, in("x2") $a3,
+                in("x3") $a4, in("x4") $a5, in("x5") $a6, lateout("x0") ret);
+            ret
+        }};
+    }
+    pub(super) use {syscall3, syscall4, syscall6, syscall_noreturn, syscall_void};
 }
 
 #[cfg(target_arch = "s390x")]
-fn exit(code: i32) -> ! {
-    unsafe {
-        core::arch::asm!(
-            "svc 0",
-            in("r1") SYS_EXIT,
-            in("r2") code,
-            options(noreturn)
-        );
+mod sc {
+    macro_rules! syscall_noreturn {
+        ($nr:expr, $a1:expr) => {
+            core::arch::asm!("svc 0", in("r1") $nr, in("r2") $a1, options(noreturn))
+        };
     }
+    macro_rules! syscall_void {
+        ($nr:expr, $a1:expr) => {
+            core::arch::asm!("svc 0", in("r1") $nr, in("r2") $a1, lateout("r2") _)
+        };
+    }
+    macro_rules! syscall1 {
+        ($ty:ty; $nr:expr, $a1:expr) => {{
+            let ret: $ty;
+            core::arch::asm!("svc 0", in("r1") $nr, in("r2") $a1, lateout("r2") ret);
+            ret
+        }};
+    }
+    macro_rules! syscall2 {
+        ($ty:ty; $nr:expr, $a1:expr, $a2:expr) => {{
+            let ret: $ty;
+            core::arch::asm!("svc 0", in("r1") $nr, in("r2") $a1, in("r3") $a2, lateout("r2") ret);
+            ret
+        }};
+    }
+    macro_rules! syscall3 {
+        ($ty:ty; $nr:expr, $a1:expr, $a2:expr, $a3:expr) => {{
+            let ret: $ty;
+            core::arch::asm!("svc 0", in("r1") $nr, in("r2") $a1, in("r3") $a2, in("r4") $a3,
+                lateout("r2") ret);
+            ret
+        }};
+    }
+    pub(super) use {syscall1, syscall2, syscall3, syscall_noreturn, syscall_void};
 }
 
-#[cfg(target_arch = "x86_64")]
+#[allow(unused_imports)]
+use sc::*;
+
+// --- syscall wrappers (architecture-independent above the macro layer) ---
+pub fn exit(code: i32) -> ! {
+    unsafe { syscall_noreturn!(SYS_EXIT, code) }
+}
+
 fn write(fd: i32, buf: &[u8]) -> isize {
-    let ret: isize;
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") SYS_WRITE,
-            in("rdi") fd,
-            in("rsi") buf.as_ptr(),
-            in("rdx") buf.len(),
-            lateout("rax") ret,
-            lateout("rcx") _,
-            lateout("r11") _,
-        );
-    }
-    ret
+    unsafe { syscall3!(isize; SYS_WRITE, fd, buf.as_ptr(), buf.len()) }
 }
 
-#[cfg(target_arch = "aarch64")]
-fn write(fd: i32, buf: &[u8]) -> isize {
-    let ret: isize;
-    unsafe {
-        core::arch::asm!(
-            "svc #0",
-            in("x8") SYS_WRITE,
-            in("x0") fd,
-            in("x1") buf.as_ptr(),
-            in("x2") buf.len(),
-            lateout("x0") ret,
-        );
-    }
-    ret
-}
-
-#[cfg(target_arch = "s390x")]
-fn write(fd: i32, buf: &[u8]) -> isize {
-    let ret: isize;
-    unsafe {
-        core::arch::asm!(
-            "svc 0",
-            in("r1") SYS_WRITE,
-            in("r2") fd,
-            in("r3") buf.as_ptr(),
-            in("r4") buf.len(),
-            lateout("r2") ret,
-        );
-    }
-    ret
-}
-
-#[cfg(target_arch = "x86_64")]
-fn open(path: &[u8]) -> i32 {
-    let ret: i32;
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") SYS_OPEN,
-            in("rdi") path.as_ptr(),
-            in("rsi") O_RDONLY,
-            in("rdx") 0,
-            lateout("rax") ret,
-            lateout("rcx") _,
-            lateout("r11") _,
-        );
-    }
-    ret
-}
-
-#[cfg(target_arch = "aarch64")]
-fn open(path: &[u8]) -> i32 {
-    let ret: i32;
-    unsafe {
-        core::arch::asm!(
-            "svc #0",
-            in("x8") SYS_OPENAT,
-            in("x0") AT_FDCWD,
-            in("x1") path.as_ptr(),
-            in("x2") O_RDONLY,
-            in("x3") 0,
-            lateout("x0") ret,
-        );
-    }
-    ret
-}
-
-#[cfg(target_arch = "s390x")]
-fn open(path: &[u8]) -> i32 {
-    let ret: i64;
-    unsafe {
-        core::arch::asm!(
-            "svc 0",
-            in("r1") SYS_OPEN,
-            in("r2") path.as_ptr(),
-            in("r3") O_RDONLY,
-            in("r4") 0i64,
-            lateout("r2") ret,
-        );
-    }
-    ret as i32
-}
-
-#[cfg(target_arch = "x86_64")]
 fn read(fd: i32, buf: &mut [u8]) -> isize {
-    let ret: isize;
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") SYS_READ,
-            in("rdi") fd,
-            in("rsi") buf.as_ptr(),
-            in("rdx") buf.len(),
-            lateout("rax") ret,
-            lateout("rcx") _,
-            lateout("r11") _,
-        );
-    }
-    ret
+    unsafe { syscall3!(isize; SYS_READ, fd, buf.as_ptr(), buf.len()) }
 }
 
-#[cfg(target_arch = "aarch64")]
-fn read(fd: i32, buf: &mut [u8]) -> isize {
-    let ret: isize;
-    unsafe {
-        core::arch::asm!(
-            "svc #0",
-            in("x8") SYS_READ,
-            in("x0") fd,
-            in("x1") buf.as_ptr(),
-            in("x2") buf.len(),
-            lateout("x0") ret,
-        );
-    }
-    ret
-}
-
-#[cfg(target_arch = "s390x")]
-fn read(fd: i32, buf: &mut [u8]) -> isize {
-    let ret: isize;
-    unsafe {
-        core::arch::asm!(
-            "svc 0",
-            in("r1") SYS_READ,
-            in("r2") fd,
-            in("r3") buf.as_ptr(),
-            in("r4") buf.len(),
-            lateout("r2") ret,
-        );
-    }
-    ret
-}
-
-#[cfg(target_arch = "x86_64")]
 fn close(fd: i32) {
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") SYS_CLOSE,
-            in("rdi") fd,
-            lateout("rax") _,
-            lateout("rcx") _,
-            lateout("r11") _,
-        );
-    }
+    unsafe { syscall_void!(SYS_CLOSE, fd) }
 }
 
-#[cfg(target_arch = "aarch64")]
-fn close(fd: i32) {
-    unsafe {
-        core::arch::asm!(
-            "svc #0",
-            in("x8") SYS_CLOSE,
-            in("x0") fd,
-            lateout("x0") _,
-        );
+fn open(path: &[u8]) -> i32 {
+    #[cfg(target_arch = "x86_64")]
+    {
+        unsafe { syscall3!(i32; SYS_OPEN, path.as_ptr(), O_RDONLY, 0) }
     }
-}
-
-#[cfg(target_arch = "s390x")]
-fn close(fd: i32) {
-    unsafe {
-        core::arch::asm!(
-            "svc 0",
-            in("r1") SYS_CLOSE,
-            in("r2") fd,
-            lateout("r2") _,
-        );
+    #[cfg(target_arch = "aarch64")]
+    {
+        unsafe { syscall4!(i32; SYS_OPENAT, AT_FDCWD, path.as_ptr(), O_RDONLY, 0) }
+    }
+    #[cfg(target_arch = "s390x")]
+    {
+        unsafe { syscall3!(i64; SYS_OPEN, path.as_ptr(), O_RDONLY, 0i64) as i32 }
     }
 }
 
 // Seek to the end of the file and return its size in bytes (lseek with SEEK_END).
 // Returns a negative value on error.
-#[cfg(target_arch = "x86_64")]
 fn lseek_end(fd: i32) -> i64 {
-    let ret: i64;
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") SYS_LSEEK,
-            in("rdi") fd,
-            in("rsi") 0i64,      // offset
-            in("rdx") SEEK_END,  // whence
-            lateout("rax") ret,
-            lateout("rcx") _,
-            lateout("r11") _,
-        );
-    }
-    ret
-}
-
-#[cfg(target_arch = "aarch64")]
-fn lseek_end(fd: i32) -> i64 {
-    let ret: i64;
-    unsafe {
-        core::arch::asm!(
-            "svc #0",
-            in("x8") SYS_LSEEK,
-            in("x0") fd,
-            in("x1") 0i64,      // offset
-            in("x2") SEEK_END,  // whence
-            lateout("x0") ret,
-        );
-    }
-    ret
-}
-
-#[cfg(target_arch = "s390x")]
-fn lseek_end(fd: i32) -> i64 {
-    let ret: i64;
-    unsafe {
-        core::arch::asm!(
-            "svc 0",
-            in("r1") SYS_LSEEK,
-            in("r2") fd,
-            in("r3") 0i64,      // offset
-            in("r4") SEEK_END,  // whence
-            lateout("r2") ret,
-        );
-    }
-    ret
+    unsafe { syscall3!(i64; SYS_LSEEK, fd, 0i64, SEEK_END) }
 }
 
 // Memory-map `len` bytes of `fd` read-only (PROT_READ, MAP_PRIVATE, offset 0).
 // Returns a null pointer on error. The kernel returns a negative errno in
 // [-4095, -1] on failure; user-space addresses are positive on these arches.
-#[cfg(target_arch = "x86_64")]
 fn mmap_read(fd: i32, len: usize) -> *const u8 {
-    let ret: isize;
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") SYS_MMAP,
-            in("rdi") 0usize,       // addr = NULL
-            in("rsi") len,          // length
-            in("rdx") PROT_READ,    // prot
-            in("r10") MAP_PRIVATE,  // flags (NOTE: r10, not rcx, for syscalls)
-            in("r8") fd,            // fd
-            in("r9") 0usize,        // offset
-            lateout("rax") ret,
-            lateout("rcx") _,
-            lateout("r11") _,
-        );
+    #[cfg(not(target_arch = "s390x"))]
+    {
+        let ret: isize =
+            unsafe { syscall6!(isize; SYS_MMAP, 0usize, len, PROT_READ, MAP_PRIVATE, fd, 0usize) };
+        if ret < 0 {
+            core::ptr::null()
+        } else {
+            ret as *const u8
+        }
     }
-    if ret < 0 { core::ptr::null() } else { ret as *const u8 }
+    #[cfg(target_arch = "s390x")]
+    {
+        // s390x uses the old mmap convention: r2 holds a pointer to an array of
+        // 6 unsigned longs { addr, len, prot, flags, fd, offset }.
+        let args: [usize; 6] = [0, len, PROT_READ, MAP_PRIVATE, fd as usize, 0];
+        let ret: i64 = unsafe { syscall1!(i64; SYS_MMAP, args.as_ptr()) };
+        if ret < 0 {
+            core::ptr::null()
+        } else {
+            ret as usize as *const u8
+        }
+    }
 }
 
-#[cfg(target_arch = "aarch64")]
-fn mmap_read(fd: i32, len: usize) -> *const u8 {
-    let ret: isize;
-    unsafe {
-        core::arch::asm!(
-            "svc #0",
-            in("x8") SYS_MMAP,
-            in("x0") 0usize,       // addr = NULL
-            in("x1") len,          // length
-            in("x2") PROT_READ,    // prot
-            in("x3") MAP_PRIVATE,  // flags
-            in("x4") fd,           // fd
-            in("x5") 0usize,       // offset
-            lateout("x0") ret,
-        );
+// Check if a path exists using access()/faccessat() with F_OK (0).
+pub fn path_exists(path: &[u8]) -> bool {
+    #[cfg(target_arch = "x86_64")]
+    {
+        unsafe { syscall2!(i32; SYS_ACCESS, path.as_ptr(), 0i32) == 0 }
     }
-    if ret < 0 { core::ptr::null() } else { ret as *const u8 }
+    #[cfg(target_arch = "aarch64")]
+    {
+        unsafe { syscall4!(i32; SYS_FACCESSAT, AT_FDCWD, path.as_ptr(), 0i32, 0i32) == 0 }
+    }
+    #[cfg(target_arch = "s390x")]
+    {
+        unsafe { syscall2!(i64; SYS_ACCESS, path.as_ptr(), 0i64) == 0 }
+    }
 }
 
-#[cfg(target_arch = "s390x")]
-fn mmap_read(fd: i32, len: usize) -> *const u8 {
-    // s390x uses the old mmap convention: r2 holds a pointer to an array of
-    // 6 unsigned longs { addr, len, prot, flags, fd, offset }.
-    let args: [usize; 6] = [0, len, PROT_READ, MAP_PRIVATE, fd as usize, 0];
-    let ret: i64;
-    unsafe {
-        core::arch::asm!(
-            "svc 0",
-            in("r1") SYS_MMAP,
-            in("r2") args.as_ptr(),
-            lateout("r2") ret,
-            // No options(nomem): the kernel reads the args array through r2.
-        );
-    }
-    if ret < 0 { core::ptr::null() } else { ret as usize as *const u8 }
-}
-
-// Check if a path exists using access() syscall with F_OK (0)
-#[cfg(target_arch = "x86_64")]
-fn path_exists(path: &[u8]) -> bool {
-    let ret: i32;
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") SYS_ACCESS,
-            in("rdi") path.as_ptr(),
-            in("rsi") 0i32,  // F_OK = 0 (check existence)
-            lateout("rax") ret,
-            lateout("rcx") _,
-            lateout("r11") _,
-        );
-    }
-    ret == 0
-}
-
-#[cfg(target_arch = "aarch64")]
-fn path_exists(path: &[u8]) -> bool {
-    let ret: i32;
-    unsafe {
-        core::arch::asm!(
-            "svc #0",
-            in("x8") SYS_FACCESSAT,
-            in("x0") AT_FDCWD,
-            in("x1") path.as_ptr(),
-            in("x2") 0i32,  // F_OK = 0 (check existence)
-            in("x3") 0i32,  // flags = 0
-            lateout("x0") ret,
-        );
-    }
-    ret == 0
-}
-
-#[cfg(target_arch = "s390x")]
-fn path_exists(path: &[u8]) -> bool {
-    let ret: i64;
-    unsafe {
-        core::arch::asm!(
-            "svc 0",
-            in("r1") SYS_ACCESS,
-            in("r2") path.as_ptr(),
-            in("r3") 0i64,  // F_OK = 0 (check existence)
-            lateout("r2") ret,
-        );
-    }
-    ret == 0
-}
-
-#[cfg(target_arch = "x86_64")]
 fn execve(filename: *const u8, argv: *const *const u8, envp: *const *const u8) -> i32 {
-    let ret: i32;
-    unsafe {
-        core::arch::asm!(
-            "syscall",
-            in("rax") SYS_EXECVE,
-            in("rdi") filename,
-            in("rsi") argv,
-            in("rdx") envp,
-            lateout("rax") ret,
-            lateout("rcx") _,
-            lateout("r11") _,
-        );
+    #[cfg(not(target_arch = "s390x"))]
+    {
+        unsafe { syscall3!(i32; SYS_EXECVE, filename, argv, envp) }
     }
-    ret
+    #[cfg(target_arch = "s390x")]
+    {
+        unsafe { syscall3!(i64; SYS_EXECVE, filename, argv, envp) as i32 }
+    }
 }
 
-#[cfg(target_arch = "aarch64")]
-fn execve(filename: *const u8, argv: *const *const u8, envp: *const *const u8) -> i32 {
-    let ret: i32;
-    unsafe {
-        core::arch::asm!(
-            "svc #0",
-            in("x8") SYS_EXECVE,
-            in("x0") filename,
-            in("x1") argv,
-            in("x2") envp,
-            lateout("x0") ret,
-        );
-    }
-    ret
-}
-
-#[cfg(target_arch = "s390x")]
-fn execve(filename: *const u8, argv: *const *const u8, envp: *const *const u8) -> i32 {
-    let ret: i64;
-    unsafe {
-        core::arch::asm!(
-            "svc 0",
-            in("r1") SYS_EXECVE,
-            in("r2") filename,
-            in("r3") argv,
-            in("r4") envp,
-            lateout("r2") ret,
-        );
-    }
-    ret as i32
-}
-
-// String utilities
-fn print(s: &[u8]) {
+// --- primitives ---
+pub fn print(s: &[u8]) {
     write(STDOUT, s);
 }
 
-fn str_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    for i in 0..a.len() {
-        if a[i] != b[i] {
-            return false;
-        }
-    }
-    true
-}
-
-fn str_starts_with(haystack: &[u8], needle: &[u8]) -> bool {
-    if haystack.len() < needle.len() {
-        return false;
-    }
-    str_eq(&haystack[..needle.len()], needle)
-}
-
-fn find_byte(haystack: &[u8], needle: u8) -> Option<usize> {
-    for i in 0..haystack.len() {
-        if haystack[i] == needle {
-            return Some(i);
-        }
-    }
-    None
-}
-
-// Environment variable reading - returns the value as a String
-// Returns None if the variable doesn't exist or isn't valid UTF-8
-fn get_env_var(name: &[u8]) -> Option<String> {
+// Environment variable lookup by reading /proc/self/environ.
+pub fn get_env_var(name: &[u8]) -> Option<String> {
     let fd = open(b"/proc/self/environ\0");
     if fd < 0 {
         return None;
     }
-
-    // Read environment into Vec
     let mut environ_data = Vec::new();
     let mut chunk = [0u8; 8192];
     loop {
@@ -620,361 +361,47 @@ fn get_env_var(name: &[u8]) -> Option<String> {
     }
     close(fd);
 
-    if environ_data.is_empty() {
-        return None;
-    }
-
-    let mut pos = 0;
-
-    while pos < environ_data.len() {
-        let start = pos;
-        while pos < environ_data.len() && environ_data[pos] != 0 {
-            pos += 1;
+    for entry in environ_data.split(|&b| b == 0) {
+        if entry.is_empty() {
+            continue;
         }
-
-        let entry = &environ_data[start..pos];
-        if let Some(eq_pos) = find_byte(entry, b'=') {
-            let key = &entry[..eq_pos];
-            let value = &entry[eq_pos + 1..];
-
-            if str_eq(key, name) {
-                // Convert to String, returning None if not valid UTF-8
-                return String::from_utf8(value.to_vec()).ok();
+        if let Some(eq_pos) = entry.iter().position(|&b| b == b'=') {
+            if &entry[..eq_pos] == name {
+                return String::from_utf8(entry[eq_pos + 1..].to_vec()).ok();
             }
         }
-
-        pos += 1;
     }
-
     None
 }
 
-// Memory-mapped manifest: a pointer/length pair into the mapped file. The
-// manifest is scanned lazily on each lookup (O(n)), so no per-entry allocation
-// is needed and arbitrarily large manifests are supported. The kernel caches
-// the file's pages for us.
-struct Manifest {
-    ptr: *const u8,
-    len: usize,
-}
-
-impl Manifest {
-    #[inline]
-    fn data(&self) -> &[u8] {
-        // Safety: ptr/len come from a successful mmap that we leak for the
-        // lifetime of the process (until execve replaces the address space).
-        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
-    }
-
-    fn lookup(&self, key: &str) -> Option<&str> {
-        let key_bytes = key.as_bytes();
-        for (k, v) in ManifestLines::new(self.data()) {
-            if k == key_bytes {
-                return core::str::from_utf8(v).ok();
-            }
-        }
-        None
-    }
-
-    /// Find the longest manifest entry whose key is a prefix of `path` at a '/' boundary.
-    /// Returns (resolved_value, suffix) where suffix includes the leading '/'.
-    fn prefix_lookup<'a, 'b>(&'a self, path: &'b str) -> Option<(&'a str, &'b str)> {
-        let path_bytes = path.as_bytes();
-        let mut best: Option<(&'a str, &'b str)> = None;
-        let mut best_len: usize = 0;
-        for (k, v) in ManifestLines::new(self.data()) {
-            if path_bytes.len() > k.len()
-                && k.len() > best_len
-                && &path_bytes[..k.len()] == k
-                && path_bytes[k.len()] == b'/'
-            {
-                // Values were owned UTF-8 Strings before; keep that guarantee by
-                // only considering candidates whose value is valid UTF-8.
-                if let Ok(value) = core::str::from_utf8(v) {
-                    best_len = k.len();
-                    best = Some((value, &path[k.len()..]));
-                }
-            }
-        }
-        best
-    }
-}
-
-/// Iterator over `(key, value)` byte slices of a Bazel runfiles MANIFEST.
-/// Replicates `str::lines()` + `split_once(' ')`: split on '\n', strip one
-/// trailing '\r' (CRLF), and skip lines without a space (e.g. the
-/// "<workspace>/.runfile" marker).
-struct ManifestLines<'a> {
-    rest: &'a [u8],
-}
-
-impl<'a> ManifestLines<'a> {
-    fn new(data: &'a [u8]) -> Self {
-        Self { rest: data }
-    }
-}
-
-impl<'a> Iterator for ManifestLines<'a> {
-    type Item = (&'a [u8], &'a [u8]);
-
-    fn next(&mut self) -> Option<(&'a [u8], &'a [u8])> {
-        while !self.rest.is_empty() {
-            let (mut line, remainder) = match find_byte(self.rest, b'\n') {
-                Some(nl) => (&self.rest[..nl], &self.rest[nl + 1..]),
-                None => (self.rest, &self.rest[self.rest.len()..]),
-            };
-            self.rest = remainder;
-            // Strip one trailing '\r' (handles CRLF line endings).
-            if let Some((&b'\r', head)) = line.split_last() {
-                line = head;
-            }
-            if let Some(sp) = find_byte(line, b' ') {
-                return Some((&line[..sp], &line[sp + 1..]));
-            }
-            // No space -> skip this line and continue.
-        }
-        None
-    }
-}
-
-// Load manifest file by memory-mapping it read-only. Returns None on open
-// failure, empty file (mmap of zero bytes is invalid), or mmap failure.
-fn load_manifest(path: &[u8]) -> Option<Manifest> {
+// Load the manifest by memory-mapping it read-only. None on open/empty/mmap failure.
+pub fn load_manifest(path: &[u8]) -> Option<Manifest> {
     let fd = open(path);
     if fd < 0 {
         return None;
     }
-
     let size = lseek_end(fd);
     if size <= 0 {
         close(fd);
         return None;
     }
     let len = size as usize;
-
     let ptr = mmap_read(fd, len);
     // The mapping keeps its own reference to the file; the fd can be closed.
     close(fd);
     if ptr.is_null() {
         return None;
     }
-
     // Leak the mapping: execve replaces the address space.
-    Some(Manifest { ptr, len })
+    Some(unsafe { Manifest::from_mapping(ptr, len) })
 }
 
-// Runfiles implementation using String for UTF-8 paths
-enum RunfilesMode {
-    ManifestBased(Manifest),
-    DirectoryBased(String),
-}
-
-struct Runfiles {
-    mode: RunfilesMode,
-    // Paths for environment variables (when export_runfiles_env is true)
-    manifest_path: Option<String>, // RUNFILES_MANIFEST_FILE
-    dir_path: Option<String>,      // RUNFILES_DIR and JAVA_RUNFILES
-}
-
-impl Runfiles {
-    fn create(executable_path: Option<&[u8]>) -> Option<Self> {
-        // Try RUNFILES_MANIFEST_FILE first
-        if let Some(manifest_path) = get_env_var(b"RUNFILES_MANIFEST_FILE") {
-            if !manifest_path.is_empty() {
-                // Create null-terminated path for load_manifest
-                let mut path_with_null = Vec::from(manifest_path.as_bytes());
-                path_with_null.push(0);
-
-                if let Some(manifest) = load_manifest(&path_with_null) {
-                    return Some(Self {
-                        mode: RunfilesMode::ManifestBased(manifest),
-                        manifest_path: Some(manifest_path),
-                        dir_path: None,
-                    });
-                }
-            }
-        }
-
-        // Try RUNFILES_DIR
-        if let Some(runfiles_dir) = get_env_var(b"RUNFILES_DIR") {
-            if !runfiles_dir.is_empty() {
-                return Some(Self {
-                    mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
-                    manifest_path: None,
-                    dir_path: Some(runfiles_dir),
-                });
-            }
-        }
-
-        // Try to find runfiles next to the executable
-        // Check for <executable>.runfiles_manifest file (preferred)
-        // Then check for <executable>.runfiles directory
-        if let Some(exe_path) = executable_path {
-            let exe_len = str_len(exe_path);
-            if exe_len > 0 {
-                // Convert executable path to string (if valid UTF-8)
-                let exe_str = core::str::from_utf8(&exe_path[..exe_len]).ok()?;
-
-                // Try <executable>.runfiles_manifest file first
-                let manifest_file_path = String::from(exe_str) + ".runfiles_manifest";
-
-                // Add null terminator for syscall
-                let mut manifest_path_with_null = Vec::from(manifest_file_path.as_bytes());
-                manifest_path_with_null.push(0);
-
-                // Try to load the manifest file
-                if let Some(manifest) = load_manifest(&manifest_path_with_null) {
-                    // Also determine the runfiles directory for RUNFILES_DIR envvar
-                    let dir_path = String::from(exe_str) + ".runfiles";
-
-                    return Some(Self {
-                        mode: RunfilesMode::ManifestBased(manifest),
-                        manifest_path: Some(manifest_file_path),
-                        dir_path: Some(dir_path),
-                    });
-                }
-
-                // Try <executable>.runfiles directory
-                let runfiles_dir = String::from(exe_str) + ".runfiles";
-
-                // Add null terminator for path_exists syscall
-                let mut dir_with_null = Vec::from(runfiles_dir.as_bytes());
-                dir_with_null.push(0);
-
-                // Check if directory exists using access() syscall
-                if path_exists(&dir_with_null) {
-                    return Some(Self {
-                        mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
-                        manifest_path: None,
-                        dir_path: Some(runfiles_dir),
-                    });
-                }
-            }
-        }
-
-        None
-    }
-
-    fn rlocation(&self, path: &str) -> Option<String> {
-        // If path is absolute, don't resolve through runfiles
-        if path.starts_with('/') {
-            return None;
-        }
-
-        match &self.mode {
-            RunfilesMode::ManifestBased(manifest) => {
-                if let Some(resolved) = manifest.lookup(path) {
-                    return Some(String::from(resolved));
-                }
-                // Prefix match for paths within TreeArtifacts
-                if let Some((resolved_prefix, suffix)) = manifest.prefix_lookup(path) {
-                    let mut result = String::from(resolved_prefix);
-                    result.push_str(suffix);
-                    return Some(result);
-                }
-                None
-            }
-            RunfilesMode::DirectoryBased(dir) => {
-                let mut result = dir.clone();
-
-                // Add separator if needed
-                if !result.ends_with('/') {
-                    result.push('/');
-                }
-
-                // Append the path
-                result.push_str(path);
-
-                Some(result)
-            }
-        }
-    }
-}
-
-// Placeholders for stub runner (will be replaced in final binary)
-// Each placeholder uses a distinctive pattern starting with @@RUNFILES_
-const ARG_SIZE: usize = 256;
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut ARGC_PLACEHOLDER: [u8; 32] = *b"@@RUNFILES_ARGC@@\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut TRANSFORM_FLAGS: [u8; 32] = *b"@@RUNFILES_TRANSFORM_FLAGS@@\0\0\0\0";
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut EXPORT_RUNFILES_ENV: [u8; 32] = *b"@@RUNFILES_EXPORT_ENV@@\0\0\0\0\0\0\0\0\0";
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut ARG0_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut ARG1_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut ARG2_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut ARG3_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut ARG4_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut ARG5_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut ARG6_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut ARG7_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut ARG8_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles_stubs"]
-static mut ARG9_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-// Get the length of a null-terminated string (Rust-style, takes slice)
-fn str_len(s: &[u8]) -> usize {
-    let mut len = 0;
-    while len < s.len() && s[len] != 0 {
-        len += 1;
-    }
-    len
-}
-
-// Check if placeholder is still in template state
-fn is_template_placeholder(placeholder: &[u8]) -> bool {
-    if placeholder.len() < 17 {
-        return false;
-    }
-    str_starts_with(placeholder, b"@@RUNFILES_")
-}
-
-// Read and parse environment variables from /proc/self/environ
-// Returns a tuple of (data_vec, pointers_vec) where pointers point into data_vec
+// Read /proc/self/environ into (data, pointers); pointers point into data.
 fn read_environ() -> (Vec<u8>, Vec<*const u8>) {
-    // Read environment from /proc/self/environ
     let fd = open(b"/proc/self/environ\0");
     if fd < 0 {
-        // If we can't read environ, return empty environment
         return (Vec::new(), vec![core::ptr::null()]);
     }
-
-    // Read into Vec
     let mut environ_data = Vec::new();
     let mut chunk = [0u8; 8192];
     loop {
@@ -990,42 +417,28 @@ fn read_environ() -> (Vec<u8>, Vec<*const u8>) {
         return (Vec::new(), vec![core::ptr::null()]);
     }
 
-    // Parse environment variables (null-separated entries)
     let mut env_ptrs = Vec::new();
     let mut pos = 0;
     let data_len = environ_data.len();
-
     while pos < data_len {
-        // Skip empty entries
         if environ_data[pos] == 0 {
             pos += 1;
             continue;
         }
-
-        // Mark start of this environment variable
         env_ptrs.push(unsafe { environ_data.as_ptr().add(pos) });
-
-        // Find the end (null byte)
         while pos < data_len && environ_data[pos] != 0 {
             pos += 1;
         }
-
-        // Move past the null byte
         pos += 1;
     }
-
-    // Null-terminate the pointer array
     env_ptrs.push(core::ptr::null());
-
     (environ_data, env_ptrs)
 }
 
-// Build modified environment with runfiles variables
-// Returns (data_vec, pointers_vec) - caller must keep data_vec alive while pointers are used
+// Build modified environment with runfiles variables; pointers point into data.
 fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u8>) {
     let (base_data, base_ptrs) = read_environ();
 
-    // If no runfiles info, just return base environment
     let rf = match runfiles {
         Some(r) => r,
         None => return (base_data, base_ptrs),
@@ -1034,73 +447,133 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u
     let mut env_data = Vec::new();
     let mut env_ptrs = Vec::new();
 
-    // Helper to add an environment variable to env_data and record pointer
     let add_env_var = |data: &mut Vec<u8>, ptrs: &mut Vec<*const u8>, name: &[u8], value: &str| {
         let start_pos = data.len();
         data.extend_from_slice(name);
         data.push(b'=');
         data.extend_from_slice(value.as_bytes());
-        data.push(0); // null terminator
-
-        // We'll fix up pointers after building the data
-        ptrs.push(start_pos as *const u8); // Temporarily store offset, fix up later
+        data.push(0);
+        ptrs.push(start_pos as *const u8);
     };
 
-    // Add runfiles environment variables first
     if let Some(ref path) = rf.manifest_path {
         add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
     }
-
     if let Some(ref path) = rf.dir_path {
         add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_DIR", path);
         add_env_var(&mut env_data, &mut env_ptrs, b"JAVA_RUNFILES", path);
     }
 
-    // Copy existing environment (skip runfiles vars that we're setting)
-    // We need to iterate through the base data directly
-    let mut pos = 0;
-    while pos < base_data.len() {
-        // Skip empty entries
-        if base_data[pos] == 0 {
-            pos += 1;
+    // Copy existing environment (skip runfiles vars we're setting).
+    for env_entry in base_data.split(|&b| b == 0) {
+        if env_entry.is_empty() {
             continue;
         }
-
-        // Find the end of this entry
-        let start = pos;
-        while pos < base_data.len() && base_data[pos] != 0 {
-            pos += 1;
-        }
-
-        let env_entry = &base_data[start..pos];
-
-        // Skip if this is a runfiles var we're replacing
         let is_runfiles_var = env_entry.starts_with(b"RUNFILES_MANIFEST_FILE=")
             || env_entry.starts_with(b"RUNFILES_DIR=")
             || env_entry.starts_with(b"JAVA_RUNFILES=");
-
         if !is_runfiles_var {
             let start_pos = env_data.len();
             env_data.extend_from_slice(env_entry);
-            env_data.push(0); // null terminator
-            env_ptrs.push(start_pos as *const u8); // Temporarily store offset
+            env_data.push(0);
+            env_ptrs.push(start_pos as *const u8);
         }
-
-        // Move past the null byte
-        pos += 1;
     }
 
-    // Now fix up all the pointers to point to actual addresses in env_data
+    // Fix up offsets to real addresses now that env_data won't move.
     let base_ptr = env_data.as_ptr();
     for ptr in env_ptrs.iter_mut() {
         let offset = *ptr as usize;
         *ptr = unsafe { base_ptr.add(offset) };
     }
-
-    // Null-terminate the pointer array
     env_ptrs.push(core::ptr::null());
 
     (env_data, env_ptrs)
+}
+
+// --- runtime args & launch ---
+pub struct RuntimeArgs {
+    argc: usize,
+    argv: *const *const u8,
+}
+
+impl RuntimeArgs {
+    /// argv[0] (the stub's own path) as bytes, for runfiles fallback discovery.
+    pub fn program_path(&self) -> Option<&[u8]> {
+        if self.argc == 0 {
+            return None;
+        }
+        unsafe {
+            let p = *self.argv;
+            let mut len = 0;
+            while *p.add(len) != 0 && len < 1048576 {
+                len += 1;
+            }
+            if len > 0 {
+                Some(core::slice::from_raw_parts(p, len))
+            } else {
+                None
+            }
+        }
+    }
+}
+
+pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
+    // Collect runtime args [1..] as NUL-terminated copies.
+    let mut runtime: Vec<Vec<u8>> = Vec::new();
+    if rt.argc > 1 {
+        for i in 1..rt.argc {
+            unsafe {
+                let p = *rt.argv.add(i);
+                let mut len = 0;
+                while *p.add(len) != 0 {
+                    len += 1;
+                    if len > 1048576 {
+                        print(b"ERROR: Runtime argument exceeds 1MB limit\n");
+                        exit(1);
+                    }
+                }
+                runtime.push(core::slice::from_raw_parts(p, len + 1).to_vec());
+            }
+        }
+    }
+
+    // Build the argv pointer array: embedded resolved + runtime + NULL.
+    let mut ptrs: Vec<*const u8> = Vec::with_capacity(launch.resolved.len() + runtime.len() + 1);
+    for a in launch.resolved {
+        ptrs.push(a.as_ptr());
+    }
+    for a in &runtime {
+        ptrs.push(a.as_ptr());
+    }
+    ptrs.push(core::ptr::null());
+
+    // The program to execute is the fully-resolved arg0; argv[0] may be overridden
+    // with the runfiles-relative path (read program before overwriting ptrs[0]).
+    let program = launch.resolved[0].as_ptr();
+    if let Some(override0) = launch.argv0_override {
+        ptrs[0] = override0.as_ptr();
+    }
+
+    let (_env_data, env_ptrs) = if launch.export_env {
+        build_runfiles_environ(launch.runfiles)
+    } else {
+        read_environ()
+    };
+
+    let ret = execve(program, ptrs.as_ptr(), env_ptrs.as_ptr());
+
+    // execve only returns on failure.
+    print(b"ERROR: execve failed with code ");
+    let digit = if ret < 0 {
+        print(b"-");
+        (-ret) as u8 + b'0'
+    } else {
+        ret as u8 + b'0'
+    };
+    print(&[digit]);
+    print(b"\n");
+    exit(1);
 }
 
 #[cfg(target_arch = "x86_64")]
@@ -1130,288 +603,11 @@ core::arch::global_asm!(
 
 #[no_mangle]
 pub extern "C" fn _start_rust(initial_sp: *const usize) -> ! {
-    unsafe {
-        // Stack layout: [sp] = argc, [sp + 8] = argv[0], [sp + 16] = argv[1], ...
-        let runtime_argc = *initial_sp;
-        let runtime_argv = (initial_sp as usize + 8) as *const *const u8;
-
-        // Check if ARGC is still a placeholder
-        if is_template_placeholder(&ARGC_PLACEHOLDER) {
-            print(b"ERROR: This is a template stub runner.\n");
-            print(b"You must finalize it by replacing the placeholders before use.\n");
-            print(b"The ARGC_PLACEHOLDER has not been replaced.\n");
-            exit(1);
-        }
-
-        // Parse argc from placeholder
-        let argc_str = &ARGC_PLACEHOLDER;
-        let argc_len = str_len(argc_str);
-        if argc_len == 0 {
-            print(b"ERROR: ARGC is empty\n");
-            exit(1);
-        }
-
-        // Parse argc as decimal number
-        let mut argc: usize = 0;
-        for i in 0..argc_len {
-            let c = argc_str[i];
-            if c >= b'0' && c <= b'9' {
-                argc = argc * 10 + (c - b'0') as usize;
-            } else {
-                print(b"ERROR: ARGC contains non-digit characters\n");
-                exit(1);
-            }
-        }
-
-        if argc == 0 || argc > 10 {
-            print(b"ERROR: Invalid argc (must be 1-10)\n");
-            exit(1);
-        }
-
-        // Parse transform flags (bitmask of which args to transform)
-        let flags_str = &TRANSFORM_FLAGS;
-        let flags_len = str_len(flags_str);
-        let mut transform_flags: u32 = 0;
-
-        if !is_template_placeholder(flags_str) && flags_len > 0 {
-            // Parse as decimal number (bitmask)
-            for i in 0..flags_len {
-                let c = flags_str[i];
-                if c >= b'0' && c <= b'9' {
-                    transform_flags = transform_flags * 10 + (c - b'0') as u32;
-                } else {
-                    print(b"ERROR: TRANSFORM_FLAGS contains non-digit characters\n");
-                    exit(1);
-                }
-            }
-        }
-        // If flags not set, default to transforming all args
-        if flags_len == 0 || is_template_placeholder(flags_str) {
-            transform_flags = 0xFFFFFFFF; // Transform all by default
-        }
-
-        // Parse export_runfiles_env flag
-        let export_env_str = &EXPORT_RUNFILES_ENV;
-        let export_env_len = str_len(export_env_str);
-        let export_runfiles_env = if !is_template_placeholder(export_env_str) && export_env_len > 0 {
-            export_env_str[0] == b'1'
-        } else {
-            true // Default to true if not set
-        };
-
-        // Check if any arguments need transformation
-        // Create a mask for only the arguments we have (argc args)
-        let argc_mask = if argc >= 32 {
-            0xFFFFFFFF
-        } else {
-            (1u32 << argc) - 1
-        };
-        let needs_transform = (transform_flags & argc_mask) != 0;
-        let needs_runfiles = needs_transform || export_runfiles_env;
-
-        // Get executable path from runtime argv[0] (the stub's actual path) for runfiles fallback
-        let executable_path = if runtime_argc > 0 {
-            let argv0_ptr = *runtime_argv;
-            let mut exe_len = 0;
-            // Safety limit of 1MB to prevent infinite loop
-            while *argv0_ptr.add(exe_len) != 0 && exe_len < 1048576 {
-                exe_len += 1;
-            }
-            if exe_len > 0 {
-                Some(core::slice::from_raw_parts(argv0_ptr, exe_len))
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        // Initialize runfiles only if needed
-        let runfiles = if needs_runfiles {
-            if let Some(rf) = Runfiles::create(executable_path) {
-                Some(rf)
-            } else {
-                print(b"ERROR: Failed to initialize runfiles\n");
-                print(b"Set RUNFILES_DIR or RUNFILES_MANIFEST_FILE, or ensure <executable>.runfiles/ directory exists\n");
-                exit(1);
-            }
-        } else {
-            None
-        };
-
-        // Get arg placeholders
-        let arg_placeholders: [&[u8; ARG_SIZE]; 10] = [
-            &ARG0_PLACEHOLDER,
-            &ARG1_PLACEHOLDER,
-            &ARG2_PLACEHOLDER,
-            &ARG3_PLACEHOLDER,
-            &ARG4_PLACEHOLDER,
-            &ARG5_PLACEHOLDER,
-            &ARG6_PLACEHOLDER,
-            &ARG7_PLACEHOLDER,
-            &ARG8_PLACEHOLDER,
-            &ARG9_PLACEHOLDER,
-        ];
-
-        // Use Vec for dynamic path storage - no fixed size limits
-        // We store as Vec<u8> since we need null-terminated bytes for execve
-        let mut resolved_paths: Vec<Vec<u8>> = Vec::with_capacity(128);
-
-        // Resolve embedded arguments
-        for i in 0..argc {
-            let arg_data = arg_placeholders[i];
-            let arg_len = str_len(arg_data);
-
-            if arg_len == 0 {
-                print(b"ERROR: Argument ");
-                let digit = [b'0' + i as u8];
-                print(&digit);
-                print(b" is empty\n");
-                exit(1);
-            }
-
-            let arg_slice = &arg_data[..arg_len];
-
-            // Check if this argument should be transformed
-            let should_transform = (transform_flags & (1 << i)) != 0;
-
-            let resolved = if should_transform {
-                // Try to resolve through runfiles (which we know exists if we need transformation)
-                if let Some(ref rf) = runfiles {
-                    // Convert argument to &str for rlocation (Bazel args are UTF-8)
-                    if let Ok(arg_str) = core::str::from_utf8(arg_slice) {
-                        if let Some(resolved_str) = rf.rlocation(arg_str) {
-                            // Convert back to bytes with null terminator
-                            let mut path = Vec::from(resolved_str.as_bytes());
-                            path.push(0);
-                            path
-                        } else {
-                            // If not found in runfiles, use the path as-is
-                            let mut path = arg_slice.to_vec();
-                            path.push(0);
-                            path
-                        }
-                    } else {
-                        // Not valid UTF-8, use as-is
-                        let mut path = arg_slice.to_vec();
-                        path.push(0);
-                        path
-                    }
-                } else {
-                    // This should never happen - we checked needs_runfiles before
-                    // But use path as-is for safety
-                    let mut path = arg_slice.to_vec();
-                    path.push(0);
-                    path
-                }
-            } else {
-                // Use path as-is without transformation
-                let mut path = arg_slice.to_vec();
-                path.push(0);
-                path
-            };
-
-            resolved_paths.push(resolved);
-        }
-
-        // Append runtime arguments (skip argv[0] which is the stub itself)
-        if runtime_argc > 1 {
-            for i in 1..runtime_argc {
-                // Get runtime argument
-                let runtime_arg_ptr = *runtime_argv.add(i);
-
-                // Find length of runtime argument (scan until null, with safety limit)
-                let mut arg_len = 0;
-                while *runtime_arg_ptr.add(arg_len) != 0 {
-                    arg_len += 1;
-                    // Safety limit to prevent infinite loop on malformed input
-                    if arg_len > 1048576 {
-                        print(b"ERROR: Runtime argument exceeds 1MB limit\n");
-                        exit(1);
-                    }
-                }
-
-                // Copy runtime argument (include null terminator)
-                let runtime_arg_slice = core::slice::from_raw_parts(runtime_arg_ptr, arg_len + 1);
-                resolved_paths.push(runtime_arg_slice.to_vec());
-            }
-        }
-
-        // Preserve argv[0] as a runfiles-relative path.
-        //
-        // The rlocation-resolved path (resolved_paths[0]) is a fully resolved
-        // absolute path, suitable for the kernel to open and execute. However,
-        // many programs (notably aspect_rules_py's venv_shim) read argv[0] and
-        // walk its parent symlinks to locate the .runfiles tree. If argv[0] is
-        // already a fully resolved path, this walk fails because the symlink
-        // chain through .runfiles has been bypassed.
-        //
-        // To fix this, we construct argv[0] as <runfiles_dir>/<original_arg>,
-        // which preserves the path through the .runfiles symlink tree. The
-        // resolved path is still used as the filename argument to execve, so
-        // the kernel can find the actual binary.
-        let argv0_runfiles_path: Option<Vec<u8>> = if let Some(ref rf) = runfiles {
-            if let Some(ref dir_path) = rf.dir_path {
-                // Get the original (pre-resolution) arg0
-                let arg0_data = arg_placeholders[0];
-                let arg0_len = str_len(arg0_data);
-                if arg0_len > 0 {
-                    let mut path = Vec::from(dir_path.as_bytes());
-                    if !dir_path.ends_with('/') {
-                        path.push(b'/');
-                    }
-                    path.extend_from_slice(&arg0_data[..arg0_len]);
-                    path.push(0);
-                    Some(path)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
-        } else {
-            None
-        };
-
-        // Build pointer array from the resolved paths
-        let mut resolved_ptrs: Vec<*const u8> = Vec::with_capacity(resolved_paths.len() + 1);
-        for path in &resolved_paths {
-            resolved_ptrs.push(path.as_ptr());
-        }
-        // NULL-terminate the argv array
-        resolved_ptrs.push(core::ptr::null());
-
-        // Get the executable path (first argument) — fully resolved for the kernel
-        let executable = resolved_ptrs[0];
-
-        // Replace argv[0] with the runfiles-relative path if available.
-        // This must happen after building resolved_ptrs so the executable
-        // pointer captures the resolved path before we overwrite argv[0].
-        if let Some(ref argv0_path) = argv0_runfiles_path {
-            resolved_ptrs[0] = argv0_path.as_ptr();
-        }
-
-        // Build environment (with runfiles vars if export_runfiles_env is true)
-        // We need to keep the env_data alive until execve
-        let (_env_data, env_ptrs) = if export_runfiles_env {
-            build_runfiles_environ(runfiles.as_ref())
-        } else {
-            read_environ()
-        };
-
-        // Execute the target program
-        let ret = execve(executable, resolved_ptrs.as_ptr(), env_ptrs.as_ptr());
-
-        // If execve returns, it failed
-        print(b"ERROR: execve failed with code ");
-        let digit = if ret < 0 {
-            print(b"-");
-            (-ret) as u8 + b'0'
-        } else {
-            ret as u8 + b'0'
-        };
-        print(&[digit]);
-        print(b"\n");
-        exit(1);
-    }
+    // Stack layout: [sp] = argc, [sp + 8] = argv[0], [sp + 16] = argv[1], ...
+    let (argc, argv) = unsafe {
+        let argc = *initial_sp;
+        let argv = (initial_sp as usize + 8) as *const *const u8;
+        (argc, argv)
+    };
+    crate::run::main(RuntimeArgs { argc, argv })
 }

--- a/runfiles-stub/src/macos.rs
+++ b/runfiles-stub/src/macos.rs
@@ -1,445 +1,136 @@
-// macOS-specific implementation using libc
-// Unlike Linux version, this uses libc and can link with libsystem
-
-extern crate alloc;
+// macOS backend: libc (libSystem) primitives, the C `main` entry point, and an
+// execve-based launch. All FFI is confined to the `sys` module and wrapped in safe
+// functions that form the platform seam consumed by the shared core.
 
 use alloc::string::String;
 use alloc::vec::Vec;
-use core::alloc::{GlobalAlloc, Layout};
-use core::cell::UnsafeCell;
-use core::panic::PanicInfo;
-use talc::{ClaimOnOom, Span, Talc};
 
-// Global allocator using talc with a static memory arena
-// 8 MiB should be plenty for manifest parsing, path resolution, and environment handling
-static mut ARENA: [u8; 8 * 1024 * 1024] = [0; 8 * 1024 * 1024];
+use crate::common::{print_number, Manifest};
+use crate::run::Launch;
+use crate::runfiles::Runfiles;
 
-// Simple wrapper for single-threaded use (no locking needed)
-struct TalcAllocator(UnsafeCell<Talc<ClaimOnOom>>);
-unsafe impl Sync for TalcAllocator {}
-
-unsafe impl GlobalAlloc for TalcAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        (*self.0.get()).malloc(layout).map_or(core::ptr::null_mut(), |p| p.as_ptr())
-    }
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        (*self.0.get()).free(core::ptr::NonNull::new_unchecked(ptr), layout);
-    }
-}
-
-#[global_allocator]
-static ALLOCATOR: TalcAllocator = TalcAllocator(UnsafeCell::new(Talc::new(unsafe {
-    ClaimOnOom::new(Span::from_array(core::ptr::addr_of!(ARENA).cast_mut()))
-})));
-
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    unsafe { exit(1) }
-}
-
-// External libc functions
-extern "C" {
-    fn exit(code: i32) -> !;
-    fn write(fd: i32, buf: *const u8, count: usize) -> isize;
-    fn open(path: *const u8, flags: i32, ...) -> i32;
-    fn close(fd: i32) -> i32;
-    fn access(path: *const u8, mode: i32) -> i32;
-    fn execve(path: *const u8, argv: *const *const u8, envp: *const *const u8) -> i32;
-
-    // Memory-map a file read-only (used for the runfiles manifest).
-    fn mmap(addr: *mut core::ffi::c_void, len: usize, prot: i32, flags: i32, fd: i32, offset: i64) -> *mut core::ffi::c_void;
-    fn lseek(fd: i32, offset: i64, whence: i32) -> i64;
-
-    // Access to errno - macOS provides this via __error()
-    // Returns a pointer to the thread-local errno variable
-    fn __error() -> *mut i32;
-
-    // Access to environment - macOS provides this
-    static mut environ: *const *const u8;
-}
-
-// Get the current errno value
-fn get_errno() -> i32 {
-    unsafe { *__error() }
-}
-
-// Check if a path exists using access() with F_OK
-fn path_exists(path: &[u8]) -> bool {
-    unsafe {
-        access(path.as_ptr(), 0) == 0  // F_OK = 0
+mod sys {
+    extern "C" {
+        pub fn exit(code: i32) -> !;
+        pub fn write(fd: i32, buf: *const u8, count: usize) -> isize;
+        pub fn open(path: *const u8, flags: i32, ...) -> i32;
+        pub fn close(fd: i32) -> i32;
+        pub fn access(path: *const u8, mode: i32) -> i32;
+        pub fn execve(path: *const u8, argv: *const *const u8, envp: *const *const u8) -> i32;
+        pub fn mmap(
+            addr: *mut core::ffi::c_void,
+            len: usize,
+            prot: i32,
+            flags: i32,
+            fd: i32,
+            offset: i64,
+        ) -> *mut core::ffi::c_void;
+        pub fn lseek(fd: i32, offset: i64, whence: i32) -> i64;
+        // Thread-local errno is reached via __error() on macOS.
+        pub fn __error() -> *mut i32;
+        pub static mut environ: *const *const u8;
     }
 }
 
-// File open flags
 const O_RDONLY: i32 = 0;
 const STDOUT: i32 = 1;
-
-// mmap parameters for read-only file mapping
 const PROT_READ: i32 = 1;
 const MAP_PRIVATE: i32 = 2;
 const SEEK_END: i32 = 2;
 const MAP_FAILED: *mut core::ffi::c_void = (-1isize) as *mut core::ffi::c_void;
 
-// String utilities
-fn print(s: &[u8]) {
+// --- path semantics ---
+pub const SEP: char = '/';
+pub const NEWLINE: &[u8] = b"\n";
+
+pub fn is_absolute(path: &str) -> bool {
+    path.starts_with('/')
+}
+
+pub fn to_native_path(s: &str) -> String {
+    String::from(s)
+}
+
+// --- primitives ---
+pub fn print(s: &[u8]) {
     unsafe {
-        write(STDOUT, s.as_ptr(), s.len());
+        sys::write(STDOUT, s.as_ptr(), s.len());
     }
 }
 
-fn print_number(mut n: usize) {
-    let mut buf = [0u8; 20]; // Enough for 64-bit numbers
-    let mut i = 0;
-
-    if n == 0 {
-        print(b"0");
-        return;
-    }
-
-    while n > 0 {
-        buf[i] = b'0' + (n % 10) as u8;
-        n /= 10;
-        i += 1;
-    }
-
-    // Print in reverse order
-    while i > 0 {
-        i -= 1;
-        print(&buf[i..i+1]);
-    }
+pub fn exit(code: i32) -> ! {
+    unsafe { sys::exit(code) }
 }
 
-fn str_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    for i in 0..a.len() {
-        if a[i] != b[i] {
-            return false;
-        }
-    }
-    true
+pub fn path_exists(path: &[u8]) -> bool {
+    unsafe { sys::access(path.as_ptr(), 0) == 0 } // F_OK = 0
 }
 
-fn str_starts_with(haystack: &[u8], needle: &[u8]) -> bool {
-    if haystack.len() < needle.len() {
-        return false;
-    }
-    str_eq(&haystack[..needle.len()], needle)
-}
-
-fn find_byte(haystack: &[u8], needle: u8) -> Option<usize> {
-    for i in 0..haystack.len() {
-        if haystack[i] == needle {
-            return Some(i);
-        }
-    }
-    None
-}
-
-// Environment variable reading via the environ pointer - returns String
-fn get_env_var(name: &[u8]) -> Option<String> {
+// Environment variable lookup via the libc `environ` pointer.
+pub fn get_env_var(name: &[u8]) -> Option<String> {
     unsafe {
-        let mut env_ptr = environ;
-
-        // Iterate through environment variables
+        let mut env_ptr = sys::environ;
         while !(*env_ptr).is_null() {
             let entry_ptr = *env_ptr;
-
-            // Find the length of this environment variable string
             let mut len = 0;
             while *entry_ptr.add(len) != 0 {
                 len += 1;
-                if len > 1048576 {  // Safety limit: 1MB
+                if len > 1048576 {
                     break;
                 }
             }
-
-            // Convert to slice
             let entry = core::slice::from_raw_parts(entry_ptr, len);
-
-            // Look for '=' separator
-            if let Some(eq_pos) = find_byte(entry, b'=') {
-                let key = &entry[..eq_pos];
-                let value = &entry[eq_pos + 1..];
-
-                if str_eq(key, name) {
-                    // Convert to String, returning None if not valid UTF-8
-                    return String::from_utf8(value.to_vec()).ok();
+            if let Some(eq_pos) = entry.iter().position(|&b| b == b'=') {
+                if &entry[..eq_pos] == name {
+                    return String::from_utf8(entry[eq_pos + 1..].to_vec()).ok();
                 }
             }
-
             env_ptr = env_ptr.add(1);
         }
     }
-
     None
 }
 
-// Memory-mapped manifest: a pointer/length pair into the mapped file. The
-// manifest is scanned lazily on each lookup (O(n)), so no per-entry allocation
-// is needed and arbitrarily large manifests are supported. The kernel caches
-// the file's pages for us.
-struct Manifest {
-    ptr: *const u8,
-    len: usize,
-}
-
-impl Manifest {
-    #[inline]
-    fn data(&self) -> &[u8] {
-        // Safety: ptr/len come from a successful mmap that we leak for the
-        // lifetime of the process (until execve replaces the address space).
-        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
-    }
-
-    fn lookup(&self, key: &str) -> Option<&str> {
-        let key_bytes = key.as_bytes();
-        for (k, v) in ManifestLines::new(self.data()) {
-            if k == key_bytes {
-                return core::str::from_utf8(v).ok();
-            }
-        }
-        None
-    }
-
-    /// Find the longest manifest entry whose key is a prefix of `path` at a '/' boundary.
-    /// Returns (resolved_value, suffix) where suffix includes the leading '/'.
-    fn prefix_lookup<'a, 'b>(&'a self, path: &'b str) -> Option<(&'a str, &'b str)> {
-        let path_bytes = path.as_bytes();
-        let mut best: Option<(&'a str, &'b str)> = None;
-        let mut best_len: usize = 0;
-        for (k, v) in ManifestLines::new(self.data()) {
-            if path_bytes.len() > k.len()
-                && k.len() > best_len
-                && &path_bytes[..k.len()] == k
-                && path_bytes[k.len()] == b'/'
-            {
-                // Values were owned UTF-8 Strings before; keep that guarantee by
-                // only considering candidates whose value is valid UTF-8.
-                if let Ok(value) = core::str::from_utf8(v) {
-                    best_len = k.len();
-                    best = Some((value, &path[k.len()..]));
-                }
-            }
-        }
-        best
-    }
-}
-
-/// Iterator over `(key, value)` byte slices of a Bazel runfiles MANIFEST.
-/// Replicates `str::lines()` + `split_once(' ')`: split on '\n', strip one
-/// trailing '\r' (CRLF), and skip lines without a space (e.g. the
-/// "<workspace>/.runfile" marker).
-struct ManifestLines<'a> {
-    rest: &'a [u8],
-}
-
-impl<'a> ManifestLines<'a> {
-    fn new(data: &'a [u8]) -> Self {
-        Self { rest: data }
-    }
-}
-
-impl<'a> Iterator for ManifestLines<'a> {
-    type Item = (&'a [u8], &'a [u8]);
-
-    fn next(&mut self) -> Option<(&'a [u8], &'a [u8])> {
-        while !self.rest.is_empty() {
-            let (mut line, remainder) = match find_byte(self.rest, b'\n') {
-                Some(nl) => (&self.rest[..nl], &self.rest[nl + 1..]),
-                None => (self.rest, &self.rest[self.rest.len()..]),
-            };
-            self.rest = remainder;
-            // Strip one trailing '\r' (handles CRLF line endings).
-            if let Some((&b'\r', head)) = line.split_last() {
-                line = head;
-            }
-            if let Some(sp) = find_byte(line, b' ') {
-                return Some((&line[..sp], &line[sp + 1..]));
-            }
-            // No space -> skip this line and continue.
-        }
-        None
-    }
-}
-
-// Load manifest file by memory-mapping it read-only. Returns None on open
-// failure, empty file (mmap of zero bytes is invalid), or mmap failure.
-fn load_manifest(path: &[u8]) -> Option<Manifest> {
+// Memory-map the manifest file read-only. Returns None on open/empty/mmap failure.
+pub fn load_manifest(path: &[u8]) -> Option<Manifest> {
     unsafe {
-        let fd = open(path.as_ptr(), O_RDONLY);
+        let fd = sys::open(path.as_ptr(), O_RDONLY);
         if fd < 0 {
             return None;
         }
-
-        let size = lseek(fd, 0, SEEK_END);
+        let size = sys::lseek(fd, 0, SEEK_END);
         if size <= 0 {
-            close(fd);
+            sys::close(fd);
             return None;
         }
         let len = size as usize;
-
-        let addr = mmap(core::ptr::null_mut(), len, PROT_READ, MAP_PRIVATE, fd, 0);
+        let addr = sys::mmap(core::ptr::null_mut(), len, PROT_READ, MAP_PRIVATE, fd, 0);
         // The mapping keeps its own reference to the file; the fd can be closed.
-        close(fd);
+        sys::close(fd);
         if addr == MAP_FAILED || addr.is_null() {
             return None;
         }
-
         // Leak the mapping: execve replaces the address space.
-        Some(Manifest { ptr: addr as *const u8, len })
+        Some(Manifest::from_mapping(addr as *const u8, len))
     }
 }
 
-// Runfiles implementation using String for dynamic path storage
-enum RunfilesMode {
-    ManifestBased(Manifest),
-    DirectoryBased(String),
-}
-
-struct Runfiles {
-    mode: RunfilesMode,
-    // Paths for environment variables (when export_runfiles_env is true)
-    manifest_path: Option<String>, // RUNFILES_MANIFEST_FILE
-    dir_path: Option<String>,      // RUNFILES_DIR and JAVA_RUNFILES
-}
-
-impl Runfiles {
-    fn create(executable_path: Option<&[u8]>) -> Option<Self> {
-        // Try RUNFILES_MANIFEST_FILE first
-        if let Some(manifest_path) = get_env_var(b"RUNFILES_MANIFEST_FILE") {
-            if !manifest_path.is_empty() {
-                // Create null-terminated path for load_manifest
-                let mut path_with_null = Vec::from(manifest_path.as_bytes());
-                path_with_null.push(0);
-
-                if let Some(manifest) = load_manifest(&path_with_null) {
-                    return Some(Self {
-                        mode: RunfilesMode::ManifestBased(manifest),
-                        manifest_path: Some(manifest_path),
-                        dir_path: None,
-                    });
-                }
-            }
-        }
-
-        // Try RUNFILES_DIR
-        if let Some(runfiles_dir) = get_env_var(b"RUNFILES_DIR") {
-            if !runfiles_dir.is_empty() {
-                return Some(Self {
-                    mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
-                    manifest_path: None,
-                    dir_path: Some(runfiles_dir),
-                });
-            }
-        }
-
-        // Try to find runfiles next to the executable
-        // Check for <executable>.runfiles_manifest file (preferred)
-        // Then check for <executable>.runfiles directory
-        if let Some(exe_path) = executable_path {
-            let exe_len = strlen(exe_path);
-            if exe_len > 0 {
-                // Convert executable path to string (if valid UTF-8)
-                let exe_str = core::str::from_utf8(&exe_path[..exe_len]).ok()?;
-
-                // Try <executable>.runfiles_manifest file first
-                let manifest_file_path = String::from(exe_str) + ".runfiles_manifest";
-
-                // Add null terminator for syscall
-                let mut manifest_path_with_null = Vec::from(manifest_file_path.as_bytes());
-                manifest_path_with_null.push(0);
-
-                // Try to load the manifest file
-                if let Some(manifest) = load_manifest(&manifest_path_with_null) {
-                    // Also determine the runfiles directory for RUNFILES_DIR envvar
-                    // The directory is <executable>.runfiles
-                    let dir_path = String::from(exe_str) + ".runfiles";
-
-                    return Some(Self {
-                        mode: RunfilesMode::ManifestBased(manifest),
-                        manifest_path: Some(manifest_file_path),
-                        dir_path: Some(dir_path),
-                    });
-                }
-
-                // Try <executable>.runfiles directory
-                let runfiles_dir = String::from(exe_str) + ".runfiles";
-
-                // Add null terminator for path_exists syscall
-                let mut dir_with_null = Vec::from(runfiles_dir.as_bytes());
-                dir_with_null.push(0);
-
-                // Check if directory exists using access() syscall
-                if path_exists(&dir_with_null) {
-                    return Some(Self {
-                        mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
-                        manifest_path: None,
-                        dir_path: Some(runfiles_dir),
-                    });
-                }
-            }
-        }
-
-        None
-    }
-
-    fn rlocation(&self, path: &str) -> Option<String> {
-        // If path is absolute, don't resolve through runfiles
-        if path.starts_with('/') {
-            return None;
-        }
-
-        match &self.mode {
-            RunfilesMode::ManifestBased(manifest) => {
-                if let Some(resolved) = manifest.lookup(path) {
-                    return Some(String::from(resolved));
-                }
-                // Prefix match for paths within TreeArtifacts
-                if let Some((resolved_prefix, suffix)) = manifest.prefix_lookup(path) {
-                    let mut result = String::from(resolved_prefix);
-                    result.push_str(suffix);
-                    return Some(result);
-                }
-                None
-            }
-            RunfilesMode::DirectoryBased(dir) => {
-                let mut result = dir.clone();
-
-                // Add separator if needed
-                if !result.ends_with('/') {
-                    result.push('/');
-                }
-
-                // Append the path
-                result.push_str(path);
-
-                Some(result)
-            }
-        }
-    }
-}
-
-// Build modified environment with runfiles variables using Vec
-// Returns (data_vec, pointers_vec) - caller must keep data_vec alive while pointers are used
+// Build modified environment with runfiles variables, returning (data, pointers).
+// The caller must keep `data` alive while the pointers are used.
 fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u8>) {
     let mut env_data = Vec::new();
     let mut env_ptrs = Vec::new();
 
-    // Helper to add an environment variable to env_data and record offset
+    // Append "name=value\0" to env_data, recording its offset (fixed up to a pointer later).
     let add_env_var = |data: &mut Vec<u8>, ptrs: &mut Vec<*const u8>, name: &[u8], value: &str| {
         let start_pos = data.len();
         data.extend_from_slice(name);
         data.push(b'=');
         data.extend_from_slice(value.as_bytes());
-        data.push(0); // null terminator
-
-        // Temporarily store offset, fix up later
+        data.push(0);
         ptrs.push(start_pos as *const u8);
     };
 
-    // Add runfiles environment variables first
     if let Some(rf) = runfiles {
         if let Some(ref path) = rf.manifest_path {
             add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
@@ -450,405 +141,124 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u
         }
     }
 
-    // Copy existing environment, filtering out runfiles vars
+    // Copy existing environment, filtering out the runfiles vars we just set.
     unsafe {
-        let mut env_ptr = environ;
+        let mut env_ptr = sys::environ;
         while !(*env_ptr).is_null() {
             let entry_ptr = *env_ptr;
-
-            // Find length of this entry
             let mut len = 0;
             while *entry_ptr.add(len) != 0 {
                 len += 1;
-                if len > 1048576 {  // Safety limit: 1MB
+                if len > 1048576 {
                     break;
                 }
             }
-
             let entry = core::slice::from_raw_parts(entry_ptr, len);
-
-            // Check if this is a runfiles variable we should skip
-            let should_skip = str_starts_with(entry, b"RUNFILES_MANIFEST_FILE=")
-                || str_starts_with(entry, b"RUNFILES_DIR=")
-                || str_starts_with(entry, b"JAVA_RUNFILES=");
-
+            let should_skip = entry.starts_with(b"RUNFILES_MANIFEST_FILE=")
+                || entry.starts_with(b"RUNFILES_DIR=")
+                || entry.starts_with(b"JAVA_RUNFILES=");
             if !should_skip {
                 let start_pos = env_data.len();
                 env_data.extend_from_slice(entry);
-                env_data.push(0); // null terminator
-                env_ptrs.push(start_pos as *const u8); // Temporarily store offset
+                env_data.push(0);
+                env_ptrs.push(start_pos as *const u8);
             }
-
             env_ptr = env_ptr.add(1);
         }
     }
 
-    // Fix up all the pointers to point to actual addresses in env_data
+    // Fix up offsets to real addresses now that env_data won't move.
     let base_ptr = env_data.as_ptr();
     for ptr in env_ptrs.iter_mut() {
         let offset = *ptr as usize;
         *ptr = unsafe { base_ptr.add(offset) };
     }
-
-    // Null-terminate the pointer array
     env_ptrs.push(core::ptr::null());
 
     (env_data, env_ptrs)
 }
 
-// Placeholders for stub runner (will be replaced in final binary)
-const ARG_SIZE: usize = 256;
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut ARGC_PLACEHOLDER: [u8; 32] = *b"@@RUNFILES_ARGC@@\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut TRANSFORM_FLAGS: [u8; 32] = *b"@@RUNFILES_TRANSFORM_FLAGS@@\0\0\0\0";
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut EXPORT_RUNFILES_ENV: [u8; 32] = *b"@@RUNFILES_EXPORT_ENV@@\0\0\0\0\0\0\0\0\0";
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut ARG0_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut ARG1_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut ARG2_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut ARG3_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut ARG4_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut ARG5_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut ARG6_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut ARG7_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut ARG8_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = "__DATA,__runfiles"]
-static mut ARG9_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-// Get the length of a null-terminated string
-fn strlen(s: &[u8]) -> usize {
-    let mut len = 0;
-    while len < s.len() && s[len] != 0 {
-        len += 1;
-    }
-    len
+// --- runtime args & launch ---
+pub struct RuntimeArgs {
+    argc: i32,
+    argv: *const *const u8,
 }
 
-// Check if placeholder is still in template state
-fn is_template_placeholder(placeholder: &[u8]) -> bool {
-    if placeholder.len() < 17 {
-        return false;
-    }
-    str_starts_with(placeholder, b"@@RUNFILES_")
-}
-
-#[no_mangle]
-pub extern "C" fn main(runtime_argc: i32, runtime_argv: *const *const u8) -> ! {
-    unsafe {
-        // Check if ARGC is still a placeholder
-        if is_template_placeholder(&ARGC_PLACEHOLDER) {
-            print(b"ERROR: This is a template stub runner.\n");
-            print(b"You must finalize it by replacing the placeholders before use.\n");
-            print(b"The ARGC_PLACEHOLDER has not been replaced.\n");
-            exit(1);
+impl RuntimeArgs {
+    /// argv[0] (the stub's own path) as bytes, for runfiles fallback discovery.
+    pub fn program_path(&self) -> Option<&[u8]> {
+        if self.argc <= 0 {
+            return None;
         }
-
-        // Parse argc from placeholder
-        let argc_str = &ARGC_PLACEHOLDER;
-        let argc_len = strlen(argc_str);
-        if argc_len == 0 {
-            print(b"ERROR: ARGC is empty\n");
-            exit(1);
-        }
-
-        // Parse argc as decimal number
-        let mut argc: usize = 0;
-        for i in 0..argc_len {
-            let c = argc_str[i];
-            if c >= b'0' && c <= b'9' {
-                argc = argc * 10 + (c - b'0') as usize;
-            } else {
-                print(b"ERROR: ARGC contains non-digit characters\n");
-                exit(1);
+        unsafe {
+            let p = *self.argv;
+            let mut len = 0;
+            while *p.add(len) != 0 && len < 1048576 {
+                len += 1;
             }
-        }
-
-        if argc == 0 || argc > 10 {
-            print(b"ERROR: Invalid argc (must be 1-10)\n");
-            exit(1);
-        }
-
-        // Parse transform flags (bitmask of which args to transform)
-        let flags_str = &TRANSFORM_FLAGS;
-        let flags_len = strlen(flags_str);
-        let mut transform_flags: u32 = 0;
-
-        if !is_template_placeholder(flags_str) && flags_len > 0 {
-            // Parse as decimal number (bitmask)
-            for i in 0..flags_len {
-                let c = flags_str[i];
-                if c >= b'0' && c <= b'9' {
-                    transform_flags = transform_flags * 10 + (c - b'0') as u32;
-                } else {
-                    print(b"ERROR: TRANSFORM_FLAGS contains non-digit characters\n");
-                    exit(1);
-                }
-            }
-        }
-        // If flags not set, default to transforming all args
-        if flags_len == 0 || is_template_placeholder(flags_str) {
-            transform_flags = 0xFFFFFFFF; // Transform all by default
-        }
-
-        // Parse export_runfiles_env flag (defaults to true)
-        let export_str = &EXPORT_RUNFILES_ENV;
-        let export_len = strlen(export_str);
-        let export_runfiles_env = if !is_template_placeholder(export_str) && export_len > 0 {
-            // Parse as "1" (true) or "0" (false)
-            export_str[0] != b'0'
-        } else {
-            true // Default to true
-        };
-
-        // Check if any arguments need transformation
-        let argc_mask = if argc >= 32 {
-            0xFFFFFFFF
-        } else {
-            (1u32 << argc) - 1
-        };
-        let needs_transform = (transform_flags & argc_mask) != 0;
-        let needs_runfiles = needs_transform || export_runfiles_env;
-
-        // Get executable path from runtime argv[0] for runfiles fallback
-        let executable_path = if runtime_argc > 0 {
-            let argv0_ptr = *runtime_argv;
-            let mut exe_len = 0;
-            // Safety limit of 1MB to prevent infinite loop
-            while *argv0_ptr.add(exe_len) != 0 && exe_len < 1048576 {
-                exe_len += 1;
-            }
-            if exe_len > 0 {
-                Some(core::slice::from_raw_parts(argv0_ptr, exe_len))
+            if len > 0 {
+                Some(core::slice::from_raw_parts(p, len))
             } else {
                 None
             }
-        } else {
-            None
-        };
-
-        // Initialize runfiles only if needed
-        let runfiles = if needs_runfiles {
-            if let Some(rf) = Runfiles::create(executable_path) {
-                Some(rf)
-            } else {
-                print(b"ERROR: Failed to initialize runfiles\n");
-                print(b"Set RUNFILES_DIR or RUNFILES_MANIFEST_FILE, or ensure <executable>.runfiles/ directory exists\n");
-                exit(1);
-            }
-        } else {
-            None
-        };
-
-        // Get arg placeholders
-        let arg_placeholders: [&[u8; ARG_SIZE]; 10] = [
-            &ARG0_PLACEHOLDER,
-            &ARG1_PLACEHOLDER,
-            &ARG2_PLACEHOLDER,
-            &ARG3_PLACEHOLDER,
-            &ARG4_PLACEHOLDER,
-            &ARG5_PLACEHOLDER,
-            &ARG6_PLACEHOLDER,
-            &ARG7_PLACEHOLDER,
-            &ARG8_PLACEHOLDER,
-            &ARG9_PLACEHOLDER,
-        ];
-
-        // Use Vec for dynamic path storage - no fixed size limits
-        let mut resolved_paths: Vec<Vec<u8>> = Vec::with_capacity(128);
-
-        // Resolve embedded arguments
-        for i in 0..argc {
-            let arg_data = arg_placeholders[i];
-            let arg_len = strlen(arg_data);
-
-            if arg_len == 0 {
-                print(b"ERROR: Argument ");
-                let digit = [b'0' + i as u8];
-                print(&digit);
-                print(b" is empty\n");
-                exit(1);
-            }
-
-            let arg_slice = &arg_data[..arg_len];
-
-            // Check if this argument should be transformed
-            let should_transform = (transform_flags & (1 << i)) != 0;
-
-            let resolved = if should_transform {
-                // Try to resolve through runfiles (which we know exists if we need transformation)
-                if let Some(ref rf) = runfiles {
-                    // Convert argument to &str for rlocation (Bazel args are UTF-8)
-                    if let Ok(arg_str) = core::str::from_utf8(arg_slice) {
-                        if let Some(resolved_str) = rf.rlocation(arg_str) {
-                            // Convert back to bytes with null terminator
-                            let mut path = Vec::from(resolved_str.as_bytes());
-                            path.push(0);
-                            path
-                        } else {
-                            // If not found in runfiles, use the path as-is
-                            let mut path = arg_slice.to_vec();
-                            path.push(0);
-                            path
-                        }
-                    } else {
-                        // Not valid UTF-8, use as-is
-                        let mut path = arg_slice.to_vec();
-                        path.push(0);
-                        path
-                    }
-                } else {
-                    // This should never happen - we checked needs_runfiles before
-                    // But use path as-is for safety
-                    let mut path = arg_slice.to_vec();
-                    path.push(0);
-                    path
-                }
-            } else {
-                // Use path as-is without transformation
-                let mut path = arg_slice.to_vec();
-                path.push(0);
-                path
-            };
-
-            resolved_paths.push(resolved);
         }
+    }
+}
 
-        // Append runtime arguments (skip argv[0] which is the stub itself)
-        if runtime_argc > 1 {
-            for i in 1..runtime_argc as usize {
-                // Get runtime argument
-                let runtime_arg_ptr = *runtime_argv.add(i);
-
-                // Find length of runtime argument (scan until null, with safety limit)
-                let mut arg_len = 0;
-                while *runtime_arg_ptr.add(arg_len) != 0 {
-                    arg_len += 1;
-                    // Safety limit to prevent infinite loop on malformed input
-                    if arg_len > 1048576 {
+pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
+    unsafe {
+        // Collect runtime args [1..] as NUL-terminated copies.
+        let mut runtime: Vec<Vec<u8>> = Vec::new();
+        if rt.argc > 1 {
+            for i in 1..rt.argc as usize {
+                let p = *rt.argv.add(i);
+                let mut len = 0;
+                while *p.add(len) != 0 {
+                    len += 1;
+                    if len > 1048576 {
                         print(b"ERROR: Runtime argument exceeds 1MB limit\n");
                         exit(1);
                     }
                 }
-
-                // Copy runtime argument (include null terminator)
-                let runtime_arg_slice = core::slice::from_raw_parts(runtime_arg_ptr, arg_len + 1);
-                resolved_paths.push(runtime_arg_slice.to_vec());
+                runtime.push(core::slice::from_raw_parts(p, len + 1).to_vec());
             }
         }
 
-        // Preserve argv[0] as a runfiles-relative path.
-        //
-        // The rlocation-resolved path (resolved_paths[0]) is a fully resolved
-        // absolute path, suitable for the kernel to open and execute. However,
-        // many programs (notably aspect_rules_py's venv_shim) read argv[0] and
-        // walk its parent symlinks to locate the .runfiles tree. If argv[0] is
-        // already a fully resolved path, this walk fails because the symlink
-        // chain through .runfiles has been bypassed.
-        //
-        // To fix this, we construct argv[0] as <runfiles_dir>/<original_arg>,
-        // which preserves the path through the .runfiles symlink tree. The
-        // resolved path is still used as the filename argument to execve, so
-        // the kernel can find the actual binary.
-        let argv0_runfiles_path: Option<Vec<u8>> = if let Some(ref rf) = runfiles {
-            if let Some(ref dir_path) = rf.dir_path {
-                // Get the original (pre-resolution) arg0
-                let arg0_data = arg_placeholders[0];
-                let arg0_len = strlen(arg0_data);
-                if arg0_len > 0 {
-                    let mut path = Vec::from(dir_path.as_bytes());
-                    if !dir_path.ends_with('/') {
-                        path.push(b'/');
-                    }
-                    path.extend_from_slice(&arg0_data[..arg0_len]);
-                    path.push(0);
-                    Some(path)
-                } else {
-                    None
-                }
-            } else {
-                None
-            }
+        // Build the argv pointer array: embedded resolved + runtime + NULL.
+        let mut ptrs: Vec<*const u8> = Vec::with_capacity(launch.resolved.len() + runtime.len() + 1);
+        for a in launch.resolved {
+            ptrs.push(a.as_ptr());
+        }
+        for a in &runtime {
+            ptrs.push(a.as_ptr());
+        }
+        ptrs.push(core::ptr::null());
+
+        // The program to execute is the fully-resolved arg0; argv[0] may be overridden
+        // with the runfiles-relative path (must read program before overwriting ptrs[0]).
+        let program = launch.resolved[0].as_ptr();
+        if let Some(override0) = launch.argv0_override {
+            ptrs[0] = override0.as_ptr();
+        }
+
+        // Build the environment.
+        let (_env_data, env_ptrs) = if launch.export_env {
+            build_runfiles_environ(launch.runfiles)
         } else {
-            None
+            let mut p = Vec::new();
+            let mut e = sys::environ;
+            while !(*e).is_null() {
+                p.push(*e);
+                e = e.add(1);
+            }
+            p.push(core::ptr::null());
+            (Vec::new(), p)
         };
 
-        // Build pointer array from the resolved paths
-        let mut resolved_ptrs: Vec<*const u8> = Vec::with_capacity(resolved_paths.len() + 1);
-        for path in &resolved_paths {
-            resolved_ptrs.push(path.as_ptr());
-        }
-        // NULL-terminate the argv array
-        resolved_ptrs.push(core::ptr::null());
+        let ret = sys::execve(program, ptrs.as_ptr(), env_ptrs.as_ptr());
 
-        // Get the executable path (first argument) — fully resolved for the kernel
-        let executable = resolved_ptrs[0];
-
-        // Replace argv[0] with the runfiles-relative path if available.
-        // This must happen after building resolved_ptrs so the executable
-        // pointer captures the resolved path before we overwrite argv[0].
-        if let Some(ref argv0_path) = argv0_runfiles_path {
-            resolved_ptrs[0] = argv0_path.as_ptr();
-        }
-
-        // Build environment (with runfiles vars if export_runfiles_env is true)
-        // We need to keep the env_data alive until execve
-        let (_env_data, env_ptrs) = if export_runfiles_env {
-            build_runfiles_environ(runfiles.as_ref())
-        } else {
-            // Return environ directly wrapped in expected format
-            let mut ptrs = Vec::new();
-            let mut env_ptr = environ;
-            while !(*env_ptr).is_null() {
-                ptrs.push(*env_ptr);
-                env_ptr = env_ptr.add(1);
-            }
-            ptrs.push(core::ptr::null());
-            (Vec::new(), ptrs)
-        };
-
-        // Execute the target program
-        let ret = execve(executable, resolved_ptrs.as_ptr(), env_ptrs.as_ptr());
-
-        // If execve returns, it failed
-        // On macOS, libc's execve() returns -1 on failure and sets errno
-        // We need to read errno to get the actual error code
-        let errno = get_errno();
+        // execve only returns on failure; libc sets errno (reachable via __error()).
+        let errno = *sys::__error();
         print(b"ERROR: execve failed with errno ");
         print_number(errno as usize);
         print(b" (return code ");
@@ -856,4 +266,9 @@ pub extern "C" fn main(runtime_argc: i32, runtime_argv: *const *const u8) -> ! {
         print(b")\n");
         exit(1);
     }
+}
+
+#[no_mangle]
+pub extern "C" fn main(argc: i32, argv: *const *const u8) -> ! {
+    crate::run::main(RuntimeArgs { argc, argv })
 }

--- a/runfiles-stub/src/main.rs
+++ b/runfiles-stub/src/main.rs
@@ -1,13 +1,31 @@
-// Platform-specific implementations
-// Linux uses raw syscalls, macOS uses libc, Windows uses Win32 API
+// Tiny, cross-platform runfiles launcher template.
+//
+// The platform-agnostic logic lives in `common`, `runfiles`, `placeholders`, and `run`.
+// Each platform backend (`linux`/`macos`/`windows`, selected below) provides the OS
+// primitives, the entry point, and the process-launch step behind a small seam.
 
 #![no_std]
 #![no_main]
+
+extern crate alloc;
+
+use core::panic::PanicInfo;
 
 // Provide a personality symbol so linking succeeds with prebuilt libcore when
 // using panic=abort in a no_std binary.
 #[unsafe(no_mangle)]
 pub extern "C" fn rust_eh_personality() {}
+
+#[panic_handler]
+fn panic(_info: &PanicInfo) -> ! {
+    platform::exit(1)
+}
+
+mod allocator;
+mod common;
+mod placeholders;
+mod run;
+mod runfiles;
 
 #[cfg(target_os = "linux")]
 #[path = "linux.rs"]

--- a/runfiles-stub/src/placeholders.rs
+++ b/runfiles-stub/src/placeholders.rs
@@ -1,0 +1,105 @@
+// Placeholder bytes patched by `finalize-stub`. These MUST keep their exact byte
+// initializers, sizes, `#[used]`, and declaration order: the finalizer locates them
+// by scanning the binary image for these byte patterns (and the nth 256-byte run of
+// '@' for ARG0..ARG9). Only the link section name differs per OS, so the statics are
+// declared once in a macro that is invoked per platform with the right section.
+//
+// They are `static mut` on purpose: that prevents the compiler from const-folding the
+// template bytes into the code, so the patched values are actually read at runtime.
+
+pub const ARG_SIZE: usize = 256;
+
+macro_rules! define_placeholders {
+    ($section:literal) => {
+        #[used]
+        #[link_section = $section]
+        static mut ARGC_PLACEHOLDER: [u8; 32] = *b"@@RUNFILES_ARGC@@\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
+
+        #[used]
+        #[link_section = $section]
+        static mut TRANSFORM_FLAGS: [u8; 32] = *b"@@RUNFILES_TRANSFORM_FLAGS@@\0\0\0\0";
+
+        #[used]
+        #[link_section = $section]
+        static mut EXPORT_RUNFILES_ENV: [u8; 32] = *b"@@RUNFILES_EXPORT_ENV@@\0\0\0\0\0\0\0\0\0";
+
+        #[used]
+        #[link_section = $section]
+        static mut ARG0_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
+        #[used]
+        #[link_section = $section]
+        static mut ARG1_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
+        #[used]
+        #[link_section = $section]
+        static mut ARG2_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
+        #[used]
+        #[link_section = $section]
+        static mut ARG3_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
+        #[used]
+        #[link_section = $section]
+        static mut ARG4_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
+        #[used]
+        #[link_section = $section]
+        static mut ARG5_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
+        #[used]
+        #[link_section = $section]
+        static mut ARG6_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
+        #[used]
+        #[link_section = $section]
+        static mut ARG7_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
+        #[used]
+        #[link_section = $section]
+        static mut ARG8_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
+        #[used]
+        #[link_section = $section]
+        static mut ARG9_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
+    };
+}
+
+#[cfg(target_os = "linux")]
+define_placeholders!(".runfiles_stubs");
+#[cfg(target_os = "macos")]
+define_placeholders!("__DATA,__runfiles");
+#[cfg(target_os = "windows")]
+define_placeholders!(".runfiles");
+
+// Read a placeholder as a byte slice. Uses a raw pointer (not `&STATIC`) to avoid
+// forming a reference to a mutable static; the bytes are only read, never mutated.
+#[inline]
+fn read(ptr: *const u8, len: usize) -> &'static [u8] {
+    unsafe { core::slice::from_raw_parts(ptr, len) }
+}
+
+pub fn argc() -> &'static [u8] {
+    read(core::ptr::addr_of!(ARGC_PLACEHOLDER) as *const u8, 32)
+}
+pub fn transform_flags() -> &'static [u8] {
+    read(core::ptr::addr_of!(TRANSFORM_FLAGS) as *const u8, 32)
+}
+pub fn export_runfiles_env() -> &'static [u8] {
+    read(core::ptr::addr_of!(EXPORT_RUNFILES_ENV) as *const u8, 32)
+}
+
+pub fn arg(i: usize) -> &'static [u8] {
+    let ptr = match i {
+        0 => core::ptr::addr_of!(ARG0_PLACEHOLDER),
+        1 => core::ptr::addr_of!(ARG1_PLACEHOLDER),
+        2 => core::ptr::addr_of!(ARG2_PLACEHOLDER),
+        3 => core::ptr::addr_of!(ARG3_PLACEHOLDER),
+        4 => core::ptr::addr_of!(ARG4_PLACEHOLDER),
+        5 => core::ptr::addr_of!(ARG5_PLACEHOLDER),
+        6 => core::ptr::addr_of!(ARG6_PLACEHOLDER),
+        7 => core::ptr::addr_of!(ARG7_PLACEHOLDER),
+        8 => core::ptr::addr_of!(ARG8_PLACEHOLDER),
+        _ => core::ptr::addr_of!(ARG9_PLACEHOLDER),
+    };
+    read(ptr as *const u8, ARG_SIZE)
+}
+
+/// True if the placeholder still holds its unpatched template value.
+pub fn is_template_placeholder(placeholder: &[u8]) -> bool {
+    if placeholder.len() < 17 {
+        return false;
+    }
+    placeholder.starts_with(b"@@RUNFILES_")
+}

--- a/runfiles-stub/src/run.rs
+++ b/runfiles-stub/src/run.rs
@@ -1,0 +1,171 @@
+// Platform-agnostic launcher flow, shared by every backend.
+//
+// Each backend's entry point gathers the process's runtime arguments into a
+// `platform::RuntimeArgs` and calls `run::main`. This function parses the patched
+// placeholders, resolves the embedded arguments through runfiles, computes the
+// runfiles-relative argv[0], and hands a `Launch` to `platform::launch`, which performs
+// the OS-specific marshalling and process replacement/spawn (and never returns).
+
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+use crate::common::cstr_len;
+use crate::placeholders::{self, is_template_placeholder};
+use crate::platform;
+use crate::runfiles::Runfiles;
+
+/// Everything the backend needs to launch the target, in OS-neutral form.
+/// `resolved[0]` is the program to execute; bytes are NUL-terminated.
+pub struct Launch<'a> {
+    pub resolved: &'a [Vec<u8>],
+    /// Runfiles-relative argv[0] (used by Unix to preserve symlink walks; ignored on Windows).
+    #[allow(dead_code)] // unused on Windows (CreateProcessW derives argv[0] from the command line)
+    pub argv0_override: Option<&'a [u8]>,
+    pub runfiles: Option<&'a Runfiles>,
+    pub export_env: bool,
+}
+
+/// Print `msg` followed by the platform newline.
+fn eline(msg: &[u8]) {
+    platform::print(msg);
+    platform::print(platform::NEWLINE);
+}
+
+pub fn main(rt: platform::RuntimeArgs) -> ! {
+    // Reject an un-finalized template.
+    if is_template_placeholder(placeholders::argc()) {
+        eline(b"ERROR: This is a template stub runner.");
+        eline(b"You must finalize it by replacing the placeholders before use.");
+        eline(b"The ARGC_PLACEHOLDER has not been replaced.");
+        platform::exit(1);
+    }
+
+    // Parse argc (decimal, 1..=10).
+    let argc_str = placeholders::argc();
+    let argc_len = cstr_len(argc_str);
+    if argc_len == 0 {
+        eline(b"ERROR: ARGC is empty");
+        platform::exit(1);
+    }
+    let mut argc: usize = 0;
+    for &c in &argc_str[..argc_len] {
+        if c.is_ascii_digit() {
+            argc = argc * 10 + (c - b'0') as usize;
+        } else {
+            eline(b"ERROR: ARGC contains non-digit characters");
+            platform::exit(1);
+        }
+    }
+    if argc == 0 || argc > 10 {
+        eline(b"ERROR: Invalid argc (must be 1-10)");
+        platform::exit(1);
+    }
+
+    // Parse transform flags (decimal bitmask of which args to resolve).
+    let flags_str = placeholders::transform_flags();
+    let flags_len = cstr_len(flags_str);
+    let mut transform_flags: u32 = 0;
+    if !is_template_placeholder(flags_str) && flags_len > 0 {
+        for &c in &flags_str[..flags_len] {
+            if c.is_ascii_digit() {
+                transform_flags = transform_flags * 10 + (c - b'0') as u32;
+            } else {
+                eline(b"ERROR: TRANSFORM_FLAGS contains non-digit characters");
+                platform::exit(1);
+            }
+        }
+    }
+    // If flags are unset, default to transforming all args.
+    if flags_len == 0 || is_template_placeholder(flags_str) {
+        transform_flags = 0xFFFFFFFF;
+    }
+
+    // Parse export-runfiles-env flag (defaults to true).
+    let export_str = placeholders::export_runfiles_env();
+    let export_len = cstr_len(export_str);
+    let export_runfiles_env = if !is_template_placeholder(export_str) && export_len > 0 {
+        export_str[0] != b'0'
+    } else {
+        true
+    };
+
+    // Decide whether runfiles are needed at all.
+    let argc_mask = if argc >= 32 { 0xFFFFFFFF } else { (1u32 << argc) - 1 };
+    let needs_transform = (transform_flags & argc_mask) != 0;
+    let needs_runfiles = needs_transform || export_runfiles_env;
+
+    // argv[0] (the stub's own path) is the fallback for runfiles discovery.
+    let executable_path = rt.program_path();
+
+    let runfiles = if needs_runfiles {
+        match Runfiles::create(executable_path) {
+            Some(rf) => Some(rf),
+            None => {
+                eline(b"ERROR: Failed to initialize runfiles");
+                eline(b"Set RUNFILES_DIR or RUNFILES_MANIFEST_FILE, or ensure <executable>.runfiles/ directory exists");
+                platform::exit(1);
+            }
+        }
+    } else {
+        None
+    };
+
+    // Resolve each embedded argument (NUL-terminated). resolved[0] is the program.
+    let mut resolved: Vec<Vec<u8>> = Vec::with_capacity(argc);
+    for i in 0..argc {
+        let arg_data = placeholders::arg(i);
+        let arg_len = cstr_len(arg_data);
+        if arg_len == 0 {
+            platform::print(b"ERROR: Argument ");
+            platform::print(&[b'0' + i as u8]);
+            eline(b" is empty");
+            platform::exit(1);
+        }
+        let arg_slice = &arg_data[..arg_len];
+        let should_transform = (transform_flags & (1 << i)) != 0;
+
+        // Resolve through runfiles when marked and possible; otherwise use as-is.
+        let mut bytes = if should_transform {
+            match runfiles.as_ref().and_then(|rf| {
+                core::str::from_utf8(arg_slice).ok().and_then(|s| rf.rlocation(s))
+            }) {
+                Some(resolved_str) => Vec::from(resolved_str.as_bytes()),
+                None => arg_slice.to_vec(),
+            }
+        } else {
+            arg_slice.to_vec()
+        };
+        bytes.push(0);
+        resolved.push(bytes);
+    }
+
+    // Preserve argv[0] as a runfiles-relative path so tools that walk argv[0]'s
+    // parent symlinks (e.g. aspect_rules_py's venv_shim) can locate .runfiles. The
+    // fully-resolved path is still used as the program to execute.
+    let argv0_override: Option<Vec<u8>> = runfiles
+        .as_ref()
+        .and_then(|rf| rf.dir_path.as_ref())
+        .and_then(|dir| {
+            let arg0 = placeholders::arg(0);
+            let arg0_len = cstr_len(arg0);
+            if arg0_len == 0 {
+                return None;
+            }
+            let mut path = Vec::from(dir.as_bytes());
+            if !dir.ends_with('/') {
+                path.push(b'/');
+            }
+            path.extend_from_slice(&arg0[..arg0_len]);
+            path.push(0);
+            Some(path)
+        });
+
+    let launch = Launch {
+        resolved: &resolved,
+        argv0_override: argv0_override.as_deref(),
+        runfiles: runfiles.as_ref(),
+        export_env: export_runfiles_env,
+    };
+    platform::launch(&launch, &rt)
+}

--- a/runfiles-stub/src/runfiles.rs
+++ b/runfiles-stub/src/runfiles.rs
@@ -1,0 +1,132 @@
+// Platform-agnostic runfiles discovery and resolution. OS-specific behaviour
+// (path separators, absolute-path detection, file I/O) is reached through the
+// `platform` module so this logic is shared by every backend.
+
+extern crate alloc;
+
+use alloc::string::String;
+use alloc::vec::Vec;
+
+use crate::common::{cstr_len, Manifest};
+use crate::platform;
+
+pub enum RunfilesMode {
+    ManifestBased(Manifest),
+    DirectoryBased(String),
+}
+
+pub struct Runfiles {
+    mode: RunfilesMode,
+    // Paths for environment variables (when export_runfiles_env is true)
+    pub manifest_path: Option<String>, // RUNFILES_MANIFEST_FILE
+    pub dir_path: Option<String>,      // RUNFILES_DIR and JAVA_RUNFILES
+}
+
+impl Runfiles {
+    pub fn create(executable_path: Option<&[u8]>) -> Option<Self> {
+        // Try RUNFILES_MANIFEST_FILE first
+        if let Some(manifest_path) = platform::get_env_var(b"RUNFILES_MANIFEST_FILE") {
+            if !manifest_path.is_empty() {
+                // Create null-terminated path for load_manifest
+                let mut path_with_null = Vec::from(manifest_path.as_bytes());
+                path_with_null.push(0);
+
+                if let Some(manifest) = platform::load_manifest(&path_with_null) {
+                    return Some(Self {
+                        mode: RunfilesMode::ManifestBased(manifest),
+                        manifest_path: Some(manifest_path),
+                        dir_path: None,
+                    });
+                }
+            }
+        }
+
+        // Try RUNFILES_DIR
+        if let Some(runfiles_dir) = platform::get_env_var(b"RUNFILES_DIR") {
+            if !runfiles_dir.is_empty() {
+                return Some(Self {
+                    mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
+                    manifest_path: None,
+                    dir_path: Some(runfiles_dir),
+                });
+            }
+        }
+
+        // Try to find runfiles next to the executable:
+        // <executable>.runfiles_manifest file first (preferred), then
+        // <executable>.runfiles directory.
+        if let Some(exe_path) = executable_path {
+            let exe_len = cstr_len(exe_path);
+            if exe_len > 0 {
+                // Convert executable path to string (if valid UTF-8)
+                let exe_str = core::str::from_utf8(&exe_path[..exe_len]).ok()?;
+
+                // Try <executable>.runfiles_manifest file first
+                let manifest_file_path = String::from(exe_str) + ".runfiles_manifest";
+
+                // Add null terminator for the file open
+                let mut manifest_path_with_null = Vec::from(manifest_file_path.as_bytes());
+                manifest_path_with_null.push(0);
+
+                if let Some(manifest) = platform::load_manifest(&manifest_path_with_null) {
+                    // Also determine the runfiles directory for RUNFILES_DIR envvar
+                    let dir_path = String::from(exe_str) + ".runfiles";
+
+                    return Some(Self {
+                        mode: RunfilesMode::ManifestBased(manifest),
+                        manifest_path: Some(manifest_file_path),
+                        dir_path: Some(dir_path),
+                    });
+                }
+
+                // Try <executable>.runfiles directory
+                let runfiles_dir = String::from(exe_str) + ".runfiles";
+
+                // Add null terminator for the existence check
+                let mut dir_with_null = Vec::from(runfiles_dir.as_bytes());
+                dir_with_null.push(0);
+
+                if platform::path_exists(&dir_with_null) {
+                    return Some(Self {
+                        mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
+                        manifest_path: None,
+                        dir_path: Some(runfiles_dir),
+                    });
+                }
+            }
+        }
+
+        None
+    }
+
+    pub fn rlocation(&self, path: &str) -> Option<String> {
+        // If path is absolute, don't resolve through runfiles.
+        if platform::is_absolute(path) {
+            return None;
+        }
+
+        match &self.mode {
+            RunfilesMode::ManifestBased(manifest) => {
+                if let Some(resolved) = manifest.lookup(path) {
+                    return Some(platform::to_native_path(resolved));
+                }
+                // Prefix match for paths within TreeArtifacts
+                if let Some((resolved_prefix, suffix)) = manifest.prefix_lookup(path) {
+                    let mut result = String::from(resolved_prefix);
+                    result.push_str(suffix);
+                    return Some(platform::to_native_path(&result));
+                }
+                None
+            }
+            RunfilesMode::DirectoryBased(dir) => {
+                let mut result = dir.clone();
+                // Add separator if needed.
+                if !result.ends_with('/') && !result.ends_with(platform::SEP) {
+                    result.push(platform::SEP);
+                }
+                result.push_str(&platform::to_native_path(path));
+                Some(result)
+            }
+        }
+    }
+}

--- a/runfiles-stub/src/windows.rs
+++ b/runfiles-stub/src/windows.rs
@@ -1,42 +1,14 @@
-// Windows-specific implementation using Windows API
-// Uses kernel32.dll functions
-
-extern crate alloc;
+// Windows backend: kernel32 (Win32) primitives, a `main` entry that parses the
+// command line, and a CreateProcessW-based launch (spawn + wait + propagate exit code).
+// Runtime args stay UTF-16; embedded args are widened from UTF-8.
 
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
-use core::alloc::{GlobalAlloc, Layout};
-use core::cell::UnsafeCell;
-use core::panic::PanicInfo;
-use talc::{ClaimOnOom, Span, Talc};
 
-// Global allocator using talc with a static memory arena
-// 8 MiB should be plenty for manifest parsing, path resolution, and environment handling
-static mut ARENA: [u8; 8 * 1024 * 1024] = [0; 8 * 1024 * 1024];
-
-// Simple wrapper for single-threaded use (no locking needed)
-struct TalcAllocator(UnsafeCell<Talc<ClaimOnOom>>);
-unsafe impl Sync for TalcAllocator {}
-
-unsafe impl GlobalAlloc for TalcAllocator {
-    unsafe fn alloc(&self, layout: Layout) -> *mut u8 {
-        (*self.0.get()).malloc(layout).map_or(core::ptr::null_mut(), |p| p.as_ptr())
-    }
-    unsafe fn dealloc(&self, ptr: *mut u8, layout: Layout) {
-        (*self.0.get()).free(core::ptr::NonNull::new_unchecked(ptr), layout);
-    }
-}
-
-#[global_allocator]
-static ALLOCATOR: TalcAllocator = TalcAllocator(UnsafeCell::new(Talc::new(unsafe {
-    ClaimOnOom::new(Span::from_array(core::ptr::addr_of!(ARENA).cast_mut()))
-})));
-
-#[panic_handler]
-fn panic(_info: &PanicInfo) -> ! {
-    unsafe { ExitProcess(1) }
-}
+use crate::common::Manifest;
+use crate::run::Launch;
+use crate::runfiles::Runfiles;
 
 // Windows API types
 type DWORD = u32;
@@ -60,6 +32,7 @@ const PAGE_READONLY: DWORD = 0x02;
 const FILE_MAP_READ: DWORD = 0x04;
 
 // STARTUPINFOW structure (wide char version for CreateProcessW)
+#[allow(non_snake_case)] // Win32 field names
 #[repr(C)]
 struct STARTUPINFOW {
     cb: DWORD,
@@ -83,6 +56,7 @@ struct STARTUPINFOW {
 }
 
 // PROCESS_INFORMATION structure
+#[allow(non_snake_case)] // Win32 field names
 #[repr(C)]
 struct PROCESS_INFORMATION {
     hProcess: HANDLE,
@@ -144,182 +118,74 @@ extern "system" {
     fn GetCommandLineW() -> *const u16;
     fn WaitForSingleObject(hHandle: HANDLE, dwMilliseconds: DWORD) -> DWORD;
     fn GetExitCodeProcess(hProcess: HANDLE, lpExitCode: *mut DWORD) -> BOOL;
+    fn GetEnvironmentStringsW() -> *mut u16;
+    fn FreeEnvironmentStringsW(lpszEnvironmentBlock: *mut u16) -> BOOL;
 }
 
-// We don't use CommandLineToArgvW to avoid shell32.dll dependency
-// Instead we implement custom command-line parsing following Windows rules
+// --- path semantics ---
+pub const SEP: char = '\\';
+pub const NEWLINE: &[u8] = b"\r\n";
 
-// Parse Windows command line into arguments
-// Returns number of arguments parsed (excluding argv[0])
-// Stores argument pointers in output array
-fn parse_command_line(
-    cmdline: *const u16,
-    argv_out: &mut [*const u16; 128],
-    argv_len_out: &mut [usize; 128],
-) -> usize {
-    unsafe {
-        let mut pos = 0usize;
-        let mut argc = 0usize;
-
-        // Skip leading whitespace
-        while *cmdline.add(pos) != 0 && (*cmdline.add(pos) == b' ' as u16 || *cmdline.add(pos) == b'\t' as u16) {
-            pos += 1;
-        }
-
-        // Skip argv[0] (executable path)
-        let quoted = *cmdline.add(pos) == b'"' as u16;
-        if quoted {
-            pos += 1; // Skip opening quote
-            while *cmdline.add(pos) != 0 && *cmdline.add(pos) != b'"' as u16 {
-                pos += 1;
-            }
-            if *cmdline.add(pos) == b'"' as u16 {
-                pos += 1; // Skip closing quote
-            }
-        } else {
-            while *cmdline.add(pos) != 0 && *cmdline.add(pos) != b' ' as u16 && *cmdline.add(pos) != b'\t' as u16 {
-                pos += 1;
-            }
-        }
-
-        // Parse remaining arguments
-        while *cmdline.add(pos) != 0 && argc < 128 {
-            // Skip whitespace
-            while *cmdline.add(pos) != 0 && (*cmdline.add(pos) == b' ' as u16 || *cmdline.add(pos) == b'\t' as u16) {
-                pos += 1;
-            }
-
-            if *cmdline.add(pos) == 0 {
-                break;
-            }
-
-            // Start of argument
-            let arg_start = pos;
-            let in_quotes = *cmdline.add(pos) == b'"' as u16;
-
-            if in_quotes {
-                pos += 1; // Skip opening quote
-                // Find closing quote
-                while *cmdline.add(pos) != 0 && *cmdline.add(pos) != b'"' as u16 {
-                    pos += 1;
-                }
-                // Store argument (skip quotes in length calculation)
-                argv_out[argc] = cmdline.add(arg_start + 1);
-                argv_len_out[argc] = pos - arg_start - 1;
-
-                if *cmdline.add(pos) == b'"' as u16 {
-                    pos += 1; // Skip closing quote
-                }
-            } else {
-                // Unquoted argument - find whitespace
-                while *cmdline.add(pos) != 0 && *cmdline.add(pos) != b' ' as u16 && *cmdline.add(pos) != b'\t' as u16 {
-                    pos += 1;
-                }
-                argv_out[argc] = cmdline.add(arg_start);
-                argv_len_out[argc] = pos - arg_start;
-            }
-
-            argc += 1;
-        }
-
-        argc
-    }
+pub fn is_absolute(path: &str) -> bool {
+    let b = path.as_bytes();
+    b.len() >= 2
+        && ((b[0].is_ascii_alphabetic() && b[1] == b':') || (b[0] == b'\\' && b[1] == b'\\'))
 }
 
-// String utilities
-fn print(s: &[u8]) {
+pub fn to_native_path(s: &str) -> String {
+    s.replace('/', "\\")
+}
+
+// --- primitives ---
+pub fn print(s: &[u8]) {
     unsafe {
         let stdout = GetStdHandle(STD_OUTPUT_HANDLE);
         let mut written: DWORD = 0;
-        WriteFile(
-            stdout,
-            s.as_ptr(),
-            s.len() as DWORD,
-            &mut written,
+        WriteFile(stdout, s.as_ptr(), s.len() as DWORD, &mut written, core::ptr::null_mut());
+    }
+}
+
+pub fn exit(code: i32) -> ! {
+    unsafe { ExitProcess(code as u32) }
+}
+
+// Directory/file existence check by trying to open it (needs backup semantics for dirs).
+pub fn path_exists(path: &[u8]) -> bool {
+    const FILE_FLAG_BACKUP_SEMANTICS: DWORD = 0x02000000;
+    unsafe {
+        let handle = CreateFileA(
+            path.as_ptr(),
+            GENERIC_READ,
+            0,
+            core::ptr::null_mut(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS,
             core::ptr::null_mut(),
         );
-    }
-}
-
-fn print_number(mut n: usize) {
-    let mut buf = [0u8; 20]; // Enough for 64-bit numbers
-    let mut i = 0;
-
-    if n == 0 {
-        print(b"0");
-        return;
-    }
-
-    while n > 0 {
-        buf[i] = b'0' + (n % 10) as u8;
-        n /= 10;
-        i += 1;
-    }
-
-    // Print in reverse order
-    while i > 0 {
-        i -= 1;
-        print(&buf[i..i+1]);
-    }
-}
-
-fn str_eq(a: &[u8], b: &[u8]) -> bool {
-    if a.len() != b.len() {
-        return false;
-    }
-    for i in 0..a.len() {
-        if a[i] != b[i] {
-            return false;
+        if handle != INVALID_HANDLE_VALUE {
+            CloseHandle(handle);
+            true
+        } else {
+            false
         }
     }
-    true
 }
 
-fn str_starts_with(haystack: &[u8], needle: &[u8]) -> bool {
-    if haystack.len() < needle.len() {
-        return false;
-    }
-    str_eq(&haystack[..needle.len()], needle)
-}
-
-fn find_byte(haystack: &[u8], needle: u8) -> Option<usize> {
-    for i in 0..haystack.len() {
-        if haystack[i] == needle {
-            return Some(i);
-        }
-    }
-    None
-}
-
-// Environment variable reading - returns String
-fn get_env_var(name: &[u8]) -> Option<String> {
+// Environment variable lookup (two-call GetEnvironmentVariableA pattern).
+pub fn get_env_var(name: &[u8]) -> Option<String> {
     unsafe {
-        // Ensure name is null-terminated
         let mut name_with_null = name.to_vec();
         name_with_null.push(0);
 
-        // First call to get required size
-        let size = GetEnvironmentVariableA(
-            name_with_null.as_ptr(),
-            core::ptr::null_mut(),
-            0,
-        );
-
+        let size = GetEnvironmentVariableA(name_with_null.as_ptr(), core::ptr::null_mut(), 0);
         if size == 0 {
             return None;
         }
-
-        // Allocate buffer and get value
         let mut buf = vec![0u8; size as usize];
-        let actual_size = GetEnvironmentVariableA(
-            name_with_null.as_ptr(),
-            buf.as_mut_ptr(),
-            buf.len() as DWORD,
-        );
-
+        let actual_size =
+            GetEnvironmentVariableA(name_with_null.as_ptr(), buf.as_mut_ptr(), buf.len() as DWORD);
         if actual_size > 0 && actual_size < buf.len() as DWORD {
             buf.truncate(actual_size as usize);
-            // Convert to String, returning None if not valid UTF-8
             String::from_utf8(buf).ok()
         } else {
             None
@@ -327,106 +193,13 @@ fn get_env_var(name: &[u8]) -> Option<String> {
     }
 }
 
-// Memory-mapped manifest: a pointer/length pair into the mapped file view. The
-// manifest is scanned lazily on each lookup (O(n)), so no per-entry allocation
-// is needed and arbitrarily large manifests are supported.
-struct Manifest {
-    ptr: *const u8,
-    len: usize,
-}
-
-impl Manifest {
-    #[inline]
-    fn data(&self) -> &[u8] {
-        // Safety: ptr/len come from a successful MapViewOfFile that we leak for
-        // the lifetime of the process (until ExitProcess reclaims it).
-        unsafe { core::slice::from_raw_parts(self.ptr, self.len) }
-    }
-
-    fn lookup(&self, key: &str) -> Option<&str> {
-        let key_bytes = key.as_bytes();
-        for (k, v) in ManifestLines::new(self.data()) {
-            if k == key_bytes {
-                return core::str::from_utf8(v).ok();
-            }
-        }
-        None
-    }
-
-    /// Find the longest manifest entry whose key is a prefix of `path` at a '/' boundary.
-    /// Returns (resolved_value, suffix) where suffix includes the leading '/'.
-    fn prefix_lookup<'a, 'b>(&'a self, path: &'b str) -> Option<(&'a str, &'b str)> {
-        let path_bytes = path.as_bytes();
-        let mut best: Option<(&'a str, &'b str)> = None;
-        let mut best_len: usize = 0;
-        for (k, v) in ManifestLines::new(self.data()) {
-            if path_bytes.len() > k.len()
-                && k.len() > best_len
-                && &path_bytes[..k.len()] == k
-                && path_bytes[k.len()] == b'/'
-            {
-                // Values were owned UTF-8 Strings before; keep that guarantee by
-                // only considering candidates whose value is valid UTF-8.
-                if let Ok(value) = core::str::from_utf8(v) {
-                    best_len = k.len();
-                    best = Some((value, &path[k.len()..]));
-                }
-            }
-        }
-        best
-    }
-}
-
-/// Iterator over `(key, value)` byte slices of a Bazel runfiles MANIFEST.
-/// Replicates `str::lines()` + `split_once(' ')`: split on '\n', strip one
-/// trailing '\r' (CRLF), and skip lines without a space (e.g. the
-/// "<workspace>/.runfile" marker).
-struct ManifestLines<'a> {
-    rest: &'a [u8],
-}
-
-impl<'a> ManifestLines<'a> {
-    fn new(data: &'a [u8]) -> Self {
-        Self { rest: data }
-    }
-}
-
-impl<'a> Iterator for ManifestLines<'a> {
-    type Item = (&'a [u8], &'a [u8]);
-
-    fn next(&mut self) -> Option<(&'a [u8], &'a [u8])> {
-        while !self.rest.is_empty() {
-            let (mut line, remainder) = match find_byte(self.rest, b'\n') {
-                Some(nl) => (&self.rest[..nl], &self.rest[nl + 1..]),
-                None => (self.rest, &self.rest[self.rest.len()..]),
-            };
-            self.rest = remainder;
-            // Strip one trailing '\r' (handles CRLF line endings).
-            if let Some((&b'\r', head)) = line.split_last() {
-                line = head;
-            }
-            if let Some(sp) = find_byte(line, b' ') {
-                return Some((&line[..sp], &line[sp + 1..]));
-            }
-            // No space -> skip this line and continue.
-        }
-        None
-    }
-}
-
-// Load manifest file by memory-mapping it read-only. Returns None on open
-// failure, empty file (CreateFileMapping of zero bytes fails), or mapping
-// failure.
-fn load_manifest(path: &[u8]) -> Option<Manifest> {
+// Memory-map the manifest read-only. `path` is NUL-terminated by the caller.
+pub fn load_manifest(path: &[u8]) -> Option<Manifest> {
     unsafe {
-        // Ensure path is null-terminated
-        let mut path_with_null = path.to_vec();
-        path_with_null.push(0);
-
         // FILE_SHARE_READ lets the child process (which inherits
         // RUNFILES_MANIFEST_FILE) open the same manifest for reading.
         let file = CreateFileA(
-            path_with_null.as_ptr(),
+            path.as_ptr(),
             GENERIC_READ,
             FILE_SHARE_READ,
             core::ptr::null_mut(),
@@ -434,7 +207,6 @@ fn load_manifest(path: &[u8]) -> Option<Manifest> {
             FILE_ATTRIBUTE_NORMAL,
             core::ptr::null_mut(),
         );
-
         if file == INVALID_HANDLE_VALUE {
             return None;
         }
@@ -461,8 +233,7 @@ fn load_manifest(path: &[u8]) -> Option<Manifest> {
         }
 
         let view = MapViewOfFile(mapping, FILE_MAP_READ, 0, 0, 0);
-        // The view keeps its own reference to the section; both handles can be
-        // closed and the view stays valid.
+        // The view keeps its own reference to the section; both handles can be closed.
         CloseHandle(mapping);
         CloseHandle(file);
         if view.is_null() {
@@ -470,895 +241,378 @@ fn load_manifest(path: &[u8]) -> Option<Manifest> {
         }
 
         // Leak the view: ExitProcess reclaims it.
-        Some(Manifest { ptr: view as *const u8, len })
+        Some(Manifest::from_mapping(view as *const u8, len))
     }
 }
 
-// Runfiles implementation using String for dynamic path storage
-enum RunfilesMode {
-    ManifestBased(Manifest),
-    DirectoryBased(String),
-}
+// Build the UTF-16 environment block (sorted, double-NUL terminated) with the runfiles
+// variables merged in. Returns an owned Vec the caller keeps alive while CreateProcessW
+// reads it. Previously this used a 128 KB `static mut`; a heap Vec removes the mutable
+// static, the fixed size cap, and the abort-on-overflow path, while preserving the exact
+// sorted-insertion ordering. Windows requires the block sorted alphabetically by name;
+// GetEnvironmentStringsW() already returns it sorted, so we insert our vars in place.
+fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
+    let mut buf: Vec<u16> = Vec::with_capacity(8192);
 
-struct Runfiles {
-    mode: RunfilesMode,
-    // Paths for environment variables (when export_runfiles_env is true)
-    manifest_path: Option<String>, // RUNFILES_MANIFEST_FILE
-    dir_path: Option<String>,      // RUNFILES_DIR and JAVA_RUNFILES
-}
-
-impl Runfiles {
-    fn create(executable_path: Option<&[u8]>) -> Option<Self> {
-        // Step 1: Try RUNFILES_MANIFEST_FILE envvar first
-        if let Some(manifest_path) = get_env_var(b"RUNFILES_MANIFEST_FILE") {
-            if !manifest_path.is_empty() {
-                // Create null-terminated path for load_manifest
-                let mut path_with_null = Vec::from(manifest_path.as_bytes());
-                path_with_null.push(0);
-
-                if let Some(manifest) = load_manifest(&path_with_null) {
-                    return Some(Self {
-                        mode: RunfilesMode::ManifestBased(manifest),
-                        manifest_path: Some(manifest_path),
-                        dir_path: None,
-                    });
-                }
-            }
+    // Append "KEY=VALUE\0", widening bytes to UTF-16.
+    let push_var = |buf: &mut Vec<u16>, key: &[u8], value: &str| {
+        for &b in key {
+            buf.push(b as u16);
         }
-
-        // Step 2: Try RUNFILES_DIR envvar
-        if let Some(runfiles_dir) = get_env_var(b"RUNFILES_DIR") {
-            if !runfiles_dir.is_empty() {
-                return Some(Self {
-                    mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
-                    manifest_path: None,
-                    dir_path: Some(runfiles_dir),
-                });
-            }
+        buf.push(b'=' as u16);
+        for &b in value.as_bytes() {
+            buf.push(b as u16);
         }
+        buf.push(0);
+    };
 
-        // Step 3: Try to find runfiles next to the executable
-        // Check for <executable>.runfiles_manifest file (preferred)
-        // Then check for <executable>.runfiles directory
-        if let Some(exe_path) = executable_path {
-            let exe_len = strlen(exe_path);
-            if exe_len > 0 {
-                // Convert executable path to string (if valid UTF-8)
-                let exe_str = core::str::from_utf8(&exe_path[..exe_len]).ok()?;
-
-                // Try <executable>.runfiles_manifest file first
-                let manifest_file_path = String::from(exe_str) + ".runfiles_manifest";
-
-                // Add null terminator for syscall
-                let mut manifest_path_with_null = Vec::from(manifest_file_path.as_bytes());
-                manifest_path_with_null.push(0);
-
-                // Try to load the manifest file
-                if let Some(manifest) = load_manifest(&manifest_path_with_null) {
-                    // Also determine the runfiles directory for RUNFILES_DIR envvar
-                    // The directory is <executable>.runfiles
-                    let dir_path = String::from(exe_str) + ".runfiles";
-
-                    return Some(Self {
-                        mode: RunfilesMode::ManifestBased(manifest),
-                        manifest_path: Some(manifest_file_path),
-                        dir_path: Some(dir_path),
-                    });
-                }
-
-                // Try <executable>.runfiles directory
-                let runfiles_dir = String::from(exe_str) + ".runfiles";
-
-                // Add null terminator for CreateFileA
-                let mut dir_with_null = Vec::from(runfiles_dir.as_bytes());
-                dir_with_null.push(0);
-
-                // Check if directory exists by trying to open it
-                unsafe {
-                    const FILE_FLAG_BACKUP_SEMANTICS: DWORD = 0x02000000;  // Needed to open directories
-                    let handle = CreateFileA(
-                        dir_with_null.as_ptr(),
-                        GENERIC_READ,
-                        0,
-                        core::ptr::null_mut(),
-                        OPEN_EXISTING,
-                        FILE_FLAG_BACKUP_SEMANTICS,
-                        core::ptr::null_mut(),
-                    );
-                    if handle != INVALID_HANDLE_VALUE {
-                        CloseHandle(handle);
-                        return Some(Self {
-                            mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
-                            manifest_path: None,
-                            dir_path: Some(runfiles_dir),
-                        });
-                    }
-                }
-            }
-        }
-
-        None
-    }
-
-    fn rlocation(&self, path: &str) -> Option<String> {
-        // If path is absolute (Windows: starts with drive letter or \\), don't resolve
-        let path_bytes = path.as_bytes();
-        if path_bytes.len() >= 2 && ((path_bytes[0].is_ascii_alphabetic() && path_bytes[1] == b':') || (path_bytes[0] == b'\\' && path_bytes[1] == b'\\')) {
-            return None;
-        }
-
-        match &self.mode {
-            RunfilesMode::ManifestBased(manifest) => {
-                if let Some(resolved) = manifest.lookup(path) {
-                    // Convert forward slashes to backslashes
-                    return Some(resolved.replace('/', "\\"));
-                }
-                // Prefix match for paths within TreeArtifacts
-                if let Some((resolved_prefix, suffix)) = manifest.prefix_lookup(path) {
-                    let mut result = String::from(resolved_prefix);
-                    result.push_str(suffix);
-                    return Some(result.replace('/', "\\"));
-                }
-                None
-            }
-            RunfilesMode::DirectoryBased(dir) => {
-                let mut result = dir.clone();
-
-                // Add separator if needed
-                if !result.ends_with('\\') && !result.ends_with('/') {
-                    result.push('\\');
-                }
-
-                // Append path, converting forward slashes to backslashes
-                result.push_str(&path.replace('/', "\\"));
-
-                Some(result)
-            }
-        }
-    }
-}
-
-// Environment building for export mode
-// Windows environments can be large (32KB+), use 128KB to be safe
-const MAX_ENV_SIZE: usize = 131072;
-
-// External Windows API function for environment access
-extern "system" {
-    fn GetEnvironmentStringsW() -> *mut u16;
-    fn FreeEnvironmentStringsW(lpszEnvironmentBlock: *mut u16) -> BOOL;
-}
-
-static mut MODIFIED_ENV_DATA: [u16; MAX_ENV_SIZE / 2] = [0; MAX_ENV_SIZE / 2];
-
-fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> *mut core::ffi::c_void {
     unsafe {
-        // Windows requires environment variables to be sorted alphabetically
-        // GetEnvironmentStringsW() already returns sorted environment
-        // We need to maintain sorted order when adding our variables
-
-        let mut data_pos = 0usize;
-        let max_pos = MODIFIED_ENV_DATA.len();
-
-        // Helper to check bounds before writing
-        let check_bounds = |pos: usize, needed: usize| -> bool {
-            pos + needed <= max_pos
-        };
-
-        // Copy existing environment and insert runfiles vars in correct sorted position
         let env_block = GetEnvironmentStringsW();
         if env_block.is_null() {
-            // No parent environment, just add runfiles vars in sorted order
-            let mut add_env = |key: &[u8], value: &str| -> bool {
-                let value_bytes = value.as_bytes();
-                let total_len = key.len() + 1 + value_bytes.len() + 1; // key + '=' + value + '\0'
-                if !check_bounds(data_pos, total_len) {
-                    return false;
-                }
-
-                for &b in key {
-                    MODIFIED_ENV_DATA[data_pos] = b as u16;
-                    data_pos += 1;
-                }
-                MODIFIED_ENV_DATA[data_pos] = b'=' as u16;
-                data_pos += 1;
-                for &b in value_bytes {
-                    MODIFIED_ENV_DATA[data_pos] = b as u16;
-                    data_pos += 1;
-                }
-                MODIFIED_ENV_DATA[data_pos] = 0;
-                data_pos += 1;
-                true
-            };
-
+            // No parent environment: add runfiles vars in sorted order.
             if let Some(rf) = runfiles {
                 if let Some(ref path) = rf.dir_path {
-                    if !add_env(b"JAVA_RUNFILES", path) {
-                        print(b"ERROR: Failed to add JAVA_RUNFILES to environment\r\n");
-                        print(b"Environment buffer limit exceeded. Total size limit: ");
-                        print_number(MAX_ENV_SIZE);
-                        print(b" bytes\r\n");
-                        ExitProcess(1);
-                    }
-                    if !add_env(b"RUNFILES_DIR", path) {
-                        print(b"ERROR: Failed to add RUNFILES_DIR to environment\r\n");
-                        print(b"Environment buffer limit exceeded. Total size limit: ");
-                        print_number(MAX_ENV_SIZE);
-                        print(b" bytes\r\n");
-                        ExitProcess(1);
-                    }
+                    push_var(&mut buf, b"JAVA_RUNFILES", path);
+                    push_var(&mut buf, b"RUNFILES_DIR", path);
                 }
                 if let Some(ref path) = rf.manifest_path {
-                    if !add_env(b"RUNFILES_MANIFEST_FILE", path) {
-                        print(b"ERROR: Failed to add RUNFILES_MANIFEST_FILE to environment\r\n");
-                        print(b"Environment buffer limit exceeded. Total size limit: ");
-                        print_number(MAX_ENV_SIZE);
-                        print(b" bytes\r\n");
-                        ExitProcess(1);
-                    }
+                    push_var(&mut buf, b"RUNFILES_MANIFEST_FILE", path);
                 }
             }
         } else {
-            // Iterate through existing environment and insert runfiles vars at correct position
             let mut pos = 0;
-            let mut java_runfiles_inserted = false;
-            let mut runfiles_dir_inserted = false;
-            let mut runfiles_manifest_inserted = false;
-            let mut env_dropped = false;
+            let mut java_inserted = false;
+            let mut dir_inserted = false;
+            let mut manifest_inserted = false;
 
             loop {
                 let entry_start = pos;
                 while *env_block.add(pos) != 0 {
                     pos += 1;
-                    if pos > 65536 { break; } // safety: MAX_ENV_SIZE / 2
                 }
-
                 let entry_len = pos - entry_start;
-                if entry_len == 0 { break; }
-
+                if entry_len == 0 {
+                    break;
+                }
                 let entry_ptr = env_block.add(entry_start);
 
-                // Check if we should skip existing runfiles vars
-                let should_skip =
-                    (entry_len > 23 && {
-                        let mut matches = true;
-                        for i in 0..23 {
-                            if *entry_ptr.add(i) != b"RUNFILES_MANIFEST_FILE="[i] as u16 {
-                                matches = false;
-                                break;
-                            }
-                        }
-                        matches
-                    }) ||
-                    (entry_len > 13 && {
-                        let mut matches = true;
-                        for i in 0..13 {
-                            if *entry_ptr.add(i) != b"RUNFILES_DIR="[i] as u16 {
-                                matches = false;
-                                break;
-                            }
-                        }
-                        matches
-                    }) ||
-                    (entry_len > 14 && {
-                        let mut matches = true;
-                        for i in 0..14 {
-                            if *entry_ptr.add(i) != b"JAVA_RUNFILES="[i] as u16 {
-                                matches = false;
-                                break;
-                            }
-                        }
-                        matches
-                    });
+                // Skip existing runfiles vars (we re-insert our own).
+                let prefixed = |needle: &[u8]| -> bool {
+                    entry_len > needle.len()
+                        && (0..needle.len()).all(|i| *entry_ptr.add(i) == needle[i] as u16)
+                };
+                let should_skip = prefixed(b"RUNFILES_MANIFEST_FILE=")
+                    || prefixed(b"RUNFILES_DIR=")
+                    || prefixed(b"JAVA_RUNFILES=");
 
                 if !should_skip {
-                    // Helper to compare var name with a target name (case-insensitive, stops at '=')
+                    // Case-insensitive "does this entry sort after `target`?"
                     let var_comes_after = |target: &[u8]| -> bool {
+                        let upper = |c: u16| if (b'a' as u16..=b'z' as u16).contains(&c) { c - 32 } else { c };
                         for i in 0..target.len().min(entry_len) {
-                            let entry_char = *entry_ptr.add(i);
-                            let target_char = target[i] as u16;
-
-                            // Convert both to uppercase for case-insensitive comparison
-                            let entry_upper = if entry_char >= b'a' as u16 && entry_char <= b'z' as u16 {
-                                entry_char - 32
-                            } else {
-                                entry_char
-                            };
-                            let target_upper = if target_char >= b'a' as u16 && target_char <= b'z' as u16 {
-                                target_char - 32
-                            } else {
-                                target_char
-                            };
-
-                            if entry_upper != target_upper {
-                                return entry_upper > target_upper;
+                            let e = upper(*entry_ptr.add(i));
+                            let t = upper(target[i] as u16);
+                            if e != t {
+                                return e > t;
                             }
                         }
                         entry_len > target.len()
                     };
 
-                    // Insert JAVA_RUNFILES if needed
-                    if !java_runfiles_inserted && var_comes_after(b"JAVA_RUNFILES") {
+                    if !java_inserted && var_comes_after(b"JAVA_RUNFILES") {
                         if let Some(rf) = runfiles {
                             if let Some(ref path) = rf.dir_path {
-                                let path_bytes = path.as_bytes();
-                                let total_len = 14 + path_bytes.len() + 1; // "JAVA_RUNFILES=" + value + '\0'
-                                if !check_bounds(data_pos, total_len) {
-                                    env_dropped = true;
-                                } else {
-                                    for &b in b"JAVA_RUNFILES=" {
-                                        MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                        data_pos += 1;
-                                    }
-                                    for &b in path_bytes {
-                                        MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                        data_pos += 1;
-                                    }
-                                    MODIFIED_ENV_DATA[data_pos] = 0;
-                                    data_pos += 1;
-                                }
+                                push_var(&mut buf, b"JAVA_RUNFILES", path);
                             }
                         }
-                        java_runfiles_inserted = true;
+                        java_inserted = true;
                     }
-
-                    // Insert RUNFILES_DIR if needed
-                    if !runfiles_dir_inserted && var_comes_after(b"RUNFILES_DIR") {
+                    if !dir_inserted && var_comes_after(b"RUNFILES_DIR") {
                         if let Some(rf) = runfiles {
                             if let Some(ref path) = rf.dir_path {
-                                let path_bytes = path.as_bytes();
-                                let total_len = 13 + path_bytes.len() + 1; // "RUNFILES_DIR=" + value + '\0'
-                                if !check_bounds(data_pos, total_len) {
-                                    env_dropped = true;
-                                } else {
-                                    for &b in b"RUNFILES_DIR=" {
-                                        MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                        data_pos += 1;
-                                    }
-                                    for &b in path_bytes {
-                                        MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                        data_pos += 1;
-                                    }
-                                    MODIFIED_ENV_DATA[data_pos] = 0;
-                                    data_pos += 1;
-                                }
+                                push_var(&mut buf, b"RUNFILES_DIR", path);
                             }
                         }
-                        runfiles_dir_inserted = true;
+                        dir_inserted = true;
                     }
-
-                    // Insert RUNFILES_MANIFEST_FILE if needed
-                    if !runfiles_manifest_inserted && var_comes_after(b"RUNFILES_MANIFEST_FILE") {
+                    if !manifest_inserted && var_comes_after(b"RUNFILES_MANIFEST_FILE") {
                         if let Some(rf) = runfiles {
                             if let Some(ref path) = rf.manifest_path {
-                                let path_bytes = path.as_bytes();
-                                let total_len = 23 + path_bytes.len() + 1; // "RUNFILES_MANIFEST_FILE=" + value + '\0'
-                                if !check_bounds(data_pos, total_len) {
-                                    env_dropped = true;
-                                } else {
-                                    for &b in b"RUNFILES_MANIFEST_FILE=" {
-                                        MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                        data_pos += 1;
-                                    }
-                                    for &b in path_bytes {
-                                        MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                        data_pos += 1;
-                                    }
-                                    MODIFIED_ENV_DATA[data_pos] = 0;
-                                    data_pos += 1;
-                                }
+                                push_var(&mut buf, b"RUNFILES_MANIFEST_FILE", path);
                             }
                         }
-                        runfiles_manifest_inserted = true;
+                        manifest_inserted = true;
                     }
 
-                    // Copy this environment variable
-                    if data_pos + entry_len + 1 <= MODIFIED_ENV_DATA.len() {
-                        for i in 0..entry_len {
-                            MODIFIED_ENV_DATA[data_pos + i] = *entry_ptr.add(i);
-                        }
-                        MODIFIED_ENV_DATA[data_pos + entry_len] = 0;
-                        data_pos += entry_len + 1;
-                    } else {
-                        env_dropped = true;
+                    // Copy this environment variable.
+                    for i in 0..entry_len {
+                        buf.push(*entry_ptr.add(i));
                     }
+                    buf.push(0);
                 }
 
                 pos += 1;
             }
 
-            // Add any remaining runfiles vars that weren't inserted yet
-            if !java_runfiles_inserted {
-                if let Some(rf) = runfiles {
+            // Append any runfiles vars that sort after every existing entry.
+            if let Some(rf) = runfiles {
+                if !java_inserted {
                     if let Some(ref path) = rf.dir_path {
-                        let path_bytes = path.as_bytes();
-                        let total_len = 14 + path_bytes.len() + 1;
-                        if !check_bounds(data_pos, total_len) {
-                            env_dropped = true;
-                        } else {
-                            for &b in b"JAVA_RUNFILES=" {
-                                MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                data_pos += 1;
-                            }
-                            for &b in path_bytes {
-                                MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                data_pos += 1;
-                            }
-                            MODIFIED_ENV_DATA[data_pos] = 0;
-                            data_pos += 1;
-                        }
+                        push_var(&mut buf, b"JAVA_RUNFILES", path);
                     }
                 }
-            }
-            if !runfiles_dir_inserted {
-                if let Some(rf) = runfiles {
+                if !dir_inserted {
                     if let Some(ref path) = rf.dir_path {
-                        let path_bytes = path.as_bytes();
-                        let total_len = 13 + path_bytes.len() + 1;
-                        if !check_bounds(data_pos, total_len) {
-                            env_dropped = true;
-                        } else {
-                            for &b in b"RUNFILES_DIR=" {
-                                MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                data_pos += 1;
-                            }
-                            for &b in path_bytes {
-                                MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                data_pos += 1;
-                            }
-                            MODIFIED_ENV_DATA[data_pos] = 0;
-                            data_pos += 1;
-                        }
+                        push_var(&mut buf, b"RUNFILES_DIR", path);
                     }
                 }
-            }
-            if !runfiles_manifest_inserted {
-                if let Some(rf) = runfiles {
+                if !manifest_inserted {
                     if let Some(ref path) = rf.manifest_path {
-                        let path_bytes = path.as_bytes();
-                        let total_len = 23 + path_bytes.len() + 1;
-                        if !check_bounds(data_pos, total_len) {
-                            env_dropped = true;
-                        } else {
-                            for &b in b"RUNFILES_MANIFEST_FILE=" {
-                                MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                data_pos += 1;
-                            }
-                            for &b in path_bytes {
-                                MODIFIED_ENV_DATA[data_pos] = b as u16;
-                                data_pos += 1;
-                            }
-                            MODIFIED_ENV_DATA[data_pos] = 0;
-                            data_pos += 1;
-                        }
+                        push_var(&mut buf, b"RUNFILES_MANIFEST_FILE", path);
                     }
                 }
-            }
-
-            // Check if any environment variables were dropped
-            if env_dropped {
-                FreeEnvironmentStringsW(env_block);
-                print(b"ERROR: Failed to copy all environment variables\r\n");
-                print(b"Environment buffer limit exceeded. Total size limit: ");
-                print_number(MAX_ENV_SIZE);
-                print(b" bytes\r\n");
-                print(b"Current usage: ");
-                print_number(data_pos * 2); // *2 because it's u16 array
-                print(b" bytes\r\n");
-                print(b"Consider reducing the number or size of environment variables.\r\n");
-                ExitProcess(1);
             }
 
             FreeEnvironmentStringsW(env_block);
         }
-
-        // Add double null terminator to mark end of environment block
-        if data_pos < MODIFIED_ENV_DATA.len() {
-            MODIFIED_ENV_DATA[data_pos] = 0;
-            data_pos += 1;
-        }
-        if data_pos < MODIFIED_ENV_DATA.len() {
-            MODIFIED_ENV_DATA[data_pos] = 0;
-        }
-
-        MODIFIED_ENV_DATA.as_mut_ptr() as *mut core::ffi::c_void
     }
+
+    // Final NUL: with the last entry's NUL this forms the double-NUL block terminator.
+    buf.push(0);
+    buf
 }
 
-// Placeholders for stub runner (will be replaced in final binary)
-const ARG_SIZE: usize = 256;
-
-#[used]
-#[link_section = ".runfiles"]
-static mut ARGC_PLACEHOLDER: [u8; 32] = *b"@@RUNFILES_ARGC@@\0\0\0\0\0\0\0\0\0\0\0\0\0\0\0";
-
-#[used]
-#[link_section = ".runfiles"]
-static mut TRANSFORM_FLAGS: [u8; 32] = *b"@@RUNFILES_TRANSFORM_FLAGS@@\0\0\0\0";
-
-#[used]
-#[link_section = ".runfiles"]
-static mut EXPORT_RUNFILES_ENV: [u8; 32] = *b"@@RUNFILES_EXPORT_ENV@@\0\0\0\0\0\0\0\0\0";
-
-#[used]
-#[link_section = ".runfiles"]
-static mut ARG0_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles"]
-static mut ARG1_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles"]
-static mut ARG2_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles"]
-static mut ARG3_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles"]
-static mut ARG4_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles"]
-static mut ARG5_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles"]
-static mut ARG6_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles"]
-static mut ARG7_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles"]
-static mut ARG8_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-#[used]
-#[link_section = ".runfiles"]
-static mut ARG9_PLACEHOLDER: [u8; ARG_SIZE] = [b'@'; ARG_SIZE];
-
-// Get the length of a null-terminated string
-fn strlen(s: &[u8]) -> usize {
-    let mut len = 0;
-    while len < s.len() && s[len] != 0 {
-        len += 1;
-    }
-    len
-}
-
-// Check if placeholder is still in template state
-fn is_template_placeholder(placeholder: &[u8]) -> bool {
-    if placeholder.len() < 17 {
-        return false;
-    }
-    str_starts_with(placeholder, b"@@RUNFILES_")
-}
-
-#[no_mangle]
-pub extern "C" fn main() -> ! {
+// Parse a Windows command line into runtime arguments (excluding argv[0]).
+// We avoid CommandLineToArgvW to skip the shell32.dll dependency.
+fn parse_command_line(
+    cmdline: *const u16,
+    argv_out: &mut [*const u16; 128],
+    argv_len_out: &mut [usize; 128],
+) -> usize {
     unsafe {
-        // Get command line
-        let cmdline = GetCommandLineW();
-
-        // Parse runtime arguments using custom parser (no shell32.dll needed)
-        let mut runtime_argv: [*const u16; 128] = [core::ptr::null(); 128];
-        let mut runtime_argv_len: [usize; 128] = [0; 128];
-        let runtime_args_count = parse_command_line(cmdline, &mut runtime_argv, &mut runtime_argv_len);
-
-        // Check if ARGC is still a placeholder
-        if is_template_placeholder(&ARGC_PLACEHOLDER) {
-            print(b"ERROR: This is a template stub runner.\r\n");
-            print(b"You must finalize it by replacing the placeholders before use.\r\n");
-            print(b"The ARGC_PLACEHOLDER has not been replaced.\r\n");
-            ExitProcess(1);
-        }
-
-        // Parse argc from placeholder
-        let argc_str = &ARGC_PLACEHOLDER;
-        let argc_len = strlen(argc_str);
-        if argc_len == 0 {
-            print(b"ERROR: ARGC is empty\r\n");
-            ExitProcess(1);
-        }
-
-        // Parse argc as decimal number
-        let mut argc: usize = 0;
-        for i in 0..argc_len {
-            let c = argc_str[i];
-            if c >= b'0' && c <= b'9' {
-                argc = argc * 10 + (c - b'0') as usize;
-            } else {
-                print(b"ERROR: ARGC contains non-digit characters\r\n");
-                ExitProcess(1);
-            }
-        }
-
-        if argc == 0 || argc > 10 {
-            print(b"ERROR: Invalid argc (must be 1-10)\r\n");
-            ExitProcess(1);
-        }
-
-        // Parse transform flags (bitmask of which args to transform)
-        let flags_str = &TRANSFORM_FLAGS;
-        let flags_len = strlen(flags_str);
-        let mut transform_flags: u32 = 0;
-
-        if !is_template_placeholder(flags_str) && flags_len > 0 {
-            // Parse as decimal number (bitmask)
-            for i in 0..flags_len {
-                let c = flags_str[i];
-                if c >= b'0' && c <= b'9' {
-                    transform_flags = transform_flags * 10 + (c - b'0') as u32;
-                } else {
-                    print(b"ERROR: TRANSFORM_FLAGS contains non-digit characters\r\n");
-                    ExitProcess(1);
-                }
-            }
-        }
-        // If flags not set, default to transforming all args
-        if flags_len == 0 || is_template_placeholder(flags_str) {
-            transform_flags = 0xFFFFFFFF; // Transform all by default
-        }
-
-        // Parse export_runfiles_env flag (defaults to true)
-        let export_str = &EXPORT_RUNFILES_ENV;
-        let export_len = strlen(export_str);
-        let export_runfiles_env = if !is_template_placeholder(export_str) && export_len > 0 {
-            // Parse as "1" (true) or "0" (false)
-            export_str[0] != b'0'
-        } else {
-            true // Default to true
-        };
-
-        // Check if any arguments need transformation
-        let argc_mask = if argc >= 32 {
-            0xFFFFFFFF
-        } else {
-            (1u32 << argc) - 1
-        };
-        let needs_transform = (transform_flags & argc_mask) != 0;
-        let needs_runfiles = needs_transform || export_runfiles_env;
-
-        // Parse argv[0] from command line manually
-        // Command line format: either "path\to\exe" args... or path\to\exe args...
-        // We extract the first token (argv[0]) for runfiles fallback
-        let mut exe_path_buf = Vec::new();
         let mut pos = 0usize;
+        let mut argc = 0usize;
 
         // Skip leading whitespace
-        while *cmdline.add(pos) != 0 && (*cmdline.add(pos) == b' ' as u16 || *cmdline.add(pos) == b'\t' as u16) {
+        while *cmdline.add(pos) != 0
+            && (*cmdline.add(pos) == b' ' as u16 || *cmdline.add(pos) == b'\t' as u16)
+        {
             pos += 1;
         }
 
-        // Check if first char is a quote
+        // Skip argv[0] (executable path)
         let quoted = *cmdline.add(pos) == b'"' as u16;
         if quoted {
-            pos += 1; // Skip opening quote
+            pos += 1;
+            while *cmdline.add(pos) != 0 && *cmdline.add(pos) != b'"' as u16 {
+                pos += 1;
+            }
+            if *cmdline.add(pos) == b'"' as u16 {
+                pos += 1;
+            }
+        } else {
+            while *cmdline.add(pos) != 0
+                && *cmdline.add(pos) != b' ' as u16
+                && *cmdline.add(pos) != b'\t' as u16
+            {
+                pos += 1;
+            }
         }
 
-        // Extract argv[0] (with 1MB safety limit)
-        while exe_path_buf.len() < 1048576 && *cmdline.add(pos) != 0 {
-            let wchar = *cmdline.add(pos);
-
-            // Check for end of argv[0]
-            if quoted {
-                if wchar == b'"' as u16 {
-                    break; // End of quoted string
-                }
-            } else {
-                if wchar == b' ' as u16 || wchar == b'\t' as u16 {
-                    break; // End of unquoted string
-                }
+        // Parse remaining arguments
+        while *cmdline.add(pos) != 0 && argc < 128 {
+            while *cmdline.add(pos) != 0
+                && (*cmdline.add(pos) == b' ' as u16 || *cmdline.add(pos) == b'\t' as u16)
+            {
+                pos += 1;
+            }
+            if *cmdline.add(pos) == 0 {
+                break;
             }
 
-            // Simple UTF-16 to ASCII conversion
+            let arg_start = pos;
+            let in_quotes = *cmdline.add(pos) == b'"' as u16;
+            if in_quotes {
+                pos += 1;
+                while *cmdline.add(pos) != 0 && *cmdline.add(pos) != b'"' as u16 {
+                    pos += 1;
+                }
+                argv_out[argc] = cmdline.add(arg_start + 1);
+                argv_len_out[argc] = pos - arg_start - 1;
+                if *cmdline.add(pos) == b'"' as u16 {
+                    pos += 1;
+                }
+            } else {
+                while *cmdline.add(pos) != 0
+                    && *cmdline.add(pos) != b' ' as u16
+                    && *cmdline.add(pos) != b'\t' as u16
+                {
+                    pos += 1;
+                }
+                argv_out[argc] = cmdline.add(arg_start);
+                argv_len_out[argc] = pos - arg_start;
+            }
+            argc += 1;
+        }
+        argc
+    }
+}
+
+// Extract argv[0] from the command line, narrowed to bytes (for runfiles fallback).
+fn parse_argv0(cmdline: *const u16) -> Vec<u8> {
+    let mut exe_path_buf = Vec::new();
+    unsafe {
+        let mut pos = 0usize;
+        while *cmdline.add(pos) != 0
+            && (*cmdline.add(pos) == b' ' as u16 || *cmdline.add(pos) == b'\t' as u16)
+        {
+            pos += 1;
+        }
+        let quoted = *cmdline.add(pos) == b'"' as u16;
+        if quoted {
+            pos += 1;
+        }
+        while exe_path_buf.len() < 1048576 && *cmdline.add(pos) != 0 {
+            let wchar = *cmdline.add(pos);
+            if quoted {
+                if wchar == b'"' as u16 {
+                    break;
+                }
+            } else if wchar == b' ' as u16 || wchar == b'\t' as u16 {
+                break;
+            }
             exe_path_buf.push((wchar & 0xFF) as u8);
             pos += 1;
         }
+    }
+    exe_path_buf
+}
 
-        let executable_path: Option<&[u8]> = if !exe_path_buf.is_empty() {
-            Some(&exe_path_buf)
-        } else {
+// --- runtime args & launch ---
+pub struct RuntimeArgs {
+    argv0_bytes: Vec<u8>,
+    runtime_argv: [*const u16; 128],
+    runtime_argv_len: [usize; 128],
+    runtime_count: usize,
+}
+
+impl RuntimeArgs {
+    /// argv[0] (the stub's own path) as bytes, for runfiles fallback discovery.
+    pub fn program_path(&self) -> Option<&[u8]> {
+        if self.argv0_bytes.is_empty() {
             None
-        };
-
-        // Initialize runfiles only if needed
-        let runfiles = if needs_runfiles {
-            if let Some(rf) = Runfiles::create(executable_path) {
-                Some(rf)
-            } else {
-                print(b"ERROR: Failed to initialize runfiles\r\n");
-                print(b"Set RUNFILES_DIR or RUNFILES_MANIFEST_FILE, or ensure <executable>.runfiles\\ directory exists\r\n");
-                ExitProcess(1);
-            }
         } else {
-            None
-        };
-
-        // Get arg placeholders
-        let arg_placeholders: [&[u8; ARG_SIZE]; 10] = [
-            &ARG0_PLACEHOLDER,
-            &ARG1_PLACEHOLDER,
-            &ARG2_PLACEHOLDER,
-            &ARG3_PLACEHOLDER,
-            &ARG4_PLACEHOLDER,
-            &ARG5_PLACEHOLDER,
-            &ARG6_PLACEHOLDER,
-            &ARG7_PLACEHOLDER,
-            &ARG8_PLACEHOLDER,
-            &ARG9_PLACEHOLDER,
-        ];
-
-        // Use Vec for dynamic path storage - no fixed size limits
-        let mut resolved_paths: Vec<Vec<u8>> = Vec::with_capacity(128);
-
-        // Resolve embedded arguments
-        for i in 0..argc {
-            let arg_data = arg_placeholders[i];
-            let arg_len = strlen(arg_data);
-
-            if arg_len == 0 {
-                print(b"ERROR: Argument ");
-                let digit = [b'0' + i as u8];
-                print(&digit);
-                print(b" is empty\r\n");
-                ExitProcess(1);
-            }
-
-            let arg_slice = &arg_data[..arg_len];
-
-            // Check if this argument should be transformed
-            let should_transform = (transform_flags & (1 << i)) != 0;
-
-            let resolved = if should_transform {
-                // Try to resolve through runfiles
-                if let Some(ref rf) = runfiles {
-                    // Convert argument to &str for rlocation (Bazel args are UTF-8)
-                    if let Ok(arg_str) = core::str::from_utf8(arg_slice) {
-                        if let Some(resolved_str) = rf.rlocation(arg_str) {
-                            // Convert back to bytes
-                            Vec::from(resolved_str.as_bytes())
-                        } else {
-                            // If not found in runfiles, use the path as-is
-                            arg_slice.to_vec()
-                        }
-                    } else {
-                        // Not valid UTF-8, use as-is
-                        arg_slice.to_vec()
-                    }
-                } else {
-                    // Use path as-is
-                    arg_slice.to_vec()
-                }
-            } else {
-                // Use path as-is without transformation
-                arg_slice.to_vec()
-            };
-
-            resolved_paths.push(resolved);
+            Some(&self.argv0_bytes)
         }
+    }
+}
 
-        // Build command line for CreateProcessW (UTF-16)
-        // Command line includes embedded args + runtime args
+pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
+    unsafe {
+        let argc = launch.resolved.len();
+
+        // Build the UTF-16 command line: embedded args (widened) + runtime args (native).
         let mut cmdline_wide: Vec<u16> = Vec::with_capacity(8192);
 
-        // Add embedded arguments (convert from UTF-8 to UTF-16)
-        for i in 0..argc {
-            let arg_slice = &resolved_paths[i];
+        for (i, arg) in launch.resolved.iter().enumerate() {
+            // Embedded args are NUL-terminated; widen without the trailing NUL.
+            let bytes = if arg.last() == Some(&0) { &arg[..arg.len() - 1] } else { &arg[..] };
 
-            // Always quote the first argument (executable path) following Bazel's approach
-            // For other arguments, only quote if they contain spaces
-            let needs_quotes = i == 0 || find_byte(arg_slice, b' ').is_some();
-
+            // Quote arg0 always (Bazel launcher.cc convention); others only if they contain spaces.
+            let needs_quotes = i == 0 || bytes.contains(&b' ');
             if needs_quotes {
                 cmdline_wide.push(b'"' as u16);
             }
-
-            // Convert UTF-8 to UTF-16 and copy
-            for &b in arg_slice {
+            for &b in bytes {
                 cmdline_wide.push(b as u16);
             }
-
             if needs_quotes {
                 cmdline_wide.push(b'"' as u16);
             }
-
-            // Add space between arguments
-            if i < argc - 1 || runtime_args_count > 0 {
+            if i < argc - 1 || rt.runtime_count > 0 {
                 cmdline_wide.push(b' ' as u16);
             }
         }
 
-        // Add runtime arguments (already UTF-16, just copy)
-        for i in 0..runtime_args_count {
-            let runtime_arg = runtime_argv[i];
-            let arg_len = runtime_argv_len[i];
-
-            // Check if we need quotes (scan for spaces)
+        for i in 0..rt.runtime_count {
+            let arg = rt.runtime_argv[i];
+            let arg_len = rt.runtime_argv_len[i];
             let mut needs_quotes = false;
             for j in 0..arg_len {
-                if *runtime_arg.add(j) == b' ' as u16 {
+                if *arg.add(j) == b' ' as u16 {
                     needs_quotes = true;
                     break;
                 }
             }
-
             if needs_quotes {
                 cmdline_wide.push(b'"' as u16);
             }
-
-            // Copy wide string
             for j in 0..arg_len {
-                cmdline_wide.push(*runtime_arg.add(j));
+                cmdline_wide.push(*arg.add(j));
             }
-
             if needs_quotes {
                 cmdline_wide.push(b'"' as u16);
             }
-
-            // Add space between arguments (except after last)
-            if i < runtime_args_count - 1 {
+            if i < rt.runtime_count - 1 {
                 cmdline_wide.push(b' ' as u16);
             }
         }
 
-        // Null-terminate command line
         cmdline_wide.push(0);
 
-        // Build environment with runfiles variables if export is enabled
-        let envp = if export_runfiles_env {
-            build_runfiles_environ(runfiles.as_ref())
+        // Build the environment with runfiles vars if export is enabled.
+        // `env_storage` keeps the block alive while CreateProcessW reads it.
+        let env_storage: Vec<u16>;
+        let envp = if launch.export_env {
+            env_storage = build_runfiles_environ(launch.runfiles);
+            env_storage.as_ptr() as *mut core::ffi::c_void
         } else {
             core::ptr::null_mut()
         };
+        let creation_flags = if launch.export_env { CREATE_UNICODE_ENVIRONMENT } else { 0 };
 
-        // Create the process
         let mut si: STARTUPINFOW = core::mem::zeroed();
         si.cb = core::mem::size_of::<STARTUPINFOW>() as DWORD;
         let mut pi: PROCESS_INFORMATION = core::mem::zeroed();
 
-        // Determine creation flags
-        // If we have a UTF-16 environment block, we need CREATE_UNICODE_ENVIRONMENT
-        let creation_flags = if export_runfiles_env {
-            CREATE_UNICODE_ENVIRONMENT
-        } else {
-            0
-        };
-
-        // Use NULL for lpApplicationName and quote the executable in the command line
-        // This follows Bazel's launcher.cc approach
+        // NULL lpApplicationName + quoted executable in the command line (Bazel approach).
         let success = CreateProcessW(
-            core::ptr::null(),          // Application name (NULL - parsed from command line)
-            cmdline_wide.as_mut_ptr(),  // Command line (UTF-16) - quoted executable + args
-            core::ptr::null_mut(),      // Process attributes
-            core::ptr::null_mut(),      // Thread attributes
-            1,                          // Inherit handles
-            creation_flags,             // Creation flags (with CREATE_UNICODE_ENVIRONMENT if needed)
-            envp,                       // Environment
-            core::ptr::null(),          // Current directory
+            core::ptr::null(),
+            cmdline_wide.as_mut_ptr(),
+            core::ptr::null_mut(),
+            core::ptr::null_mut(),
+            1,
+            creation_flags,
+            envp,
+            core::ptr::null(),
             &mut si,
             &mut pi,
         );
-
         if success == 0 {
             print(b"ERROR: CreateProcess failed\r\n");
             ExitProcess(1);
         }
 
-        // Wait for the child process to complete
         WaitForSingleObject(pi.hProcess, INFINITE);
-
-        // Get the child process's exit code
         let mut exit_code: DWORD = 0;
         GetExitCodeProcess(pi.hProcess, &mut exit_code);
-
-        // Close handles
         CloseHandle(pi.hProcess);
         CloseHandle(pi.hThread);
-
-        // Exit with the child process's exit code
         ExitProcess(exit_code);
     }
+}
+
+#[no_mangle]
+pub extern "C" fn main() -> ! {
+    let cmdline = unsafe { GetCommandLineW() };
+    let mut runtime_argv: [*const u16; 128] = [core::ptr::null(); 128];
+    let mut runtime_argv_len: [usize; 128] = [0; 128];
+    let runtime_count = parse_command_line(cmdline, &mut runtime_argv, &mut runtime_argv_len);
+    let argv0_bytes = parse_argv0(cmdline);
+    crate::run::main(RuntimeArgs {
+        argv0_bytes,
+        runtime_argv,
+        runtime_argv_len,
+        runtime_count,
+    })
 }


### PR DESCRIPTION
Invert the three near-duplicate platform files into a shared core plus thin per-OS backends, holding (and net-reducing) binary size.

Shared core, compiled on every platform:
- common.rs    manifest parser (Manifest/ManifestLines), byte helpers
- runfiles.rs  Runfiles discovery + rlocation
- run.rs       argc/flags/arg-resolution/argv[0] flow (zero unsafe)
- placeholders.rs  #[used] static-mut placeholders via a per-OS-section macro,
               read through addr_of! accessors (clears the static-mut warnings)
- allocator.rs talc global allocator + panic handler

Per-OS backends (linux/macos/windows) provide a cfg-gated free-function seam (print/exit/path_exists/get_env_var/load_manifest/is_absolute/to_native_path/ launch). No trait, so it monomorphizes to identical codegen under LTO; bytes are the lingua franca and each backend marshals to execve argv/envp or CreateProcessW cmdline + UTF-16 env block.

Other changes:
- Replace hand-rolled str_eq/str_starts_with/find_byte/strlen with core slice methods (==, starts_with, iter().position).
- Dedup Linux per-arch syscall asm via cfg-gated macros; output is byte-identical to before on x86_64/aarch64/s390x.
- Replace the Windows 128 KB `static mut` env buffer with a heap Vec<u16>, removing the fixed cap and the abort-on-overflow path.

Source 3662 -> 2107 lines (-42%); unsafe occurrences 70 -> 43 (-39%), all remaining unsafe inherent (syscalls/FFI/allocator/mmap/_start) and isolated. Release binary sizes net -3464 bytes across the 7 targets (worst case +0.9%); placeholder byte-layout unchanged so finalize-stub is unaffected.