### PR TITLE
perf(macos): fold __DATA_CONST into __DATA to drop a page

### DIFF
--- a/runfiles-stub/BUILD.bazel
+++ b/runfiles-stub/BUILD.bazel
@@ -13,6 +13,15 @@ rust_release_binary(
             "-Clink-arg=-lc",
             "-Clink-self-contained=no",
         ],
+        # Fold __DATA_CONST (only ~192 B: __got + a little __const) into __DATA.
+        # On arm64 macOS every segment is 16 KiB-page-aligned, so a standalone
+        # __DATA_CONST wastes a whole 16 KiB page; merging it reclaims that page
+        # (aarch64: 50656 -> 34144, x86_64: 25484 -> 21388). The stub does its
+        # work and execve's immediately, so giving up the read-only-after-reloc
+        # hardening on the GOT is irrelevant here.
+        "@platforms//os:macos": [
+            "-Clink-arg=-Wl,-no_data_const",
+        ],
         "//conditions:default": [],
     }),
 )


### PR DESCRIPTION
The runfiles stub's __DATA_CONST segment holds only __got plus a little __const (~192 bytes), but it is a separate page-aligned segment, so it costs a whole page: 16 KiB on arm64 (16 KiB pages), 4 KiB on x86_64. Pass -Wl,-no_data_const so the linker merges it into __DATA.

This gives up the read-only-after-relocation hardening on the GOT, which is irrelevant for a stub that resolves runfiles and execve's immediately. The finalizer (panic = "unwind", and large enough that the page is noise) keeps __DATA_CONST. Verified the stubs still finalize, re-sign, and run.