### PR TITLE
fix: resolve relative runfiles-manifest targets as symlinks

### DIFF
--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -226,6 +226,17 @@ impl RunfilesSetup {
         Ok(())
     }
 
+    /// Append raw `<source> <target>` manifest lines after the normal entries.
+    /// Used to inject relative (symlink-style) targets that Bazel emits for
+    /// unresolved symlinks, which `add_file`'s absolute entries can't represent.
+    fn append_manifest_lines(&self, lines: &[(&str, &str)]) -> std::io::Result<()> {
+        let mut file = fs::OpenOptions::new().append(true).open(&self.manifest_path)?;
+        for (source, target) in lines {
+            writeln!(file, "{} {}", source, target)?;
+        }
+        Ok(())
+    }
+
     /// Get the absolute path for an rlocation path
     fn get_path(&self, rlocation_path: &str) -> Option<&PathBuf> {
         self.entries.get(rlocation_path)
@@ -859,6 +870,80 @@ fn test_run_runfiles_discovery(config: &TestConfig) -> Result<(), String> {
     Ok(())
 }
 
+/// Regression test: manifest entries with relative (symlink-style) targets.
+///
+/// Bazel writes an unresolved symlink's `readlink` target into the manifest
+/// verbatim, so a manifest target can be relative — interpreted, like any symlink
+/// target, relative to the directory of its own key. aspect_rules_py's venv chains
+/// these: the entrypoint `bin/python` is a relative symlink to a sibling
+/// `bin/python3`, which is itself a relative symlink up to the real interpreter.
+/// The launcher must resolve such relative targets (re-looking-up each hop) rather
+/// than feeding the raw `../../..` string to execve.
+/// See https://github.com/lucidsoftware/rules_py_hermetic_launcher_repro.
+fn test_relative_manifest_symlinks(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: relative_manifest_symlinks");
+
+    let test_dir = config.work_dir.join("test_relative_symlinks");
+    fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {}", e))?;
+
+    let mut runfiles = RunfilesSetup::new(&test_dir, "relsym_stub")
+        .map_err(|e| format!("Failed to create runfiles: {}", e))?;
+
+    // The real interpreter lives in a separate (canonical) repo directory and is
+    // listed with an absolute target, exactly as Bazel does for the interpreter.
+    let add_binary = config.test_binaries_dir.join(format!("add-numbers{}", EXE_EXT));
+    let interp_rlocation = format!("interpreter_repo/bin/add-numbers{}", EXE_EXT);
+    runfiles
+        .add_file(&interp_rlocation, &add_binary)
+        .map_err(|e| format!("Failed to add interpreter: {}", e))?;
+
+    runfiles
+        .write_manifest()
+        .map_err(|e| format!("Failed to write manifest: {}", e))?;
+
+    // Two relative-target hops, mirroring the venv interpreter shim chain. The
+    // finalized entrypoint is `python`; resolution must follow both hops:
+    //   _main/venv/bin/python  -> python3                                  (sibling)
+    //   _main/venv/bin/python3 -> ../../../interpreter_repo/bin/add-numbers (up to repo)
+    // landing on the absolute interpreter entry written above. The three `..`
+    // segments pop the three key dirs (_main, venv, bin) back to the runfiles root.
+    let entry_key = format!("{}/venv/bin/python", WORKSPACE_NAME);
+    let sibling_key = format!("{}/venv/bin/python3", WORKSPACE_NAME);
+    runfiles
+        .append_manifest_lines(&[
+            // python -> sibling python3 (relative, single component)
+            (&entry_key, "python3"),
+            // python3 -> up three dirs into the interpreter repo (relative, with ..)
+            (
+                &sibling_key,
+                &format!("../../../interpreter_repo/bin/add-numbers{}", EXE_EXT),
+            ),
+        ])
+        .map_err(|e| format!("Failed to append relative entries: {}", e))?;
+
+    // Finalize a stub whose entrypoint is the chained relative symlink `python`.
+    let stub_path = test_dir.join(format!("relsym_stub{}", EXE_EXT));
+    finalize_stub(config, &stub_path, &[&entry_key, "21", "21"], &[0])?;
+
+    // Manifest mode is the path that fed execve the raw "../../.." string before
+    // the fix; this must now resolve through both hops to the real interpreter.
+    let (stdout, stderr, exit_code) = run_stub(&stub_path, &runfiles, &[], true)?;
+    if exit_code != 0 {
+        return Err(format!(
+            "Relative-symlink stub failed with exit code {} (relative manifest target \
+             fed to execve unresolved).\nstdout: {}\nstderr: {}",
+            exit_code, stdout, stderr
+        ));
+    }
+    if !stdout.contains("SUM:42") {
+        return Err(format!("Unexpected output: {}. Expected 'SUM:42'", stdout));
+    }
+
+    println!("    PASS (two relative-target hops, manifest mode)");
+
+    Ok(())
+}
+
 /// Test: print-env to verify environment and argument passing
 fn test_print_env(config: &TestConfig) -> Result<(), String> {
     println!("  Running test: print_env");
@@ -1069,6 +1154,7 @@ fn main() -> ExitCode {
         ("fallback_runfiles_dir", test_fallback_runfiles_dir),
         ("fallback_runfiles_manifest", test_fallback_runfiles_manifest),
         ("run_runfiles_discovery", test_run_runfiles_discovery),
+        ("relative_manifest_symlinks", test_relative_manifest_symlinks),
         ("print_env", test_print_env),
         ("large_manifest", test_large_manifest),
     ];

--- a/runfiles-stub/src/runfiles.rs
+++ b/runfiles-stub/src/runfiles.rs
@@ -107,18 +107,7 @@ impl Runfiles {
         }
 
         match &self.mode {
-            RunfilesMode::ManifestBased(manifest) => {
-                if let Some(resolved) = manifest.lookup(path) {
-                    return Some(platform::to_native_path(resolved));
-                }
-                // Prefix match for paths within TreeArtifacts
-                if let Some((resolved_prefix, suffix)) = manifest.prefix_lookup(path) {
-                    let mut result = String::from(resolved_prefix);
-                    result.push_str(suffix);
-                    return Some(platform::to_native_path(&result));
-                }
-                None
-            }
+            RunfilesMode::ManifestBased(manifest) => resolve_manifest(manifest, path),
             RunfilesMode::DirectoryBased(dir) => {
                 let mut result = dir.clone();
                 // Add separator if needed.
@@ -130,4 +119,86 @@ impl Runfiles {
             }
         }
     }
+}
+
+/// Maximum number of relative manifest hops to follow before giving up. Bazel
+/// emits only short symlink chains (e.g. `python` -> `python3` -> `../../interp`),
+/// so a small bound is plenty and also breaks any accidental cycle.
+const MAX_MANIFEST_HOPS: usize = 32;
+
+/// Resolve a runfiles-relative `path` through a manifest.
+///
+/// A manifest line maps a runfiles-relative key (LHS) to a target (RHS) that
+/// behaves exactly like a filesystem symlink target: an absolute RHS is the final
+/// location, while a relative RHS is interpreted relative to the directory of its
+/// key (POSIX symlink semantics). A relative target therefore names another
+/// runfiles-relative path, which may itself be another manifest entry — Bazel
+/// chains venv interpreter shims this way — so we follow the chain until it lands
+/// on an absolute path.
+fn resolve_manifest(manifest: &Manifest, path: &str) -> Option<String> {
+    let mut key = String::from(path);
+    for _ in 0..MAX_MANIFEST_HOPS {
+        let value = match manifest.lookup(&key) {
+            Some(v) => v,
+            None => {
+                // Prefix match for paths within a TreeArtifact: only the directory
+                // is listed, the file beneath it is not. Such directory entries are
+                // always absolute, so the joined path is the final location.
+                if let Some((resolved_prefix, suffix)) = manifest.prefix_lookup(&key) {
+                    let mut result = String::from(resolved_prefix);
+                    result.push_str(suffix);
+                    return Some(platform::to_native_path(&result));
+                }
+                return None;
+            }
+        };
+
+        // An absolute target is the final location; hand it back natively.
+        if platform::is_absolute(value) {
+            return Some(platform::to_native_path(value));
+        }
+
+        // A relative target is a symlink relative to the key's directory. Resolve
+        // it into a new runfiles-relative key and look that up in turn.
+        key = join_relative(parent_dir(&key), value)?;
+    }
+    None
+}
+
+/// Directory portion of a forward-slash runfiles key, without the trailing slash.
+/// `"a/b/c"` -> `"a/b"`; a key with no slash -> `""` (the runfiles root).
+fn parent_dir(key: &str) -> &str {
+    match key.rfind('/') {
+        Some(i) => &key[..i],
+        None => "",
+    }
+}
+
+/// Resolve a relative symlink `target` against directory `base` — both
+/// forward-slash, runfiles-relative — normalizing `.` and `..` components.
+/// Returns the new runfiles-relative key, or `None` if it would escape the
+/// runfiles root (a malformed entry we refuse rather than follow outside the tree).
+fn join_relative(base: &str, target: &str) -> Option<String> {
+    let mut stack: Vec<&str> = Vec::new();
+    for comp in base.split('/').chain(target.split('/')) {
+        match comp {
+            "" | "." => {}
+            // `pop()?` fails the whole resolution if `..` reaches above the root.
+            ".." => {
+                stack.pop()?;
+            }
+            other => stack.push(other),
+        }
+    }
+    if stack.is_empty() {
+        return None;
+    }
+    let mut result = String::new();
+    for (i, comp) in stack.iter().enumerate() {
+        if i > 0 {
+            result.push('/');
+        }
+        result.push_str(comp);
+    }
+    Some(result)
 }


### PR DESCRIPTION
Bazel writes an unresolved-symlink artifact's readlink target into the runfiles manifest verbatim, so a manifest entry's target (RHS) can be relative (e.g. aspect_rules_py venv: `_main/._hello.venv/bin/python ../../../<interp>/bin/python3`). The launcher returned the RHS as-is, so in manifest mode execve ran the `../../..` string relative to cwd and failed with errno 2.

Treat a manifest RHS like a filesystem symlink target: an absolute RHS is the final location, while a relative RHS is resolved against the directory of its key (POSIX symlink semantics) into a new runfiles-relative key, which is looked up in turn. This is iterated (bounded) to follow Bazel's chained venv interpreter shims (python -> python3 -> ../../../interp). A target that would escape the runfiles root is refused. Directory mode is unchanged (it already defers symlink resolution to the kernel).

Add a regression test exercising two relative-target hops in manifest mode.