### PR TITLE
fix: locate runfiles from the OS launch path, not argv[0]

### DIFF
--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -769,6 +769,96 @@ fn test_fallback_runfiles_manifest(config: &TestConfig) -> Result<(), String> {
     Ok(())
 }
 
+/// Regression test: runfiles discovery under `bazel run` semantics.
+///
+/// argv[0] is not guaranteed to be a reliable, absolute path that points at the
+/// executable. Instead, it may be relative (and it may be completely fake).
+/// The stub should use reliable, operating-system specific APIs to find it's own
+/// path and not rely on argv[0] at all.
+///
+/// `bazel test` masks the bug because it pre-sets RUNFILES_DIR, and the other
+/// fallback tests above invoke the stub by its *absolute* path, so neither
+/// exercises this code path. See https://github.com/aspect-build/rules_py/pull/1113.
+fn test_run_runfiles_discovery(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: run_runfiles_discovery");
+
+    let test_dir = config.work_dir.join("test_run_discovery");
+    fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {}", e))?;
+
+    // A stub with its <stub>.runfiles directory next to it, like a built binary.
+    let stub_name = format!("run_disc_stub{}", EXE_EXT);
+    let stub_path = test_dir.join(&stub_name);
+    let runfiles_dir = test_dir.join(format!("{}.runfiles", stub_name));
+
+    // Place the target binary inside the runfiles tree.
+    let binary_dir = runfiles_dir.join(WORKSPACE_NAME).join("bin");
+    fs::create_dir_all(&binary_dir).map_err(|e| format!("Failed to create binary dir: {}", e))?;
+    let add_binary = config.test_binaries_dir.join(format!("add-numbers{}", EXE_EXT));
+    let dest_binary = binary_dir.join(format!("add-numbers{}", EXE_EXT));
+    fs::copy(&add_binary, &dest_binary).map_err(|e| format!("Failed to copy binary: {}", e))?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::fs::PermissionsExt;
+        let mut perms = fs::metadata(&dest_binary)
+            .map_err(|e| format!("Failed to get permissions: {}", e))?
+            .permissions();
+        perms.set_mode(0o755);
+        fs::set_permissions(&dest_binary, perms)
+            .map_err(|e| format!("Failed to set permissions: {}", e))?;
+    }
+
+    let add_rlocation = format!("{}/bin/add-numbers{}", WORKSPACE_NAME, EXE_EXT);
+    finalize_stub(config, &stub_path, &[&add_rlocation, "5", "10"], &[0])?;
+
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+
+        // The working directory `bazel run` leaves us in: inside the runfiles tree.
+        let cwd_inside_runfiles = runfiles_dir.join(WORKSPACE_NAME);
+
+        // Exec the stub by its absolute path (so the OS can self-locate the running
+        // binary) but with a *relative* argv[0], exactly as `bazel run` does.
+        let mut cmd = Command::new(&stub_path);
+        cmd.arg0(format!("bazel-bin/{}", stub_name));
+        cmd.current_dir(&cwd_inside_runfiles);
+        cmd.env_remove("RUNFILES_DIR");
+        cmd.env_remove("RUNFILES_MANIFEST_FILE");
+        cmd.env_remove("JAVA_RUNFILES");
+
+        let output = cmd.output().map_err(|e| format!("Failed to run stub: {}", e))?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        let exit_code = output.status.code().unwrap_or(-1);
+
+        if exit_code != 0 {
+            return Err(format!(
+                "Stub failed with exit code {} (rules_py #1113 regression: relative argv[0] \
+                 + cwd inside the runfiles tree).\nstdout: {}\nstderr: {}",
+                exit_code, stdout, stderr
+            ));
+        }
+        if !stdout.contains("SUM:15") {
+            return Err(format!("Unexpected output: {}. Expected 'SUM:15'", stdout));
+        }
+
+        println!("    PASS (relative argv[0], cwd inside runfiles)");
+    }
+
+    #[cfg(not(unix))]
+    {
+        // The relative-argv[0] failure mode is Unix-specific; on Windows the
+        // launcher derives runfiles from the command-line argv[0], which Bazel
+        // passes as an absolute path. The setup above still keeps the case
+        // compiling and the stub finalized.
+        let _ = &stub_path;
+        println!("    SKIP (Unix-only reproduction)");
+    }
+
+    Ok(())
+}
+
 /// Test: print-env to verify environment and argument passing
 fn test_print_env(config: &TestConfig) -> Result<(), String> {
     println!("  Running test: print_env");
@@ -978,6 +1068,7 @@ fn main() -> ExitCode {
         ("mixed_arguments", test_mixed_arguments),
         ("fallback_runfiles_dir", test_fallback_runfiles_dir),
         ("fallback_runfiles_manifest", test_fallback_runfiles_manifest),
+        ("run_runfiles_discovery", test_run_runfiles_discovery),
         ("print_env", test_print_env),
         ("large_manifest", test_large_manifest),
     ];

--- a/runfiles-stub/src/common.rs
+++ b/runfiles-stub/src/common.rs
@@ -3,12 +3,33 @@
 
 extern crate alloc;
 
+use alloc::vec::Vec;
+
 use crate::platform;
 
 /// Length of a NUL-terminated byte string stored in a fixed-size buffer:
 /// the offset of the first NUL, or the full length if there is none.
 pub fn cstr_len(s: &[u8]) -> usize {
     s.iter().position(|&b| b == 0).unwrap_or(s.len())
+}
+
+/// Make `path` absolute without resolving symlinks. An already-absolute path is
+/// returned unchanged; a relative one is joined onto the current working
+/// directory. Best-effort: if the cwd is unavailable, the path is returned as-is.
+pub fn absolutize(path: Vec<u8>) -> Vec<u8> {
+    if let Ok(s) = core::str::from_utf8(&path) {
+        if platform::is_absolute(s) {
+            return path;
+        }
+    }
+    if let Some(mut cwd) = platform::current_dir() {
+        if cwd.last().copied() != Some(platform::SEP as u8) {
+            cwd.push(platform::SEP as u8);
+        }
+        cwd.extend_from_slice(&path);
+        return cwd;
+    }
+    path
 }
 
 /// Print a decimal number to stdout (used in diagnostics).

--- a/runfiles-stub/src/linux.rs
+++ b/runfiles-stub/src/linux.rs
@@ -64,6 +64,7 @@ mod syscall_numbers {
     pub const SYS_LSEEK: usize = 8;
     pub const SYS_MMAP: usize = 9;
     pub const SYS_ACCESS: usize = 21;
+    pub const SYS_GETCWD: usize = 79;
     pub const SYS_EXECVE: usize = 59;
     pub const SYS_EXIT: usize = 60;
 }
@@ -77,6 +78,7 @@ mod syscall_numbers {
     pub const SYS_LSEEK: usize = 62;
     pub const SYS_MMAP: usize = 222;
     pub const SYS_FACCESSAT: usize = 48;  // faccessat is used on aarch64
+    pub const SYS_GETCWD: usize = 17;
     pub const SYS_EXECVE: usize = 221;
     pub const SYS_EXIT: usize = 93;
     pub const AT_FDCWD: i32 = -100;  // Special fd for openat/faccessat to work like open/access
@@ -92,6 +94,7 @@ mod syscall_numbers {
     pub const SYS_LSEEK: usize = 19;
     pub const SYS_EXECVE: usize = 11;
     pub const SYS_ACCESS: usize = 33;
+    pub const SYS_GETCWD: usize = 183;
     pub const SYS_MMAP: usize = 90;
 }
 
@@ -104,6 +107,10 @@ const STDOUT: i32 = 1;
 const PROT_READ: usize = 1;
 const MAP_PRIVATE: usize = 2;
 const SEEK_END: i32 = 2;
+
+// ELF auxiliary-vector entry type holding a pointer to the pathname used to exec
+// this process (arch-independent).
+const AT_EXECFN: usize = 31;
 
 // --- path semantics ---
 pub const SEP: char = '/';
@@ -179,6 +186,14 @@ mod sc {
             core::arch::asm!("svc #0", in("x8") $nr, in("x0") $a1, lateout("x0") _)
         };
     }
+    macro_rules! syscall2 {
+        ($ty:ty; $nr:expr, $a1:expr, $a2:expr) => {{
+            let ret: $ty;
+            core::arch::asm!("svc #0", in("x8") $nr, in("x0") $a1, in("x1") $a2,
+                lateout("x0") ret);
+            ret
+        }};
+    }
     macro_rules! syscall3 {
         ($ty:ty; $nr:expr, $a1:expr, $a2:expr, $a3:expr) => {{
             let ret: $ty;
@@ -203,7 +218,7 @@ mod sc {
             ret
         }};
     }
-    pub(super) use {syscall3, syscall4, syscall6, syscall_noreturn, syscall_void};
+    pub(super) use {syscall2, syscall3, syscall4, syscall6, syscall_noreturn, syscall_void};
 }
 
 #[cfg(target_arch = "s390x")]
@@ -326,6 +341,36 @@ pub fn path_exists(path: &[u8]) -> bool {
     {
         unsafe { syscall2!(i64; SYS_ACCESS, path.as_ptr(), 0i64) == 0 }
     }
+}
+
+// getcwd(2) into `buf`. Returns the number of bytes written (including the
+// trailing NUL) on success, or a negative value on error.
+fn getcwd(buf: &mut [u8]) -> isize {
+    #[cfg(target_arch = "x86_64")]
+    {
+        unsafe { syscall2!(isize; SYS_GETCWD, buf.as_mut_ptr(), buf.len()) }
+    }
+    #[cfg(target_arch = "aarch64")]
+    {
+        unsafe { syscall2!(isize; SYS_GETCWD, buf.as_mut_ptr(), buf.len()) }
+    }
+    #[cfg(target_arch = "s390x")]
+    {
+        unsafe { syscall2!(i64; SYS_GETCWD, buf.as_mut_ptr(), buf.len()) as isize }
+    }
+}
+
+// Current working directory, used to absolutize a relative launch path. None on
+// failure.
+pub fn current_dir() -> Option<Vec<u8>> {
+    let mut buf = [0u8; 4096];
+    if getcwd(&mut buf) > 0 {
+        let len = crate::common::cstr_len(&buf);
+        if len > 0 {
+            return Some(buf[..len].to_vec());
+        }
+    }
+    None
 }
 
 fn execve(filename: *const u8, argv: *const *const u8, envp: *const *const u8) -> i32 {
@@ -487,26 +532,31 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u
 pub struct RuntimeArgs {
     argc: usize,
     argv: *const *const u8,
+    // Pointer to the AT_EXECFN string (the pathname used to exec us), or null.
+    execfn: *const u8,
 }
 
 impl RuntimeArgs {
-    /// argv[0] (the stub's own path) as bytes, for runfiles fallback discovery.
-    pub fn program_path(&self) -> Option<&[u8]> {
-        if self.argc == 0 {
+    /// Absolute path of the launching executable, from AT_EXECFN made absolute,
+    /// for runfiles self-location. Independent of argv[0].
+    pub fn executable_path(&self) -> Option<Vec<u8>> {
+        if self.execfn.is_null() {
             return None;
         }
+        let mut len = 0;
         unsafe {
-            let p = *self.argv;
-            let mut len = 0;
-            while *p.add(len) != 0 && len < 1048576 {
+            while *self.execfn.add(len) != 0 {
                 len += 1;
-            }
-            if len > 0 {
-                Some(core::slice::from_raw_parts(p, len))
-            } else {
-                None
+                if len > 1048576 {
+                    return None;
+                }
             }
         }
+        if len == 0 {
+            return None;
+        }
+        let raw = unsafe { core::slice::from_raw_parts(self.execfn, len) }.to_vec();
+        Some(crate::common::absolutize(raw))
     }
 }
 
@@ -593,13 +643,40 @@ core::arch::global_asm!(
     "brasl %r14, _start_rust",     // Call the actual start function
 );
 
+// Walk the ELF auxiliary vector (which follows argv and envp on the initial
+// stack) and return the AT_EXECFN value: a pointer to the pathname used to exec
+// this process. Null if the entry is absent.
+unsafe fn find_execfn(initial_sp: *const usize, argc: usize) -> *const u8 {
+    // Skip argc, the argc argv entries, and the argv NULL terminator -> envp[0].
+    let mut p = initial_sp.add(1 + argc + 1);
+    // Skip the environment pointers up to their NULL terminator -> auxv[0].
+    while *p != 0 {
+        p = p.add(1);
+    }
+    p = p.add(1);
+    // Walk auxv entries (pairs of {type, value}) until AT_NULL (type 0).
+    loop {
+        let a_type = *p;
+        if a_type == 0 {
+            return core::ptr::null();
+        }
+        if a_type == AT_EXECFN {
+            return *p.add(1) as *const u8;
+        }
+        p = p.add(2);
+    }
+}
+
 #[no_mangle]
 pub extern "C" fn _start_rust(initial_sp: *const usize) -> ! {
-    // Stack layout: [sp] = argc, [sp + 8] = argv[0], [sp + 16] = argv[1], ...
-    let (argc, argv) = unsafe {
+    // Stack layout: [sp] = argc, [sp + 8] = argv[0], [sp + 16] = argv[1], ...,
+    // the argv NULL terminator, the environment pointers, a NULL, then the ELF
+    // auxiliary vector.
+    let rt = unsafe {
         let argc = *initial_sp;
         let argv = (initial_sp as usize + 8) as *const *const u8;
-        (argc, argv)
+        let execfn = find_execfn(initial_sp, argc);
+        RuntimeArgs { argc, argv, execfn }
     };
-    crate::run::main(RuntimeArgs { argc, argv })
+    crate::run::main(rt)
 }

--- a/runfiles-stub/src/macos.rs
+++ b/runfiles-stub/src/macos.rs
@@ -3,9 +3,10 @@
 // functions that form the platform seam consumed by the shared core.
 
 use alloc::string::String;
+use alloc::vec;
 use alloc::vec::Vec;
 
-use crate::common::{print_number, Manifest};
+use crate::common::{cstr_len, print_number, Manifest};
 use crate::run::Launch;
 use crate::runfiles::Runfiles;
 
@@ -26,6 +27,10 @@ mod sys {
             offset: i64,
         ) -> *mut core::ffi::c_void;
         pub fn lseek(fd: i32, offset: i64, whence: i32) -> i64;
+        // Launch path + working directory, for runfiles self-location.
+        #[allow(non_snake_case)]
+        pub fn _NSGetExecutablePath(buf: *mut u8, bufsize: *mut u32) -> i32;
+        pub fn getcwd(buf: *mut u8, size: usize) -> *mut u8;
         // Thread-local errno is reached via __error() on macOS.
         pub fn __error() -> *mut i32;
         pub static mut environ: *const *const u8;
@@ -64,6 +69,45 @@ pub fn exit(code: i32) -> ! {
 
 pub fn path_exists(path: &[u8]) -> bool {
     unsafe { sys::access(path.as_ptr(), 0) == 0 } // F_OK = 0
+}
+
+// Path used to launch this process, via _NSGetExecutablePath. This is the path
+// as exec'd (symlinks NOT resolved); it is absolutized separately. None on
+// failure.
+fn launch_path() -> Option<Vec<u8>> {
+    unsafe {
+        // First query the required buffer size, then read the NUL-terminated path.
+        let mut size: u32 = 0;
+        sys::_NSGetExecutablePath(core::ptr::null_mut(), &mut size);
+        if size == 0 {
+            return None;
+        }
+        let mut buf = vec![0u8; size as usize];
+        if sys::_NSGetExecutablePath(buf.as_mut_ptr(), &mut size) != 0 {
+            return None;
+        }
+        buf.truncate(cstr_len(&buf));
+        if buf.is_empty() {
+            None
+        } else {
+            Some(buf)
+        }
+    }
+}
+
+// Current working directory via getcwd(3), used to absolutize a relative launch
+// path. None on failure.
+pub fn current_dir() -> Option<Vec<u8>> {
+    let mut buf = vec![0u8; 4096];
+    if unsafe { sys::getcwd(buf.as_mut_ptr(), buf.len()) }.is_null() {
+        return None;
+    }
+    buf.truncate(cstr_len(&buf));
+    if buf.is_empty() {
+        None
+    } else {
+        Some(buf)
+    }
 }
 
 // Environment variable lookup via the libc `environ` pointer.
@@ -185,23 +229,10 @@ pub struct RuntimeArgs {
 }
 
 impl RuntimeArgs {
-    /// argv[0] (the stub's own path) as bytes, for runfiles fallback discovery.
-    pub fn program_path(&self) -> Option<&[u8]> {
-        if self.argc <= 0 {
-            return None;
-        }
-        unsafe {
-            let p = *self.argv;
-            let mut len = 0;
-            while *p.add(len) != 0 && len < 1048576 {
-                len += 1;
-            }
-            if len > 0 {
-                Some(core::slice::from_raw_parts(p, len))
-            } else {
-                None
-            }
-        }
+    /// Absolute path of the launching executable (`_NSGetExecutablePath`, made
+    /// absolute), for runfiles self-location. Independent of argv[0].
+    pub fn executable_path(&self) -> Option<Vec<u8>> {
+        launch_path().map(crate::common::absolutize)
     }
 }
 

--- a/runfiles-stub/src/run.rs
+++ b/runfiles-stub/src/run.rs
@@ -95,11 +95,8 @@ pub fn main(rt: platform::RuntimeArgs) -> ! {
     let needs_transform = (transform_flags & argc_mask) != 0;
     let needs_runfiles = needs_transform || export_runfiles_env;
 
-    // argv[0] (the stub's own path) is the fallback for runfiles discovery.
-    let executable_path = rt.program_path();
-
     let runfiles = if needs_runfiles {
-        match Runfiles::create(executable_path) {
+        match Runfiles::create(&rt) {
             Some(rf) => Some(rf),
             None => {
                 eline(b"ERROR: Failed to initialize runfiles");

--- a/runfiles-stub/src/runfiles.rs
+++ b/runfiles-stub/src/runfiles.rs
@@ -23,7 +23,7 @@ pub struct Runfiles {
 }
 
 impl Runfiles {
-    pub fn create(executable_path: Option<&[u8]>) -> Option<Self> {
+    pub fn create(rt: &platform::RuntimeArgs) -> Option<Self> {
         // Try RUNFILES_MANIFEST_FILE first
         if let Some(manifest_path) = platform::get_env_var(b"RUNFILES_MANIFEST_FILE") {
             if !manifest_path.is_empty() {
@@ -52,13 +52,14 @@ impl Runfiles {
             }
         }
 
-        // Try to find runfiles next to the executable:
+        // Locate runfiles next to the launching executable:
         // <executable>.runfiles_manifest file first (preferred), then
-        // <executable>.runfiles directory.
-        if let Some(exe_path) = executable_path {
-            let exe_len = cstr_len(exe_path);
+        // <executable>.runfiles directory. The executable path comes from the OS
+        // (an absolute, non-symlink-resolved launch path), not from argv[0].
+        if let Some(exe_path) = rt.executable_path() {
+            let exe_len = cstr_len(&exe_path);
             if exe_len > 0 {
-                // Convert executable path to string (if valid UTF-8)
+                // Convert the executable path to a string (if valid UTF-8).
                 let exe_str = core::str::from_utf8(&exe_path[..exe_len]).ok()?;
 
                 // Try <executable>.runfiles_manifest file first

--- a/runfiles-stub/src/windows.rs
+++ b/runfiles-stub/src/windows.rs
@@ -120,6 +120,13 @@ extern "system" {
     fn GetExitCodeProcess(hProcess: HANDLE, lpExitCode: *mut DWORD) -> BOOL;
     fn GetEnvironmentStringsW() -> *mut u16;
     fn FreeEnvironmentStringsW(lpszEnvironmentBlock: *mut u16) -> BOOL;
+    fn GetCurrentProcess() -> HANDLE;
+    fn QueryFullProcessImageNameW(
+        hProcess: HANDLE,
+        dwFlags: DWORD,
+        lpExeName: *mut u16,
+        lpdwSize: *mut DWORD,
+    ) -> BOOL;
 }
 
 // --- path semantics ---
@@ -169,6 +176,30 @@ pub fn path_exists(path: &[u8]) -> bool {
             false
         }
     }
+}
+
+// Path used to launch this process, via QueryFullProcessImageNameW (the
+// documented API for a process's own image path). With dwFlags = 0 it returns a
+// fully-qualified Win32 path, i.e. already absolute. UTF-16 is narrowed to bytes
+// the same way argv is elsewhere in this backend. None on failure.
+fn launch_path() -> Option<Vec<u8>> {
+    let mut wide = vec![0u16; 4096];
+    let mut size: DWORD = wide.len() as DWORD;
+    let ok = unsafe {
+        QueryFullProcessImageNameW(GetCurrentProcess(), 0, wide.as_mut_ptr(), &mut size)
+    };
+    if ok == 0 || size == 0 || size as usize > wide.len() {
+        return None;
+    }
+    // `size` is the number of characters written, excluding the NUL terminator.
+    Some(wide[..size as usize].iter().map(|&w| (w & 0xFF) as u8).collect())
+}
+
+// QueryFullProcessImageNameW already yields an absolute path, so the cwd is
+// never needed to absolutize it; this exists only to satisfy the shared
+// `absolutize` seam and is not expected to be called on Windows.
+pub fn current_dir() -> Option<Vec<u8>> {
+    None
 }
 
 // Environment variable lookup (two-call GetEnvironmentVariableA pattern).
@@ -458,52 +489,18 @@ fn parse_command_line(
     }
 }
 
-// Extract argv[0] from the command line, narrowed to bytes (for runfiles fallback).
-fn parse_argv0(cmdline: *const u16) -> Vec<u8> {
-    let mut exe_path_buf = Vec::new();
-    unsafe {
-        let mut pos = 0usize;
-        while *cmdline.add(pos) != 0
-            && (*cmdline.add(pos) == b' ' as u16 || *cmdline.add(pos) == b'\t' as u16)
-        {
-            pos += 1;
-        }
-        let quoted = *cmdline.add(pos) == b'"' as u16;
-        if quoted {
-            pos += 1;
-        }
-        while exe_path_buf.len() < 1048576 && *cmdline.add(pos) != 0 {
-            let wchar = *cmdline.add(pos);
-            if quoted {
-                if wchar == b'"' as u16 {
-                    break;
-                }
-            } else if wchar == b' ' as u16 || wchar == b'\t' as u16 {
-                break;
-            }
-            exe_path_buf.push((wchar & 0xFF) as u8);
-            pos += 1;
-        }
-    }
-    exe_path_buf
-}
-
 // --- runtime args & launch ---
 pub struct RuntimeArgs {
-    argv0_bytes: Vec<u8>,
     runtime_argv: [*const u16; 128],
     runtime_argv_len: [usize; 128],
     runtime_count: usize,
 }
 
 impl RuntimeArgs {
-    /// argv[0] (the stub's own path) as bytes, for runfiles fallback discovery.
-    pub fn program_path(&self) -> Option<&[u8]> {
-        if self.argv0_bytes.is_empty() {
-            None
-        } else {
-            Some(&self.argv0_bytes)
-        }
+    /// Absolute path of the launching executable (QueryFullProcessImageNameW),
+    /// for runfiles self-location. Independent of the command-line argv[0].
+    pub fn executable_path(&self) -> Option<Vec<u8>> {
+        launch_path().map(crate::common::absolutize)
     }
 }
 
@@ -628,9 +625,7 @@ pub extern "C" fn main() -> ! {
     let mut runtime_argv: [*const u16; 128] = [core::ptr::null(); 128];
     let mut runtime_argv_len: [usize; 128] = [0; 128];
     let runtime_count = parse_command_line(cmdline, &mut runtime_argv, &mut runtime_argv_len);
-    let argv0_bytes = parse_argv0(cmdline);
     crate::run::main(RuntimeArgs {
-        argv0_bytes,
         runtime_argv,
         runtime_argv_len,
         runtime_count,


### PR DESCRIPTION
`bazel run` and directly-executed deployed binaries exec the launcher with a relative argv[0] (e.g. `bazel-bin/foo`) from a working directory inside the runfiles tree and without RUNFILES_DIR set, so computing `<argv[0]>.runfiles` resolved against the wrong directory and runfiles discovery failed with "Failed to initialize runfiles" / execve errno 2. `bazel test` masked this by pre-setting RUNFILES_DIR. See https://github.com/aspect-build/rules_py/pull/1113.

Derive the executable path from a safe OS launch-path API instead of argv[0], make it absolute (joining the cwd when relative), and do not resolve symlinks:
  - Linux (all arches incl. s390x): AT_EXECFN from the ELF auxv
  - macOS: _NSGetExecutablePath
  - Windows: QueryFullProcessImageNameW

`program_path()` (argv[0]) is removed; `Runfiles::create` now takes `&RuntimeArgs` and calls the new `executable_path()` seam, with a shared `common::absolutize` + per-backend `current_dir` (getcwd).

Add an integration regression test (`run_runfiles_discovery`) that execs the stub with a relative argv[0] from a cwd inside the runfiles tree with the runfiles env vars unset; it fails before this change and passes after.