### PR TITLE
feat: add executable-relative fallbacks

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
           $config = if ($env:BUILDBUDDY_API_KEY) { "--config=cache" } else { $null }
-          bazel --output_user_root=C:/b test $config --config=release //integration-tests:integration_test
+          bazel --output_user_root=C:/b test $config --config=release --test_output=errors //integration-tests:integration_test
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,6 +12,25 @@ register_toolchains("//launcher/private/prebuilt:all")
 
 # Only dev dependencies below this line
 
+v1_compatibility_repositories = use_extension(
+    "//integration-tests:v1_compatibility_repositories.bzl",
+    "v1_compatibility_repositories",
+    dev_dependency = True,
+)
+use_repo(
+    v1_compatibility_repositories,
+    "v1_compat_20260619_finalize_stub_aarch64_linux",
+    "v1_compat_20260619_finalize_stub_aarch64_macos",
+    "v1_compat_20260619_finalize_stub_x86_64_linux",
+    "v1_compat_20260619_finalize_stub_x86_64_macos",
+    "v1_compat_20260619_finalize_stub_x86_64_windows",
+    "v1_compat_20260619_runfiles_stub_aarch64_linux",
+    "v1_compat_20260619_runfiles_stub_aarch64_macos",
+    "v1_compat_20260619_runfiles_stub_x86_64_linux",
+    "v1_compat_20260619_runfiles_stub_x86_64_macos",
+    "v1_compat_20260619_runfiles_stub_x86_64_windows",
+)
+
 bazel_dep(name = "bazel_lib", version = "3.2.2", dev_dependency = True)
 bazel_dep(name = "rules_shell", version = "0.8.0", dev_dependency = True)
 bazel_dep(name = "rules_cc", version = "0.2.18", dev_dependency = True)

--- a/README.md
+++ b/README.md
@@ -136,13 +136,17 @@ finalize-stub --template <PATH> [OPTIONS] -- <arg0> [arg1 ...]
 -o, --output <PATH>              Output path (default: stdout; chmod +x on Unix)
     --transform <N>              Mark embedded arg N (0–9) for runfiles resolution.
                                  Repeatable or comma-separated. Default: none.
+    --fallback <N=PATH>          Fall back to PATH relative to the launcher for transformed
+                                 arg N. Repeatable; at most one fallback per argument.
     --export-runfiles-env <B>    Export RUNFILES_DIR/RUNFILES_MANIFEST_FILE/JAVA_RUNFILES
-                                 to the child (default: true)
+                                 to the child. False preserves inherited values (default: true)
 -v, --verbose                    Verbose output
 ```
 
-Up to 10 embedded arguments (`arg0`–`arg9`), each ≤ 256 bytes. `arg0` is the program to
-execute; the rest are its leading arguments. Runtime arguments are unrestricted.
+Up to 10 embedded arguments (`arg0`–`arg9`), each ≤ 256 bytes. For a fallback-enabled
+argument, the argument, a NUL separator, and its fallback share that 256-byte slot.
+`arg0` is the program to execute; the rest are its leading arguments. Runtime arguments
+are limited only by the target operating system's process invocation constraints.
 
 ### Runfiles discovery
 
@@ -154,9 +158,34 @@ At startup the finalized launcher locates runfiles in this order:
 4. `<executable>.runfiles/`
 
 Each argument marked `--transform` is resolved through runfiles (manifest lookup or
-directory join; tree-artifact prefixes supported). Absolute paths (leading `/`) pass
-through unchanged. The launcher then appends its own runtime arguments and replaces
-itself with the target.
+directory join; tree-artifact prefixes supported). Without a fallback, absolute paths
+(leading `/`) pass through unchanged. The launcher then appends its own runtime
+arguments and replaces itself with the target.
+
+For an argument with `--fallback N=PATH`, the runfiles result wins only when it
+exists. Otherwise the launcher joins `PATH` to the parent of its OS-reported
+executable path, converts separators for the target platform, and requires the
+result to exist. The join preserves `..` components and does not depend on the
+current working directory. Unix uses the path through which the launcher was
+invoked, including a symlinked directory. Windows uses the physical image path
+reported by `QueryFullProcessImageNameW`. Before Windows filesystem and process
+APIs consume an absolute DOS or UNC path, the launcher normalizes it to
+`\\?\C:\...` or `\\?\UNC\server\share\...` form. This avoids `MAX_PATH`
+without depending on host policy or an application manifest; the complete child
+command line remains subject to the `CreateProcessW` length limit. A fallback can
+only accompany a relative embedded runfiles path; absolute embedded paths retain
+their pass-through semantics. A missing runfiles tree is allowed when at least
+one argument is transformed and every transformed argument has a fallback. With
+no transformed arguments, the default environment export still requires
+runfiles.
+
+With `--export-runfiles-env=true`, a runfiles context used by the launch replaces
+the child's inherited runfiles variables. If at least one fallback is selected
+and no transformed argument resolves through runfiles, the launcher removes
+those inherited variables rather than exporting an unrelated context. With
+`--export-runfiles-env=false`, the child inherits the variables unchanged.
+Fallbacks require a V2 template. V1 custom templates retain their existing
+`--export-runfiles-env` behavior.
 
 ---
 
@@ -165,21 +194,23 @@ itself with the target.
 ```
 runfiles-stub (template)           finalize-stub                  launcher
 ┌────────────────────────┐         patches placeholders:         ┌──────────────────────┐
-│ argc / flags / arg0..N │  ──────▶  argc, transform bitmask,  ─▶│ same size, runs the  │
-│   = placeholder bytes  │           export flag, arg values     │ embedded program     │
+│ argc / flags / arg0..N │  ──────▶  argc, transform flags,    ─▶│ same size, runs the  │
+│   = placeholder bytes  │           args + in-slot fallbacks     │ embedded program     │
 └────────────────────────┘                                       └──────────────────────┘
 ```
 
 The finalizer scans the template for fixed-size placeholder byte patterns and
-overwrites them in place — argument count, a bitmask of which args to resolve, the
-export-env flag, and the argument strings. Output size equals input size, and the
-result is identical regardless of which host produced it.
+overwrites them in place — argument count, the runfiles-resolution bitmask, the
+export-env flag, and argument strings. A fallback follows its argument's terminating
+NUL in the same fixed-size slot; that nonempty suffix is the sole record that the
+argument has a fallback. Output size equals template size, and the result is identical
+regardless of which host produced it.
 
 | OS | Arches | Entry | Syscall layer | Process exec | Notes |
 |----|--------|-------|---------------|--------------|-------|
 | Linux | x86_64, aarch64, s390x | custom `_start` | raw syscalls, no libc | `execve` | fully static (musl), zero deps |
 | macOS | x86_64, aarch64 | `main` | libSystem | `execve` | finalizer re-signs ad-hoc (patching invalidates the Mach-O signature) |
-| Windows | x86_64, aarch64 | `main` | Win32 (UTF-16) | `CreateProcessW` + wait | converts `/` → `\` |
+| Windows | x86_64, aarch64 | `main` | Win32 (UTF-16) | `CreateProcessW` + wait | verbatim DOS/UNC API paths |
 
 The stubs are `no_std` Rust with a static-arena allocator. Patched Mach-O binaries are
 re-signed automatically by the finalizer.

--- a/finalize-stub/src/main.rs
+++ b/finalize-stub/src/main.rs
@@ -35,6 +35,10 @@ struct Cli {
     #[arg(long, action = ArgAction::Append, value_delimiter = ',', value_parser = clap::value_parser!(u32).range(0..10))]
     transform: Vec<u32>,
 
+    /// Executable-relative fallback for a transformed argument, encoded as N=PATH. Repeatable; each argument may have at most one fallback.
+    #[arg(long, action = ArgAction::Append, value_name = "N=PATH")]
+    fallback: Vec<String>,
+
     /// Export runfiles environment variables (RUNFILES_DIR, RUNFILES_MANIFEST_FILE, JAVA_RUNFILES) to the executed process
     #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
     export_runfiles_env: bool,
@@ -92,7 +96,15 @@ fn replace_at(data: &mut [u8], offset: usize, new_value: &[u8], fixed_size: usiz
     Ok(())
 }
 
-fn finalize_stub(template_path: &str, output_path: Option<&str>, argv: &[String], transform_flags: u32, export_runfiles_env: bool, verbose: bool) -> Result<(), String> {
+fn is_target_portably_absolute(path: &str) -> bool {
+    let bytes = path.as_bytes();
+    let windows_drive_qualified = bytes.len() >= 2
+        && bytes[0].is_ascii_alphabetic()
+        && bytes[1] == b':';
+    path.starts_with('/') || path.starts_with('\\') || windows_drive_qualified
+}
+
+fn finalize_stub(template_path: &str, output_path: Option<&str>, argv: &[String], transform_flags: u32, fallbacks: &[(usize, String)], export_runfiles_env: bool, verbose: bool) -> Result<(), String> {
     if argv.is_empty() {
         return Err("At least one argument (argv[0]) is required".to_string());
     }
@@ -140,11 +152,24 @@ fn finalize_stub(template_path: &str, output_path: Option<&str>, argv: &[String]
         eprintln!("Replaced TRANSFORM_FLAGS with: {} (0b{:b})", flags_str, transform_flags);
     }
 
-    // Find and replace EXPORT_RUNFILES_ENV
-    let export_pattern = b"@@RUNFILES_EXPORT_ENV@@";
-    let export_pos = find_pattern(&data, export_pattern)
-        .ok_or("EXPORT_RUNFILES_ENV placeholder not found in template")?;
-
+    // V2 uses the existing export slot as a capability marker, so it does not
+    // enlarge the template. V1 templates retain their existing export option,
+    // but cannot carry fallback metadata that their runtime would ignore.
+    let export_v2_pattern = b"@@RUNFILES_EXPORT_ENV@@V2";
+    let export_v1_pattern = b"@@RUNFILES_EXPORT_ENV@@";
+    let (export_pos, is_v2) = if let Some(pos) = find_pattern(&data, export_v2_pattern) {
+        (pos, true)
+    } else if let Some(pos) = find_pattern(&data, export_v1_pattern) {
+        (pos, false)
+    } else {
+        return Err("EXPORT_RUNFILES_ENV placeholder not found in template".to_string());
+    };
+    if !fallbacks.is_empty() && !is_v2 {
+        return Err(
+            "template does not support executable-relative fallbacks; use a V2 runfiles stub template"
+                .to_string(),
+        );
+    }
     let export_str = if export_runfiles_env { "1" } else { "0" };
     replace_at(&mut data, export_pos, export_str.as_bytes(), 32)?;
 
@@ -166,9 +191,28 @@ fn finalize_stub(template_path: &str, output_path: Option<&str>, argv: &[String]
     // Now do the replacements
     for (i, arg) in argv.iter().enumerate() {
         let arg_pos = arg_positions[i];
-        replace_at(&mut data, arg_pos, arg.as_bytes(), ARG_SIZE)?;
+        let fallback = fallbacks
+            .iter()
+            .find_map(|(index, path)| (*index == i).then_some(path));
+        let mut encoded_arg = Vec::from(arg.as_bytes());
+        if let Some(fallback) = fallback {
+            encoded_arg.push(0);
+            encoded_arg.extend_from_slice(fallback.as_bytes());
+        }
+        if encoded_arg.len() > ARG_SIZE {
+            return Err(format!(
+                "ARG{} and its fallback require {} bytes; maximum combined size is {} bytes",
+                i,
+                encoded_arg.len(),
+                ARG_SIZE,
+            ));
+        }
+        replace_at(&mut data, arg_pos, &encoded_arg, ARG_SIZE)?;
         if verbose {
             eprintln!("Replaced ARG{} with: {}", i, arg);
+            if let Some(fallback) = fallback {
+                eprintln!("Embedded fallback for ARG{}: {}", i, fallback);
+            }
         }
     }
 
@@ -288,7 +332,67 @@ fn main() {
         flags
     };
 
-    match finalize_stub(&cli.template, cli.output.as_deref(), &cli.args, transform_flags, cli.export_runfiles_env, cli.verbose) {
+    let fallbacks = (|| -> Result<Vec<(usize, String)>, String> {
+        let mut seen = 0u32;
+        let mut fallbacks = Vec::new();
+        for value in &cli.fallback {
+            let (index, path) = value
+                .split_once('=')
+                .ok_or_else(|| format!("invalid fallback {:?}; expected N=PATH", value))?;
+            let index: usize = index
+                .parse()
+                .map_err(|_| format!("invalid fallback argument index {:?}", index))?;
+            if index >= 10 {
+                return Err(format!(
+                    "fallback argument index {} exceeds the maximum index 9",
+                    index
+                ));
+            }
+            if index >= cli.args.len() {
+                return Err(format!(
+                    "fallback argument index {} is outside the {} embedded arguments",
+                    index,
+                    cli.args.len()
+                ));
+            }
+            if transform_flags & (1 << index) == 0 {
+                return Err(format!(
+                    "fallback argument {} is not marked for runfiles transformation",
+                    index
+                ));
+            }
+            if is_target_portably_absolute(&cli.args[index]) {
+                return Err(format!(
+                    "fallback argument {} cannot be attached to absolute embedded argument {:?}",
+                    index, cli.args[index]
+                ));
+            }
+            if path.is_empty() {
+                return Err(format!("fallback argument {} has an empty path", index));
+            }
+            if is_target_portably_absolute(path) {
+                return Err(format!(
+                    "fallback argument {} path {:?} must be executable-relative",
+                    index, path
+                ));
+            }
+            if seen & (1 << index) != 0 {
+                return Err(format!("fallback argument {} is declared more than once", index));
+            }
+            seen |= 1 << index;
+            fallbacks.push((index, path.to_owned()));
+        }
+        Ok(fallbacks)
+    })();
+    let fallbacks = match fallbacks {
+        Ok(fallbacks) => fallbacks,
+        Err(error) => {
+            eprintln!("Error: {}", error);
+            process::exit(1);
+        }
+    };
+
+    match finalize_stub(&cli.template, cli.output.as_deref(), &cli.args, transform_flags, &fallbacks, cli.export_runfiles_env, cli.verbose) {
         Ok(()) => {
             if cli.verbose {
                 if let Some(output) = cli.output {

--- a/integration-tests/BUILD.bazel
+++ b/integration-tests/BUILD.bazel
@@ -57,6 +57,17 @@ alias(
 )
 
 alias(
+    name = "published-v1-template",
+    actual = select({
+        ":linux_x86_64": "@v1_compat_20260619_runfiles_stub_x86_64_linux//file",
+        ":linux_aarch64": "@v1_compat_20260619_runfiles_stub_aarch64_linux//file",
+        ":macos_x86_64": "@v1_compat_20260619_runfiles_stub_x86_64_macos//file",
+        ":macos_aarch64": "@v1_compat_20260619_runfiles_stub_aarch64_macos//file",
+        ":windows": "@v1_compat_20260619_runfiles_stub_x86_64_windows//file",
+    }),
+)
+
+alias(
     name = "release-finalizer",
     actual = select({
         ":linux_x86_64": "//finalize-stub:finalize-stub_x86_64-unknown-linux-musl",
@@ -64,6 +75,17 @@ alias(
         ":macos_x86_64": "//finalize-stub:finalize-stub_x86_64-apple-darwin",
         ":macos_aarch64": "//finalize-stub:finalize-stub_aarch64-apple-darwin",
         ":windows": "//finalize-stub:finalize-stub_x86_64-pc-windows-gnullvm",
+    }),
+)
+
+alias(
+    name = "published-v1-finalizer",
+    actual = select({
+        ":linux_x86_64": "@v1_compat_20260619_finalize_stub_x86_64_linux//file",
+        ":linux_aarch64": "@v1_compat_20260619_finalize_stub_aarch64_linux//file",
+        ":macos_x86_64": "@v1_compat_20260619_finalize_stub_x86_64_macos//file",
+        ":macos_aarch64": "@v1_compat_20260619_finalize_stub_aarch64_macos//file",
+        ":windows": "@v1_compat_20260619_finalize_stub_x86_64_windows//file",
     }),
 )
 
@@ -99,6 +121,12 @@ rust_binary(
     edition = "2021",
 )
 
+rust_binary(
+    name = "print-opaque-argv",
+    srcs = ["src/bin/print_opaque_argv.rs"],
+    edition = "2021",
+)
+
 copy_to_directory(
     name = "test-binaries",
     srcs = [
@@ -107,6 +135,7 @@ copy_to_directory(
         ":merge-json",
         ":orchestrator",
         ":print-env",
+        ":print-opaque-argv",
     ],
 )
 
@@ -118,10 +147,16 @@ rust_test(
         "$(rlocationpath :release-template)",
         "--finalizer",
         "$(rlocationpath :release-finalizer)",
+        "--v1-template",
+        "$(rlocationpath :published-v1-template)",
+        "--v1-finalizer",
+        "$(rlocationpath :published-v1-finalizer)",
         "--test-binaries",
         "$(rlocationpath :test-binaries)",
     ],
     data = [
+        ":published-v1-finalizer",
+        ":published-v1-template",
         ":release-finalizer",
         ":release-template",
         ":test-binaries",

--- a/integration-tests/src/bin/print_opaque_argv.rs
+++ b/integration-tests/src/bin/print_opaque_argv.rs
@@ -1,0 +1,20 @@
+use std::env;
+
+fn main() {
+    let arg0 = env::args_os().next().expect("argv[0] is present");
+
+    #[cfg(unix)]
+    {
+        use std::fmt::Write as _;
+        use std::os::unix::ffi::OsStrExt;
+
+        let mut hex = String::new();
+        for byte in arg0.as_bytes() {
+            write!(&mut hex, "{byte:02x}").expect("writing to a String cannot fail");
+        }
+        println!("ARGV0_HEX:{hex}");
+    }
+
+    #[cfg(not(unix))]
+    println!("ARGV0:{}", arg0.to_string_lossy());
+}

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -402,13 +402,32 @@ fn run_successful_stub(command: &mut Command, context: &str) -> Result<String, S
     Ok(stdout)
 }
 
+#[cfg(windows)]
+fn windows_paths_equal(left: &str, right: &str) -> bool {
+    let normalize = |path: &str| {
+        let path = if let Some(rest) = path.strip_prefix("\\\\?\\UNC\\") {
+            format!("\\\\{rest}")
+        } else if let Some(rest) = path.strip_prefix("\\\\?\\") {
+            rest.to_string()
+        } else {
+            path.to_string()
+        };
+        path.replace('/', "\\")
+    };
+    normalize(left).eq_ignore_ascii_case(&normalize(right))
+}
+
 fn assert_argv0(stdout: &str, expected: &str, context: &str) -> Result<(), String> {
     let actual = stdout
         .lines()
         .next()
         .and_then(|line| line.strip_prefix("ARGS:"))
         .and_then(|args| args.split('|').next());
-    if actual != Some(expected) {
+    #[cfg(windows)]
+    let matches = actual.map_or(false, |actual| windows_paths_equal(actual, expected));
+    #[cfg(not(windows))]
+    let matches = actual == Some(expected);
+    if !matches {
         return Err(format!(
             "{} selected the wrong executable path\nexpected argv0: {}\nstdout: {}",
             context, expected, stdout
@@ -1461,21 +1480,22 @@ fn test_windows_extended_paths(config: &TestConfig) -> Result<(), String> {
     println!("  Running test: windows_extended_paths");
 
     let test_dir = config.work_dir.join("test_windows_extended_paths");
-    let stub_dir = test_dir
-        .join(format!("launcher-東京-{}", "a".repeat(180)))
+    let stub_dir = test_dir.join("launcher-東京");
+    let target_dir = stub_dir
+        .join(format!("targets-{}", "a".repeat(180)))
         .join(format!("nested-{}", "b".repeat(100)));
     fs::create_dir_all(&stub_dir)
-        .map_err(|e| format!("Failed to create long launcher directory: {}", e))?;
-    if stub_dir.as_os_str().encode_wide().count() <= 260 {
-        return Err(format!(
-            "Windows extended-path fixture did not exceed MAX_PATH: {}",
-            stub_dir.display()
-        ));
-    }
+        .map_err(|e| format!("Failed to create launcher directory: {}", e))?;
 
     let source_binary = config.test_binaries_dir.join("print-env.exe");
-    let fallback_binary = stub_dir.join("fallback-東京").join("print-env.exe");
-    let primary_binary = stub_dir.join("primary-主要").join("print-env.exe");
+    let fallback_binary = target_dir.join("fallback-東京").join("print-env.exe");
+    let primary_binary = target_dir.join("primary-主要").join("print-env.exe");
+    if fallback_binary.as_os_str().encode_wide().count() <= 260 {
+        return Err(format!(
+            "Windows extended-path fixture did not exceed MAX_PATH: {}",
+            fallback_binary.display()
+        ));
+    }
     for destination in [&fallback_binary, &primary_binary] {
         fs::create_dir_all(destination.parent().unwrap())
             .map_err(|e| format!("Failed to create {}: {}", destination.display(), e))?;
@@ -1490,15 +1510,8 @@ fn test_windows_extended_paths(config: &TestConfig) -> Result<(), String> {
             .and_then(|line| line.strip_prefix("ARGS:"))
             .and_then(|args| args.split('|').next())
             .ok_or_else(|| format!("{} did not print argv[0]\nstdout: {}", context, stdout))?;
-        let actual = if let Some(rest) = actual.strip_prefix("\\\\?\\UNC\\") {
-            format!("\\\\{rest}")
-        } else if let Some(rest) = actual.strip_prefix("\\\\?\\") {
-            rest.to_string()
-        } else {
-            actual.to_string()
-        };
         let expected = expected.to_string_lossy();
-        if !actual.eq_ignore_ascii_case(&expected) {
+        if !windows_paths_equal(actual, &expected) {
             return Err(format!(
                 "{} selected the wrong long path\nexpected argv0: {}\nactual argv0: {}\nstdout: {}",
                 context, expected, actual, stdout
@@ -1507,13 +1520,21 @@ fn test_windows_extended_paths(config: &TestConfig) -> Result<(), String> {
         Ok(())
     };
 
+    let target_relative = target_dir
+        .strip_prefix(&stub_dir)
+        .map_err(|e| format!("Failed to relativize long target directory: {}", e))?;
+    let fallback_arg = target_relative
+        .join("fallback-東京")
+        .join("print-env.exe")
+        .to_string_lossy()
+        .replace('\\', "/");
     let fallback_stub = stub_dir.join("fallback-stub.exe");
     finalize_stub_with_fallbacks(
         config,
         &fallback_stub,
         &["_main/missing-long-primary.exe"],
         &[0],
-        &[(0, "fallback-東京/print-env.exe")],
+        &[(0, &fallback_arg)],
         false,
     )?;
     let mut fallback_command = Command::new(&fallback_stub);
@@ -1538,7 +1559,7 @@ fn test_windows_extended_paths(config: &TestConfig) -> Result<(), String> {
         &manifest_stub,
         &[key],
         &[0],
-        &[(0, "fallback-東京/print-env.exe")],
+        &[(0, &fallback_arg)],
         false,
     )?;
     let mut manifest_command = Command::new(&manifest_stub);

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -6,7 +6,8 @@
 //! 3. Using the finalizer to create stub binaries
 //! 4. Running the stubs and validating their behavior
 //!
-//! Usage: test-runner --template <path> --finalizer <path> --test-binaries <dir>
+//! Usage: test-runner --template <path> --finalizer <path> --v1-template <path>
+//!     --v1-finalizer <path> --test-binaries <dir>
 //!
 //! The test runner automatically detects the current platform and creates
 //! appropriate paths (Windows vs Unix style).
@@ -41,6 +42,10 @@ struct TestConfig {
     template_path: PathBuf,
     /// Path to the finalize-stub binary
     finalizer_path: PathBuf,
+    /// Path to the published V1 runfiles-stub template
+    v1_template_path: PathBuf,
+    /// Path to the published V1 finalize-stub binary
+    v1_finalizer_path: PathBuf,
     /// Directory containing test binaries (hash-file, add-numbers, etc.)
     test_binaries_dir: PathBuf,
     /// Working directory for test artifacts
@@ -66,12 +71,30 @@ fn resolve_runfile_path(runfiles: &Runfiles, path: PathBuf) -> PathBuf {
     rlocation!(runfiles, runfiles_key.as_str()).unwrap_or(path)
 }
 
+fn assert_v1_artifact(path: &Path, label: &str) -> Result<(), String> {
+    const V1_MARKER: &[u8] = b"@@RUNFILES_EXPORT_ENV@@";
+    const V2_MARKER: &[u8] = b"@@RUNFILES_EXPORT_ENV@@V2";
+
+    let data = fs::read(path)
+        .map_err(|err| format!("Failed to read {label} {}: {err}", path.display()))?;
+    let contains = |needle: &[u8]| data.windows(needle.len()).any(|window| window == needle);
+    if !contains(V1_MARKER) || contains(V2_MARKER) {
+        return Err(format!(
+            "{label} {} is not a V1 compatibility artifact",
+            path.display()
+        ));
+    }
+    Ok(())
+}
+
 impl TestConfig {
     fn from_args() -> Result<Self, String> {
         let args: Vec<String> = env::args().collect();
 
         let mut template_path = None;
         let mut finalizer_path = None;
+        let mut v1_template_path = None;
+        let mut v1_finalizer_path = None;
         let mut test_binaries_dir = None;
         let mut work_dir = None;
 
@@ -86,6 +109,14 @@ impl TestConfig {
                     i += 1;
                     finalizer_path = Some(PathBuf::from(&args[i]));
                 }
+                "--v1-template" => {
+                    i += 1;
+                    v1_template_path = Some(PathBuf::from(&args[i]));
+                }
+                "--v1-finalizer" => {
+                    i += 1;
+                    v1_finalizer_path = Some(PathBuf::from(&args[i]));
+                }
                 "--test-binaries" => {
                     i += 1;
                     test_binaries_dir = Some(PathBuf::from(&args[i]));
@@ -95,11 +126,13 @@ impl TestConfig {
                     work_dir = Some(PathBuf::from(&args[i]));
                 }
                 "--help" | "-h" => {
-                    println!("Usage: test-runner --template <path> --finalizer <path> --test-binaries <dir> [--work-dir <dir>]");
+                    println!("Usage: test-runner --template <path> --finalizer <path> --v1-template <path> --v1-finalizer <path> --test-binaries <dir> [--work-dir <dir>]");
                     println!();
                     println!("Options:");
                     println!("  --template       Path to runfiles-stub template binary");
                     println!("  --finalizer      Path to finalize-stub binary");
+                    println!("  --v1-template    Path to published V1 runfiles-stub template");
+                    println!("  --v1-finalizer   Path to published V1 finalize-stub binary");
                     println!("  --test-binaries  Directory containing test binaries");
                     println!("  --work-dir       Working directory for test artifacts (default: temp dir)");
                     std::process::exit(0);
@@ -117,6 +150,14 @@ impl TestConfig {
             resolve_runfile_path(&runfiles, template_path.ok_or("--template is required")?);
         let finalizer_path =
             resolve_runfile_path(&runfiles, finalizer_path.ok_or("--finalizer is required")?);
+        let v1_template_path = resolve_runfile_path(
+            &runfiles,
+            v1_template_path.ok_or("--v1-template is required")?,
+        );
+        let v1_finalizer_path = resolve_runfile_path(
+            &runfiles,
+            v1_finalizer_path.ok_or("--v1-finalizer is required")?,
+        );
         let test_binaries_dir = resolve_runfile_path(
             &runfiles,
             test_binaries_dir.ok_or("--test-binaries is required")?,
@@ -132,6 +173,20 @@ impl TestConfig {
         if !finalizer_path.exists() {
             return Err(format!("Finalizer not found: {}", finalizer_path.display()));
         }
+        if !v1_template_path.exists() {
+            return Err(format!(
+                "Published V1 template not found: {}",
+                v1_template_path.display()
+            ));
+        }
+        if !v1_finalizer_path.exists() {
+            return Err(format!(
+                "Published V1 finalizer not found: {}",
+                v1_finalizer_path.display()
+            ));
+        }
+        assert_v1_artifact(&v1_template_path, "Published V1 template")?;
+        assert_v1_artifact(&v1_finalizer_path, "Published V1 finalizer")?;
         if !test_binaries_dir.exists() {
             return Err(format!("Test binaries dir not found: {}", test_binaries_dir.display()));
         }
@@ -139,6 +194,8 @@ impl TestConfig {
         Ok(Self {
             template_path,
             finalizer_path,
+            v1_template_path,
+            v1_finalizer_path,
             test_binaries_dir,
             work_dir,
         })
@@ -250,8 +307,39 @@ fn finalize_stub(
     args: &[&str],
     transform_indices: &[usize],
 ) -> Result<(), String> {
-    let mut cmd = Command::new(&config.finalizer_path);
-    cmd.arg("--template").arg(&config.template_path);
+    finalize_stub_with_fallbacks(config, output_path, args, transform_indices, &[], true)
+}
+
+fn finalize_stub_with_fallbacks(
+    config: &TestConfig,
+    output_path: &Path,
+    args: &[&str],
+    transform_indices: &[usize],
+    fallbacks: &[(usize, &str)],
+    export_runfiles_env: bool,
+) -> Result<(), String> {
+    finalize_stub_with_tools(
+        &config.finalizer_path,
+        &config.template_path,
+        output_path,
+        args,
+        transform_indices,
+        fallbacks,
+        export_runfiles_env,
+    )
+}
+
+fn finalize_stub_with_tools(
+    finalizer_path: &Path,
+    template_path: &Path,
+    output_path: &Path,
+    args: &[&str],
+    transform_indices: &[usize],
+    fallbacks: &[(usize, &str)],
+    export_runfiles_env: bool,
+) -> Result<(), String> {
+    let mut cmd = Command::new(finalizer_path);
+    cmd.arg("--template").arg(template_path);
     cmd.arg("--output").arg(output_path);
 
     // Add transform flags
@@ -259,6 +347,12 @@ fn finalize_stub(
         let transform_str: Vec<String> = transform_indices.iter().map(|i| i.to_string()).collect();
         cmd.arg("--transform").arg(transform_str.join(","));
     }
+
+    for (index, path) in fallbacks {
+        cmd.arg("--fallback").arg(format!("{}={}", index, path));
+    }
+    cmd.arg("--export-runfiles-env")
+        .arg(export_runfiles_env.to_string());
 
     cmd.arg("--");
 
@@ -271,7 +365,11 @@ fn finalize_stub(
 
     if !output.status.success() {
         let stderr = String::from_utf8_lossy(&output.stderr);
-        return Err(format!("Finalizer failed: {}", stderr));
+        return Err(format!(
+            "Finalizer {} failed: {}",
+            finalizer_path.display(),
+            stderr
+        ));
     }
 
     // Make executable on Unix
@@ -286,6 +384,56 @@ fn finalize_stub(
             .map_err(|e| format!("Failed to set permissions: {}", e))?;
     }
 
+    Ok(())
+}
+
+fn run_successful_stub(command: &mut Command, context: &str) -> Result<String, String> {
+    let output = command
+        .output()
+        .map_err(|e| format!("Failed to run {}: {}", context, e))?;
+    let stdout = String::from_utf8_lossy(&output.stdout).to_string();
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        return Err(format!(
+            "{} failed with status {}\nstdout: {}\nstderr: {}",
+            context, output.status, stdout, stderr
+        ));
+    }
+    Ok(stdout)
+}
+
+fn assert_argv0(stdout: &str, expected: &str, context: &str) -> Result<(), String> {
+    let actual = stdout
+        .lines()
+        .next()
+        .and_then(|line| line.strip_prefix("ARGS:"))
+        .and_then(|args| args.split('|').next());
+    if actual != Some(expected) {
+        return Err(format!(
+            "{} selected the wrong executable path\nexpected argv0: {}\nstdout: {}",
+            context, expected, stdout
+        ));
+    }
+    Ok(())
+}
+
+fn assert_runfiles_env(
+    stdout: &str,
+    expected: &[(&str, Option<&Path>)],
+    context: &str,
+) -> Result<(), String> {
+    for (variable, value) in expected {
+        let expected = value.map_or_else(
+            || format!("ENV:{}=<unset>", variable),
+            |path| format!("ENV:{}={}", variable, path.display()),
+        );
+        if !stdout.contains(&expected) {
+            return Err(format!(
+                "{} has the wrong runfiles environment\nexpected: {}\nstdout: {}",
+                context, expected, stdout
+            ));
+        }
+    }
     Ok(())
 }
 
@@ -719,44 +867,28 @@ fn test_fallback_runfiles_manifest(config: &TestConfig) -> Result<(), String> {
     let stub_path = test_dir.join(format!("manifest_stub{}", EXE_EXT));
     let manifest_path = test_dir.join(format!("manifest_stub{}.runfiles_manifest", EXE_EXT));
 
-    // Create the runfiles directory structure for the files
+    // The adjacent logical runfiles tree intentionally does not exist. The
+    // manifest maps the executable elsewhere, while argv[0] retains this path
+    // so runfiles-aware children can recover their logical identity.
     let runfiles_dir = test_dir.join(format!("manifest_stub{}.runfiles", EXE_EXT));
-    let binary_dir = runfiles_dir.join(WORKSPACE_NAME).join("bin");
-    fs::create_dir_all(&binary_dir).map_err(|e| format!("Failed to create binary dir: {}", e))?;
-
-    let add_binary = config.test_binaries_dir.join(format!("add-numbers{}", EXE_EXT));
-    let dest_binary = binary_dir.join(format!("add-numbers{}", EXE_EXT));
-    fs::copy(&add_binary, &dest_binary).map_err(|e| format!("Failed to copy binary: {}", e))?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&dest_binary)
-            .map_err(|e| format!("Failed to get permissions: {}", e))?
-            .permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&dest_binary, perms)
-            .map_err(|e| format!("Failed to set permissions: {}", e))?;
-    }
+    let print_env_binary = config
+        .test_binaries_dir
+        .join(format!("print-env{}", EXE_EXT));
 
     // Write the manifest file (key value pairs separated by space)
-    let add_rlocation = format!("{}/bin/add-numbers{}", WORKSPACE_NAME, EXE_EXT);
-    let manifest_content = format!("{} {}\n", add_rlocation, dest_binary.display());
+    let print_env_rlocation = format!("{}/bin/print-env{}", WORKSPACE_NAME, EXE_EXT);
+    let manifest_content = format!("{} {}\n", print_env_rlocation, print_env_binary.display());
     fs::write(&manifest_path, manifest_content)
         .map_err(|e| format!("Failed to write manifest: {}", e))?;
 
     // Create the stub
-    finalize_stub(
-        config,
-        &stub_path,
-        &[&add_rlocation, "7", "8"],
-        &[0],
-    )?;
+    finalize_stub(config, &stub_path, &[&print_env_rlocation], &[0])?;
 
     // Run WITHOUT setting any environment variables
     let mut cmd = Command::new(&stub_path);
     cmd.env_remove("RUNFILES_DIR");
     cmd.env_remove("RUNFILES_MANIFEST_FILE");
+    cmd.env_remove("JAVA_RUNFILES");
 
     let output = cmd.output().map_err(|e| format!("Failed to run stub: {}", e))?;
 
@@ -771,9 +903,15 @@ fn test_fallback_runfiles_manifest(config: &TestConfig) -> Result<(), String> {
         ));
     }
 
-    if !stdout.contains("SUM:15") {
-        return Err(format!("Unexpected output: {}. Expected 'SUM:15'", stdout));
-    }
+    #[cfg(unix)]
+    let expected_argv0 = runfiles_dir.join(&print_env_rlocation);
+    #[cfg(windows)]
+    let expected_argv0 = print_env_binary;
+    assert_argv0(
+        &stdout,
+        &expected_argv0.to_string_lossy(),
+        "adjacent manifest argv0",
+    )?;
 
     println!("    PASS");
 
@@ -969,6 +1107,804 @@ fn test_relative_manifest_symlinks(config: &TestConfig) -> Result<(), String> {
     Ok(())
 }
 
+fn test_executable_fallback_selection(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: executable_fallback_selection");
+
+    let test_dir = config.work_dir.join("test_executable_fallback_selection");
+    // The Windows launcher obtains this path as UTF-16. A code point above
+    // U+00FF catches the old low-byte narrowing before fallback resolution.
+    let stub_dir = test_dir.join("launcher-東京");
+    let other_cwd = test_dir.join("other-cwd");
+    fs::create_dir_all(&stub_dir)
+        .map_err(|e| format!("Failed to create {}: {}", stub_dir.display(), e))?;
+    fs::create_dir_all(&other_cwd)
+        .map_err(|e| format!("Failed to create {}: {}", other_cwd.display(), e))?;
+
+    let print_env_binary = config
+        .test_binaries_dir
+        .join(format!("print-env{}", EXE_EXT));
+    let key = format!("{}/bin/print-env{}", WORKSPACE_NAME, EXE_EXT);
+    let mut primary = RunfilesSetup::new(&test_dir, "primary-東京")
+        .map_err(|e| format!("Failed to create runfiles: {}", e))?;
+    primary
+        .add_file(&key, &print_env_binary)
+        .map_err(|e| format!("Failed to add primary executable: {}", e))?;
+    primary
+        .write_manifest()
+        .map_err(|e| format!("Failed to write primary manifest: {}", e))?;
+    let fallback_arg = format!("../primary-東京.runfiles/{}", key);
+
+    let stub_path = stub_dir.join(format!("stub{}", EXE_EXT));
+    finalize_stub_with_fallbacks(
+        config,
+        &stub_path,
+        &[&key],
+        &[0],
+        &[(0, &fallback_arg)],
+        false,
+    )?;
+
+    let fallback_argv0 = format!(
+        "{}{}{}",
+        stub_dir.display(),
+        PATH_SEP,
+        fallback_arg.replace('/', &PATH_SEP.to_string())
+    );
+    let primary_argv0 = format!(
+        "{}{}{}",
+        primary.runfiles_dir.display(),
+        PATH_SEP,
+        key.replace('/', &PATH_SEP.to_string())
+    );
+    let stale_runfiles = test_dir.join("does-not-exist.runfiles");
+    let runfiles_file = test_dir.join("not-a-runfiles-directory");
+    fs::write(&runfiles_file, b"not a directory")
+        .map_err(|e| format!("Failed to write non-directory runfiles fixture: {}", e))?;
+    let stale_manifest = test_dir.join("stale.runfiles_manifest");
+    fs::write(
+        &stale_manifest,
+        format!("{} {}\n", key, test_dir.join("missing-primary").display()),
+    )
+    .map_err(|e| format!("Failed to write stale manifest: {}", e))?;
+    let cases = [
+        ("stale RUNFILES_DIR", None, fallback_argv0.as_str()),
+        (
+            "non-directory RUNFILES_DIR",
+            Some(("RUNFILES_DIR", runfiles_file.as_path())),
+            fallback_argv0.as_str(),
+        ),
+        (
+            "stale manifest target",
+            Some(("RUNFILES_MANIFEST_FILE", stale_manifest.as_path())),
+            fallback_argv0.as_str(),
+        ),
+        (
+            "primary runfile",
+            Some(("RUNFILES_DIR", primary.runfiles_dir.as_path())),
+            primary_argv0.as_str(),
+        ),
+        (
+            "primary manifest",
+            Some(("RUNFILES_MANIFEST_FILE", primary.manifest_path.as_path())),
+            primary_argv0.as_str(),
+        ),
+    ];
+    for (name, runfiles_setting, expected_argv0) in cases {
+        let mut command = Command::new(&stub_path);
+        let missing_manifest = test_dir.join("missing-manifest");
+        let mut expected_runfiles_dir = stale_runfiles.as_path();
+        let mut expected_manifest = missing_manifest.as_path();
+        command
+            .env_clear()
+            .current_dir(&other_cwd)
+            .env("RUNFILES_DIR", &stale_runfiles)
+            .env("RUNFILES_MANIFEST_FILE", &missing_manifest)
+            .env("JAVA_RUNFILES", &stale_runfiles);
+        if let Some((name, value)) = runfiles_setting {
+            command.env(name, value);
+            if name == "RUNFILES_DIR" {
+                expected_runfiles_dir = value;
+            } else if name == "RUNFILES_MANIFEST_FILE" {
+                expected_manifest = value;
+            }
+        }
+        let stdout = run_successful_stub(&mut command, name)?;
+        assert_argv0(&stdout, expected_argv0, name)?;
+        assert_runfiles_env(
+            &stdout,
+            &[
+                ("RUNFILES_DIR", Some(expected_runfiles_dir)),
+                ("RUNFILES_MANIFEST_FILE", Some(expected_manifest)),
+                ("JAVA_RUNFILES", Some(stale_runfiles.as_path())),
+            ],
+            name,
+        )?;
+    }
+
+    #[cfg(unix)]
+    {
+        let linked_stub_dir = test_dir.join("linked-launcher");
+        std::os::unix::fs::symlink(&stub_dir, &linked_stub_dir)
+            .map_err(|e| format!("Failed to create launcher directory symlink: {}", e))?;
+        let mut command = Command::new(linked_stub_dir.join(format!("stub{}", EXE_EXT)));
+        command.env_clear().current_dir(&other_cwd);
+        let stdout = run_successful_stub(&mut command, "symlinked launcher fallback")?;
+        let linked_argv0 = format!(
+            "{}{}{}",
+            linked_stub_dir.display(),
+            PATH_SEP,
+            fallback_arg.replace('/', &PATH_SEP.to_string())
+        );
+        assert_argv0(&stdout, &linked_argv0, "symlinked launcher fallback")?;
+    }
+
+    let exporting_stub = stub_dir.join(format!("exporting-stub{}", EXE_EXT));
+    finalize_stub_with_fallbacks(
+        config,
+        &exporting_stub,
+        &[&key],
+        &[0],
+        &[(0, &fallback_arg)],
+        true,
+    )?;
+    let mut exporting_command = Command::new(&exporting_stub);
+    exporting_command
+        .env_clear()
+        .env("RUNFILES_DIR", &runfiles_file)
+        .env("RUNFILES_MANIFEST_FILE", test_dir.join("missing-manifest"));
+    let stdout = run_successful_stub(
+        &mut exporting_command,
+        "exporting fallback stub without runfiles",
+    )?;
+    assert_argv0(
+        &stdout,
+        &fallback_argv0,
+        "exporting fallback stub without runfiles",
+    )?;
+    assert_runfiles_env(
+        &stdout,
+        &[
+            ("RUNFILES_DIR", None),
+            ("RUNFILES_MANIFEST_FILE", None),
+            ("JAVA_RUNFILES", None),
+        ],
+        "exporting fallback stub without runfiles",
+    )?;
+
+    let mut unicode_primary_command = Command::new(&exporting_stub);
+    unicode_primary_command
+        .env_clear()
+        .env("RUNFILES_DIR", &primary.runfiles_dir);
+    let stdout = run_successful_stub(
+        &mut unicode_primary_command,
+        "exporting fallback stub with Unicode primary runfiles",
+    )?;
+    assert_argv0(
+        &stdout,
+        &primary_argv0,
+        "exporting fallback stub with Unicode primary runfiles",
+    )?;
+    assert_runfiles_env(
+        &stdout,
+        &[
+            ("RUNFILES_DIR", Some(primary.runfiles_dir.as_path())),
+            ("JAVA_RUNFILES", Some(primary.runfiles_dir.as_path())),
+        ],
+        "exporting fallback stub with Unicode primary runfiles",
+    )?;
+
+    // A transformed absolute argument does not use runfiles and has no
+    // fallback. Preserve the existing export contract: the discovered context
+    // still replaces the child's inherited runfiles variables.
+    let absolute_stub = stub_dir.join(format!("absolute-stub{}", EXE_EXT));
+    let absolute_program = print_env_binary.to_string_lossy();
+    finalize_stub_with_fallbacks(
+        config,
+        &absolute_stub,
+        &[absolute_program.as_ref()],
+        &[0],
+        &[],
+        true,
+    )?;
+    let mut absolute_command = Command::new(&absolute_stub);
+    absolute_command
+        .env_clear()
+        .env("RUNFILES_DIR", &primary.runfiles_dir);
+    let stdout = run_successful_stub(
+        &mut absolute_command,
+        "transformed absolute executable with runfiles",
+    )?;
+    assert_argv0(
+        &stdout,
+        absolute_program.as_ref(),
+        "transformed absolute executable with runfiles",
+    )?;
+    assert_runfiles_env(
+        &stdout,
+        &[
+            ("RUNFILES_DIR", Some(primary.runfiles_dir.as_path())),
+            ("JAVA_RUNFILES", Some(primary.runfiles_dir.as_path())),
+        ],
+        "transformed absolute executable with runfiles",
+    )?;
+
+    // A valid but unrelated context must not leak into a child selected through
+    // executable-relative fallback. A nested launcher would otherwise mistake
+    // this manifest for its own runfiles and disable usable physical paths.
+    let child_manifest = test_dir.join("child-東京.runfiles_manifest");
+    fs::write(
+        &child_manifest,
+        format!(
+            "{}/child-only {}\n",
+            WORKSPACE_NAME,
+            print_env_binary.display()
+        ),
+    )
+    .map_err(|e| format!("Failed to write child-only manifest: {}", e))?;
+    let mut child_manifest_command = Command::new(&exporting_stub);
+    child_manifest_command
+        .env_clear()
+        .env("RUNFILES_MANIFEST_FILE", &child_manifest);
+    let stdout = run_successful_stub(
+        &mut child_manifest_command,
+        "fallback stub with child-only runfiles",
+    )?;
+    assert_argv0(
+        &stdout,
+        &fallback_argv0,
+        "fallback stub with child-only runfiles",
+    )?;
+    assert_runfiles_env(
+        &stdout,
+        &[
+            ("RUNFILES_DIR", None),
+            ("RUNFILES_MANIFEST_FILE", None),
+            ("JAVA_RUNFILES", None),
+        ],
+        "fallback stub with child-only runfiles",
+    )?;
+
+    println!(
+        "    PASS (Unicode path, inherited no-export env, fallback export, primary runfile, and unrelated-manifest scrub)"
+    );
+    Ok(())
+}
+
+#[cfg(target_os = "linux")]
+fn test_non_utf8_executable_relative_fallback(config: &TestConfig) -> Result<(), String> {
+    use std::fmt::Write as _;
+    use std::os::unix::ffi::{OsStrExt, OsStringExt};
+    use std::os::unix::fs::PermissionsExt;
+
+    println!("  Running test: non_utf8_executable_relative_fallback");
+
+    let test_dir = config
+        .work_dir
+        .join("test_non_utf8_executable_relative_fallback");
+    let mut directory_name = b"launcher-".to_vec();
+    directory_name.push(0xff);
+    let stub_dir = test_dir.join(std::ffi::OsString::from_vec(directory_name));
+    let fallback_dir = stub_dir.join("fallback");
+    let other_cwd = test_dir.join("other-cwd");
+    fs::create_dir_all(&fallback_dir)
+        .map_err(|e| format!("Failed to create non-UTF-8 launcher directory: {}", e))?;
+    fs::create_dir_all(&other_cwd)
+        .map_err(|e| format!("Failed to create {}: {}", other_cwd.display(), e))?;
+
+    let opaque_binary = config.test_binaries_dir.join("print-opaque-argv");
+    let fallback_binary = fallback_dir.join("print-opaque-argv");
+    fs::copy(&opaque_binary, &fallback_binary)
+        .map_err(|e| format!("Failed to copy opaque argv binary: {}", e))?;
+    let mut permissions = fs::metadata(&fallback_binary)
+        .map_err(|e| format!("Failed to stat opaque argv binary: {}", e))?
+        .permissions();
+    permissions.set_mode(0o755);
+    fs::set_permissions(&fallback_binary, permissions)
+        .map_err(|e| format!("Failed to make opaque argv binary executable: {}", e))?;
+
+    let finalized = test_dir.join("finalized-stub");
+    finalize_stub_with_fallbacks(
+        config,
+        &finalized,
+        &["_main/missing-opaque-primary"],
+        &[0],
+        &[(0, "fallback/print-opaque-argv")],
+        false,
+    )?;
+    let stub_path = stub_dir.join("stub");
+    fs::rename(&finalized, &stub_path)
+        .map_err(|e| format!("Failed to move launcher into non-UTF-8 directory: {}", e))?;
+
+    let mut command = Command::new(&stub_path);
+    command.env_clear().current_dir(&other_cwd);
+    let stdout = run_successful_stub(&mut command, "non-UTF-8 launcher fallback")?;
+
+    let mut expected_hex = String::new();
+    for byte in fallback_binary.as_os_str().as_bytes() {
+        write!(&mut expected_hex, "{byte:02x}")
+            .map_err(|e| format!("Failed to format expected argv[0]: {}", e))?;
+    }
+    let expected = format!("ARGV0_HEX:{expected_hex}");
+    if !stdout.contains(&expected) {
+        return Err(format!(
+            "Executable-relative fallback narrowed the non-UTF-8 launcher path\nexpected: {}\nstdout: {}",
+            expected, stdout
+        ));
+    }
+
+    println!("    PASS");
+    Ok(())
+}
+
+#[cfg(windows)]
+fn test_windows_extended_paths(config: &TestConfig) -> Result<(), String> {
+    use std::os::windows::ffi::OsStrExt;
+
+    println!("  Running test: windows_extended_paths");
+
+    let test_dir = config.work_dir.join("test_windows_extended_paths");
+    let stub_dir = test_dir
+        .join(format!("launcher-東京-{}", "a".repeat(180)))
+        .join(format!("nested-{}", "b".repeat(100)));
+    fs::create_dir_all(&stub_dir)
+        .map_err(|e| format!("Failed to create long launcher directory: {}", e))?;
+    if stub_dir.as_os_str().encode_wide().count() <= 260 {
+        return Err(format!(
+            "Windows extended-path fixture did not exceed MAX_PATH: {}",
+            stub_dir.display()
+        ));
+    }
+
+    let source_binary = config.test_binaries_dir.join("print-env.exe");
+    let fallback_binary = stub_dir.join("fallback-東京").join("print-env.exe");
+    let primary_binary = stub_dir.join("primary-主要").join("print-env.exe");
+    for destination in [&fallback_binary, &primary_binary] {
+        fs::create_dir_all(destination.parent().unwrap())
+            .map_err(|e| format!("Failed to create {}: {}", destination.display(), e))?;
+        fs::copy(&source_binary, destination)
+            .map_err(|e| format!("Failed to copy {}: {}", destination.display(), e))?;
+    }
+
+    let assert_path = |stdout: &str, expected: &Path, context: &str| -> Result<(), String> {
+        let actual = stdout
+            .lines()
+            .next()
+            .and_then(|line| line.strip_prefix("ARGS:"))
+            .and_then(|args| args.split('|').next())
+            .ok_or_else(|| format!("{} did not print argv[0]\nstdout: {}", context, stdout))?;
+        let actual = if let Some(rest) = actual.strip_prefix("\\\\?\\UNC\\") {
+            format!("\\\\{rest}")
+        } else if let Some(rest) = actual.strip_prefix("\\\\?\\") {
+            rest.to_string()
+        } else {
+            actual.to_string()
+        };
+        let expected = expected.to_string_lossy();
+        if !actual.eq_ignore_ascii_case(&expected) {
+            return Err(format!(
+                "{} selected the wrong long path\nexpected argv0: {}\nactual argv0: {}\nstdout: {}",
+                context, expected, actual, stdout
+            ));
+        }
+        Ok(())
+    };
+
+    let fallback_stub = stub_dir.join("fallback-stub.exe");
+    finalize_stub_with_fallbacks(
+        config,
+        &fallback_stub,
+        &["_main/missing-long-primary.exe"],
+        &[0],
+        &[(0, "fallback-東京/print-env.exe")],
+        false,
+    )?;
+    let mut fallback_command = Command::new(&fallback_stub);
+    fallback_command.env_clear();
+    let stdout = run_successful_stub(&mut fallback_command, "long Windows fallback")?;
+    assert_path(&stdout, &fallback_binary, "long Windows fallback")?;
+
+    let key = "_main/bin/print-env.exe";
+    let manifest_path = stub_dir.join("long-primary.runfiles_manifest");
+    fs::write(
+        &manifest_path,
+        format!(
+            "{} {}\n",
+            key,
+            primary_binary.to_string_lossy().replace('\\', "/")
+        ),
+    )
+    .map_err(|e| format!("Failed to write long manifest: {}", e))?;
+    let manifest_stub = stub_dir.join("manifest-stub.exe");
+    finalize_stub_with_fallbacks(
+        config,
+        &manifest_stub,
+        &[key],
+        &[0],
+        &[(0, "fallback-東京/print-env.exe")],
+        false,
+    )?;
+    let mut manifest_command = Command::new(&manifest_stub);
+    manifest_command
+        .env_clear()
+        .env("RUNFILES_MANIFEST_FILE", &manifest_path);
+    let stdout = run_successful_stub(&mut manifest_command, "long Windows manifest primary")?;
+    assert_path(&stdout, &primary_binary, "long Windows manifest primary")?;
+
+    println!("    PASS (fallback, manifest, existence check, and CreateProcessW)");
+    Ok(())
+}
+
+fn test_transformed_data_argument_falls_back(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: transformed_data_argument_falls_back");
+
+    let test_dir = config.work_dir.join("test_data_argument_fallback");
+    let stub_dir = test_dir.join("launcher");
+    fs::create_dir_all(&stub_dir)
+        .map_err(|e| format!("Failed to create {}: {}", stub_dir.display(), e))?;
+    let fallback_arg = "../fallback/input.txt";
+    let fallback_path = test_dir.join("fallback").join("input.txt");
+    fs::create_dir_all(fallback_path.parent().unwrap())
+        .map_err(|e| format!("Failed to create fallback data directory: {}", e))?;
+    fs::write(&fallback_path, b"Hello, World!\n")
+        .map_err(|e| format!("Failed to write fallback data: {}", e))?;
+
+    let hash_binary = config
+        .test_binaries_dir
+        .join(format!("hash-file{}", EXE_EXT));
+    let hash_key = format!("{}/bin/hash-file{}", WORKSPACE_NAME, EXE_EXT);
+    let mut primary = RunfilesSetup::new(&test_dir, "primary")
+        .map_err(|e| format!("Failed to create primary runfiles: {}", e))?;
+    primary
+        .add_file(&hash_key, &hash_binary)
+        .map_err(|e| format!("Failed to add primary hash executable: {}", e))?;
+    let missing_data_key = format!("{}/missing/input.txt", WORKSPACE_NAME);
+    let stub_path = stub_dir.join(format!("stub{}", EXE_EXT));
+    finalize_stub_with_fallbacks(
+        config,
+        &stub_path,
+        &[&hash_key, &missing_data_key],
+        &[0, 1],
+        &[(1, fallback_arg)],
+        false,
+    )?;
+
+    let missing_runfiles = Command::new(&stub_path)
+        .env_clear()
+        .output()
+        .map_err(|e| format!("Failed to run incomplete-fallback stub: {}", e))?;
+    let missing_stdout = String::from_utf8_lossy(&missing_runfiles.stdout);
+    if missing_runfiles.status.success()
+        || !missing_stdout.contains("Failed to initialize runfiles")
+    {
+        return Err(format!(
+            "Launcher accepted incomplete fallback coverage without runfiles\nstdout: {}\nstderr: {}",
+            missing_stdout,
+            String::from_utf8_lossy(&missing_runfiles.stderr)
+        ));
+    }
+
+    let mut command = Command::new(&stub_path);
+    command
+        .env_clear()
+        .env("RUNFILES_DIR", &primary.runfiles_dir);
+    let stdout = run_successful_stub(&mut command, "data-argument fallback stub")?;
+    let expected_hash = "c98c24b677eff44860afea6f493bbaec5bb1c4cbb209c6fc2bbb47f66ff2ad31";
+    if stdout.trim().to_lowercase() != format!("sha256:{}", expected_hash) {
+        return Err(format!(
+            "Transformed data argument did not select its executable-relative fallback\nstdout: {}",
+            stdout
+        ));
+    }
+
+    println!("    PASS");
+    Ok(())
+}
+
+fn test_no_transformed_arguments(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: no_transformed_arguments");
+
+    let test_dir = config.work_dir.join("test_no_transformed_arguments");
+    fs::create_dir_all(&test_dir)
+        .map_err(|e| format!("Failed to create {}: {}", test_dir.display(), e))?;
+    let print_env_binary = config
+        .test_binaries_dir
+        .join(format!("print-env{}", EXE_EXT));
+    let print_env_binary = print_env_binary.to_string_lossy();
+
+    let exporting_stub = test_dir.join(format!("exporting{}", EXE_EXT));
+    finalize_stub_with_fallbacks(
+        config,
+        &exporting_stub,
+        &[print_env_binary.as_ref()],
+        &[],
+        &[],
+        true,
+    )?;
+    let output = Command::new(&exporting_stub)
+        .env_clear()
+        .output()
+        .map_err(|e| format!("Failed to run no-transform exporting stub: {}", e))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    if output.status.success() || !stdout.contains("Failed to initialize runfiles") {
+        return Err(format!(
+            "No-transform exporting stub ran without runfiles\nstdout: {}\nstderr: {}",
+            stdout,
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    let non_exporting_stub = test_dir.join(format!("non-exporting{}", EXE_EXT));
+    finalize_stub_with_fallbacks(
+        config,
+        &non_exporting_stub,
+        &[print_env_binary.as_ref()],
+        &[],
+        &[],
+        false,
+    )?;
+    let mut command = Command::new(&non_exporting_stub);
+    let inherited_runfiles = test_dir.join("inherited.runfiles");
+    let inherited_manifest = test_dir.join("inherited.runfiles_manifest");
+    command
+        .env_clear()
+        .env("RUNFILES_DIR", &inherited_runfiles)
+        .env("RUNFILES_MANIFEST_FILE", &inherited_manifest)
+        .env("JAVA_RUNFILES", &inherited_runfiles);
+    let stdout = run_successful_stub(&mut command, "no-transform non-exporting stub")?;
+    assert_runfiles_env(
+        &stdout,
+        &[
+            ("RUNFILES_DIR", Some(inherited_runfiles.as_path())),
+            ("RUNFILES_MANIFEST_FILE", Some(inherited_manifest.as_path())),
+            ("JAVA_RUNFILES", Some(inherited_runfiles.as_path())),
+        ],
+        "no-transform non-exporting stub",
+    )?;
+
+    println!("    PASS");
+    Ok(())
+}
+
+fn test_finalizer_rejects_invalid_fallbacks(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: finalizer_rejects_invalid_fallbacks");
+
+    let cases: &[(&str, &[&str], &[&str], &str)] = &[
+        ("invalid", &["invalid"], &["arg0"], "expected N=PATH"),
+        (
+            "duplicate",
+            &["0=first", "0=second"],
+            &["arg0"],
+            "fallback argument 0 is declared more than once",
+        ),
+        (
+            "non-transformed",
+            &["1=path"],
+            &["arg0", "arg1"],
+            "fallback argument 1 is not marked for runfiles transformation",
+        ),
+        (
+            "out-of-range",
+            &["10=path"],
+            &["arg0"],
+            "fallback argument index 10 exceeds the maximum index 9",
+        ),
+        (
+            "absolute POSIX path",
+            &["0=/absolute/path"],
+            &["arg0"],
+            "fallback argument 0 path \"/absolute/path\" must be executable-relative",
+        ),
+        (
+            "absolute Windows drive path",
+            &["0=C:\\absolute\\path"],
+            &["arg0"],
+            "fallback argument 0 path \"C:\\\\absolute\\\\path\" must be executable-relative",
+        ),
+        (
+            "drive-relative Windows path",
+            &["0=C:relative\\path"],
+            &["arg0"],
+            "fallback argument 0 path \"C:relative\\\\path\" must be executable-relative",
+        ),
+        (
+            "absolute Windows UNC path",
+            &["0=\\\\server\\share\\tool"],
+            &["arg0"],
+            "fallback argument 0 path \"\\\\\\\\server\\\\share\\\\tool\" must be executable-relative",
+        ),
+        (
+            "absolute embedded argument",
+            &["0=relative/path"],
+            &["/absolute/program"],
+            "fallback argument 0 cannot be attached to absolute embedded argument \"/absolute/program\"",
+        ),
+    ];
+    for &(name, fallbacks, args, expected) in cases {
+        let mut command = Command::new(&config.finalizer_path);
+        command
+            .arg("--template")
+            .arg(&config.template_path)
+            .arg("--transform")
+            .arg("0");
+        for fallback in fallbacks {
+            command.arg("--fallback").arg(fallback);
+        }
+        let output = command
+            .arg("--")
+            .args(args)
+            .output()
+            .map_err(|e| format!("Failed to run {} finalizer case: {}", name, e))?;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if output.status.success() {
+            return Err(format!("Finalizer accepted {} fallback", name));
+        }
+        if !stderr.contains(expected) {
+            return Err(format!(
+                "Finalizer rejected {} fallback with the wrong diagnostic\nexpected: {}\nstderr: {}",
+                name, expected, stderr
+            ));
+        }
+    }
+
+    let boundary_output = config.work_dir.join(format!("boundary-stub{}", EXE_EXT));
+    let boundary_fallback = "x".repeat(254);
+    let boundary = Command::new(&config.finalizer_path)
+        .arg("--template")
+        .arg(&config.template_path)
+        .arg("--output")
+        .arg(&boundary_output)
+        .arg("--transform")
+        .arg("0")
+        .arg("--fallback")
+        .arg(format!("0={}", boundary_fallback))
+        .arg("--")
+        .arg("a")
+        .output()
+        .map_err(|e| format!("Failed to run exact-boundary finalizer case: {}", e))?;
+    if !boundary.status.success() {
+        return Err(format!(
+            "Finalizer rejected the exact 256-byte argument/fallback boundary: {}",
+            String::from_utf8_lossy(&boundary.stderr),
+        ));
+    }
+
+    let overflow = Command::new(&config.finalizer_path)
+        .arg("--template")
+        .arg(&config.template_path)
+        .arg("--transform")
+        .arg("0")
+        .arg("--fallback")
+        .arg(format!("0={}", "x".repeat(255)))
+        .arg("--")
+        .arg("a")
+        .output()
+        .map_err(|e| format!("Failed to run overflow finalizer case: {}", e))?;
+    let overflow_stderr = String::from_utf8_lossy(&overflow.stderr);
+    if overflow.status.success()
+        || !overflow_stderr
+            .contains("ARG0 and its fallback require 257 bytes; maximum combined size is 256 bytes")
+    {
+        return Err(format!(
+            "Finalizer did not enforce the combined slot boundary\nstderr: {}",
+            overflow_stderr,
+        ));
+    }
+
+    let old_fallback = Command::new(&config.finalizer_path)
+        .arg("--template")
+        .arg(&config.v1_template_path)
+        .arg("--transform")
+        .arg("0")
+        .arg("--fallback")
+        .arg("0=fallback")
+        .arg("--")
+        .arg("_main/missing")
+        .output()
+        .map_err(|e| format!("Failed to run published-V1-template fallback case: {}", e))?;
+    let old_fallback_stderr = String::from_utf8_lossy(&old_fallback.stderr);
+    if old_fallback.status.success()
+        || !old_fallback_stderr.contains(
+            "template does not support executable-relative fallbacks; use a V2 runfiles stub template",
+        )
+    {
+        return Err(format!(
+            "Finalizer did not reject fallback metadata for the published V1 template\nstderr: {}",
+            old_fallback_stderr,
+        ));
+    }
+
+    println!("    PASS (syntax, boundaries, absolutes, and template capability)");
+    Ok(())
+}
+
+fn test_finalizer_version_compatibility(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: finalizer_version_compatibility");
+
+    let test_dir = config.work_dir.join("test_finalizer_version_compatibility");
+    let print_env_binary = config
+        .test_binaries_dir
+        .join(format!("print-env{}", EXE_EXT));
+    let print_env_key = format!("{}/bin/print-env{}", WORKSPACE_NAME, EXE_EXT);
+    let mut runfiles = RunfilesSetup::new(&test_dir, "compat")
+        .map_err(|e| format!("Failed to create compatibility runfiles: {}", e))?;
+    runfiles
+        .add_file(&print_env_key, &print_env_binary)
+        .map_err(|e| format!("Failed to add compatibility executable: {}", e))?;
+    let expected_argv0 = runfiles
+        .get_path(&print_env_key)
+        .ok_or("Compatibility executable missing from runfiles fixture")?
+        .to_string_lossy()
+        .into_owned();
+    let stale_manifest = test_dir.join("inherited.runfiles_manifest");
+    let inherited_java = test_dir.join("inherited-java.runfiles");
+    let combinations = [
+        (
+            "published V1 finalizer with V2 template",
+            "v1-finalizer-v2-template",
+            config.v1_finalizer_path.as_path(),
+            config.template_path.as_path(),
+        ),
+        (
+            "V2 finalizer with published V1 template",
+            "v2-finalizer-v1-template",
+            config.finalizer_path.as_path(),
+            config.v1_template_path.as_path(),
+        ),
+    ];
+
+    for export_runfiles_env in [false, true] {
+        let suffix = if export_runfiles_env {
+            "export"
+        } else {
+            "preserve"
+        };
+        for (label, output_name, finalizer, template) in combinations {
+            let output = test_dir.join(format!("{output_name}-{suffix}{}", EXE_EXT));
+            finalize_stub_with_tools(
+                finalizer,
+                template,
+                &output,
+                &[&print_env_key],
+                &[0],
+                &[],
+                export_runfiles_env,
+            )?;
+
+            let context = format!("{} with export={}", label, export_runfiles_env);
+            let mut command = Command::new(&output);
+            command
+                .env_clear()
+                .env("RUNFILES_DIR", &runfiles.runfiles_dir)
+                .env("RUNFILES_MANIFEST_FILE", &stale_manifest)
+                .env("JAVA_RUNFILES", &inherited_java);
+            let stdout = run_successful_stub(&mut command, &context)?;
+            assert_argv0(&stdout, &expected_argv0, &context)?;
+            let expected_manifest = if export_runfiles_env {
+                None
+            } else {
+                Some(stale_manifest.as_path())
+            };
+            let expected_java = if export_runfiles_env {
+                runfiles.runfiles_dir.as_path()
+            } else {
+                inherited_java.as_path()
+            };
+            assert_runfiles_env(
+                &stdout,
+                &[
+                    ("RUNFILES_DIR", Some(runfiles.runfiles_dir.as_path())),
+                    ("RUNFILES_MANIFEST_FILE", expected_manifest),
+                    ("JAVA_RUNFILES", Some(expected_java)),
+                ],
+                &context,
+            )?;
+        }
+    }
+
+    println!("    PASS (published V1/V2 execution, transforms, and export settings)");
+    Ok(())
+}
+
 /// Test: print-env to verify environment and argument passing
 fn test_print_env(config: &TestConfig) -> Result<(), String> {
     println!("  Running test: print_env");
@@ -1009,6 +1945,11 @@ fn test_print_env(config: &TestConfig) -> Result<(), String> {
     if exit_code != 0 {
         return Err(format!("Stub failed with exit code {}: {}", exit_code, stderr));
     }
+    let manifest_argv0 = runfiles
+        .get_path(&print_env_rlocation)
+        .ok_or_else(|| format!("Missing manifest entry for {}", print_env_rlocation))?
+        .to_string_lossy();
+    assert_argv0(&stdout, &manifest_argv0, "manifest runfiles argv0")?;
 
     // Verify embedded arguments are passed
     if !stdout.contains("--embedded-flag") {
@@ -1180,9 +2121,35 @@ fn main() -> ExitCode {
         ("fallback_runfiles_manifest", test_fallback_runfiles_manifest),
         ("run_runfiles_discovery", test_run_runfiles_discovery),
         ("relative_manifest_symlinks", test_relative_manifest_symlinks),
+        (
+            "executable_fallback_selection",
+            test_executable_fallback_selection,
+        ),
+        (
+            "transformed_data_argument_falls_back",
+            test_transformed_data_argument_falls_back,
+        ),
+        ("no_transformed_arguments", test_no_transformed_arguments),
+        (
+            "finalizer_rejects_invalid_fallbacks",
+            test_finalizer_rejects_invalid_fallbacks,
+        ),
+        (
+            "finalizer_version_compatibility",
+            test_finalizer_version_compatibility,
+        ),
         ("print_env", test_print_env),
         ("large_manifest", test_large_manifest),
     ];
+    #[cfg(any(target_os = "linux", target_os = "windows"))]
+    let mut tests = tests;
+    #[cfg(target_os = "linux")]
+    tests.push((
+        "non_utf8_executable_relative_fallback",
+        test_non_utf8_executable_relative_fallback,
+    ));
+    #[cfg(windows)]
+    tests.push(("windows_extended_paths", test_windows_extended_paths));
 
     let mut passed = 0;
     let mut failed = 0;

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -1365,20 +1365,26 @@ fn test_executable_fallback_selection(config: &TestConfig) -> Result<(), String>
         "transformed absolute executable with runfiles",
     )?;
 
-    // A valid but unrelated context must not leak into a child selected through
-    // executable-relative fallback. A nested launcher would otherwise mistake
-    // this manifest for its own runfiles and disable usable physical paths.
+    // A context that resolves a data argument must not leak into a child selected
+    // through executable-relative fallback. A nested launcher would otherwise
+    // mistake this manifest for its own runfiles and disable usable physical paths.
     let child_manifest = test_dir.join("child-東京.runfiles_manifest");
+    let child_data_key = format!("{}/child-only", WORKSPACE_NAME);
     fs::write(
         &child_manifest,
-        format!(
-            "{}/child-only {}\n",
-            WORKSPACE_NAME,
-            print_env_binary.display()
-        ),
+        format!("{} {}\n", child_data_key, print_env_binary.display()),
     )
     .map_err(|e| format!("Failed to write child-only manifest: {}", e))?;
-    let mut child_manifest_command = Command::new(&exporting_stub);
+    let mixed_source_stub = stub_dir.join(format!("mixed-source-stub{}", EXE_EXT));
+    finalize_stub_with_fallbacks(
+        config,
+        &mixed_source_stub,
+        &[&key, &child_data_key],
+        &[0, 1],
+        &[(0, &fallback_arg)],
+        true,
+    )?;
+    let mut child_manifest_command = Command::new(&mixed_source_stub);
     child_manifest_command
         .env_clear()
         .env("RUNFILES_MANIFEST_FILE", &child_manifest);
@@ -1402,7 +1408,7 @@ fn test_executable_fallback_selection(config: &TestConfig) -> Result<(), String>
     )?;
 
     println!(
-        "    PASS (Unicode path, inherited no-export env, fallback export, primary runfile, and unrelated-manifest scrub)"
+        "    PASS (Unicode path, inherited no-export env, fallback export, primary runfile, and mixed-source scrub)"
     );
     Ok(())
 }

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -1661,6 +1661,37 @@ fn test_no_transformed_arguments(config: &TestConfig) -> Result<(), String> {
         "no-transform non-exporting stub",
     )?;
 
+    #[cfg(windows)]
+    {
+        let command_name = "literal-entrypoint";
+        let path_dir = test_dir.join("path");
+        fs::create_dir_all(&path_dir)
+            .map_err(|e| format!("Failed to create {}: {}", path_dir.display(), e))?;
+        fs::copy(
+            Path::new(print_env_binary.as_ref()),
+            path_dir.join(format!("{command_name}.exe")),
+        )
+        .map_err(|e| format!("Failed to create PATH executable: {e}"))?;
+
+        let path_search_stub = test_dir.join("path-search.exe");
+        finalize_stub_with_fallbacks(
+            config,
+            &path_search_stub,
+            &[command_name],
+            &[],
+            &[],
+            false,
+        )?;
+        let mut command = Command::new(&path_search_stub);
+        command.env("PATH", &path_dir);
+        let stdout = run_successful_stub(&mut command, "literal argv[0] found through PATH")?;
+        assert_argv0(
+            &stdout,
+            command_name,
+            "literal argv[0] found through PATH",
+        )?;
+    }
+
     println!("    PASS");
     Ok(())
 }

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -1166,6 +1166,19 @@ fn test_executable_fallback_selection(config: &TestConfig) -> Result<(), String>
         format!("{} {}\n", key, test_dir.join("missing-primary").display()),
     )
     .map_err(|e| format!("Failed to write stale manifest: {}", e))?;
+    let dangling_primary = test_dir.join("dangling-primary");
+    #[cfg(unix)]
+    std::os::unix::fs::symlink(test_dir.join("missing-primary"), &dangling_primary)
+        .map_err(|e| format!("Failed to create dangling primary symlink: {}", e))?;
+    #[cfg(windows)]
+    std::os::windows::fs::symlink_file(test_dir.join("missing-primary"), &dangling_primary)
+        .map_err(|e| format!("Failed to create dangling primary symlink: {}", e))?;
+    let dangling_manifest = test_dir.join("dangling.runfiles_manifest");
+    fs::write(
+        &dangling_manifest,
+        format!("{} {}\n", key, dangling_primary.display()),
+    )
+    .map_err(|e| format!("Failed to write dangling manifest: {}", e))?;
     let cases = [
         ("stale RUNFILES_DIR", None, fallback_argv0.as_str()),
         (
@@ -1176,6 +1189,11 @@ fn test_executable_fallback_selection(config: &TestConfig) -> Result<(), String>
         (
             "stale manifest target",
             Some(("RUNFILES_MANIFEST_FILE", stale_manifest.as_path())),
+            fallback_argv0.as_str(),
+        ),
+        (
+            "dangling manifest symlink",
+            Some(("RUNFILES_MANIFEST_FILE", dangling_manifest.as_path())),
             fallback_argv0.as_str(),
         ),
         (

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -1475,27 +1475,26 @@ fn test_non_utf8_executable_relative_fallback(config: &TestConfig) -> Result<(),
 
 #[cfg(windows)]
 fn test_windows_extended_paths(config: &TestConfig) -> Result<(), String> {
-    use std::os::windows::ffi::OsStrExt;
+    use std::os::windows::ffi::{OsStrExt, OsStringExt};
 
     println!("  Running test: windows_extended_paths");
 
     let test_dir = config.work_dir.join("test_windows_extended_paths");
-    let stub_dir = test_dir.join("launcher-東京");
-    let target_dir = stub_dir
-        .join(format!("targets-{}", "a".repeat(180)))
+    let stub_dir = test_dir
+        .join(format!("launcher-東京-{}", "a".repeat(180)))
         .join(format!("nested-{}", "b".repeat(100)));
     fs::create_dir_all(&stub_dir)
-        .map_err(|e| format!("Failed to create launcher directory: {}", e))?;
-
-    let source_binary = config.test_binaries_dir.join("print-env.exe");
-    let fallback_binary = target_dir.join("fallback-東京").join("print-env.exe");
-    let primary_binary = target_dir.join("primary-主要").join("print-env.exe");
-    if fallback_binary.as_os_str().encode_wide().count() <= 260 {
+        .map_err(|e| format!("Failed to create long launcher directory: {}", e))?;
+    if stub_dir.as_os_str().encode_wide().count() <= 260 {
         return Err(format!(
             "Windows extended-path fixture did not exceed MAX_PATH: {}",
-            fallback_binary.display()
+            stub_dir.display()
         ));
     }
+
+    let source_binary = config.test_binaries_dir.join("print-env.exe");
+    let fallback_binary = stub_dir.join("fallback-東京").join("print-env.exe");
+    let primary_binary = stub_dir.join("primary-主要").join("print-env.exe");
     for destination in [&fallback_binary, &primary_binary] {
         fs::create_dir_all(destination.parent().unwrap())
             .map_err(|e| format!("Failed to create {}: {}", destination.display(), e))?;
@@ -1520,24 +1519,29 @@ fn test_windows_extended_paths(config: &TestConfig) -> Result<(), String> {
         Ok(())
     };
 
-    let target_relative = target_dir
-        .strip_prefix(&stub_dir)
-        .map_err(|e| format!("Failed to relativize long target directory: {}", e))?;
-    let fallback_arg = target_relative
-        .join("fallback-東京")
-        .join("print-env.exe")
-        .to_string_lossy()
-        .replace('\\', "/");
+    // Invoke the long fixture through Win32's verbatim spelling so the test
+    // reaches the launcher's path handling instead of failing in Command.
+    let verbatim_path = |path: &Path| {
+        let mut result: Vec<u16> = "\\\\?\\".encode_utf16().collect();
+        result.extend(path.as_os_str().encode_wide().map(|unit| {
+            if unit == b'/' as u16 {
+                b'\\' as u16
+            } else {
+                unit
+            }
+        }));
+        PathBuf::from(std::ffi::OsString::from_wide(&result))
+    };
     let fallback_stub = stub_dir.join("fallback-stub.exe");
     finalize_stub_with_fallbacks(
         config,
         &fallback_stub,
         &["_main/missing-long-primary.exe"],
         &[0],
-        &[(0, &fallback_arg)],
+        &[(0, "fallback-東京/print-env.exe")],
         false,
     )?;
-    let mut fallback_command = Command::new(&fallback_stub);
+    let mut fallback_command = Command::new(verbatim_path(&fallback_stub));
     fallback_command.env_clear();
     let stdout = run_successful_stub(&mut fallback_command, "long Windows fallback")?;
     assert_path(&stdout, &fallback_binary, "long Windows fallback")?;
@@ -1559,10 +1563,10 @@ fn test_windows_extended_paths(config: &TestConfig) -> Result<(), String> {
         &manifest_stub,
         &[key],
         &[0],
-        &[(0, &fallback_arg)],
+        &[(0, "fallback-東京/print-env.exe")],
         false,
     )?;
-    let mut manifest_command = Command::new(&manifest_stub);
+    let mut manifest_command = Command::new(verbatim_path(&manifest_stub));
     manifest_command
         .env_clear()
         .env("RUNFILES_MANIFEST_FILE", &manifest_path);

--- a/integration-tests/v1_compatibility_repositories.bzl
+++ b/integration-tests/v1_compatibility_repositories.bzl
@@ -1,0 +1,65 @@
+"""Immutable V1 release artifacts used only by integration tests."""
+
+load("@bazel_tools//tools/build_defs/repo:http.bzl", "http_file")
+
+_ARTIFACTS = {
+    "finalize-stub-aarch64-linux": {
+        "name": "v1_compat_20260619_finalize_stub_aarch64_linux",
+        "sha256": "042bf32e5b511a8b2a346f34e79876e0ee252fea03a6c73bd16d23e5785b298c",
+    },
+    "finalize-stub-aarch64-macos": {
+        "name": "v1_compat_20260619_finalize_stub_aarch64_macos",
+        "sha256": "e4578d8b8056c857a64dc18144de7272243582f82da76346cd71dfb9ee0eb163",
+    },
+    "finalize-stub-x86_64-linux": {
+        "name": "v1_compat_20260619_finalize_stub_x86_64_linux",
+        "sha256": "c7a09c660f998150305b32bdc619820ec1c7b4a8be153901cb1e32c3ba0e44e9",
+    },
+    "finalize-stub-x86_64-macos": {
+        "name": "v1_compat_20260619_finalize_stub_x86_64_macos",
+        "sha256": "555b7aadaa2a0061ea37ccae8b6e4095a6310178f86d310672473d40eb7f4269",
+    },
+    "finalize-stub-x86_64-windows.exe": {
+        "name": "v1_compat_20260619_finalize_stub_x86_64_windows",
+        "sha256": "e9c6610f3a08e0a4989a7a2dc5923403d376b5732425e42a6e394238089a8389",
+    },
+    "runfiles-stub-aarch64-linux": {
+        "name": "v1_compat_20260619_runfiles_stub_aarch64_linux",
+        "sha256": "1bc3c4308410685958e4b1b7a10f0a61e5a817b0298a5493073ebafd62fc3e0f",
+    },
+    "runfiles-stub-aarch64-macos": {
+        "name": "v1_compat_20260619_runfiles_stub_aarch64_macos",
+        "sha256": "d998a9751cdf5d114a47f2bb6ccc2d24405c6e9550488ce0cdbff1bb7e3ab4e9",
+    },
+    "runfiles-stub-x86_64-linux": {
+        "name": "v1_compat_20260619_runfiles_stub_x86_64_linux",
+        "sha256": "1cfdfe80a0d06eecf8b063f4604102de001f6d75d9a81eeb294964aab6c6a888",
+    },
+    "runfiles-stub-x86_64-macos": {
+        "name": "v1_compat_20260619_runfiles_stub_x86_64_macos",
+        "sha256": "4af8603ac91c2183133fa3c81fd98bb56310fbbb35408346a09f65586f2abd0d",
+    },
+    "runfiles-stub-x86_64-windows.exe": {
+        "name": "v1_compat_20260619_runfiles_stub_x86_64_windows",
+        "sha256": "978090fc2914e2aa3b4c83ca5f3899d2651ff367e43e1d21688923ea5eb1594e",
+    },
+}
+
+def _v1_compatibility_repositories_impl(ctx):
+    for filename, attrs in _ARTIFACTS.items():
+        http_file(
+            name = attrs["name"],
+            downloaded_file_path = filename,
+            executable = True,
+            sha256 = attrs["sha256"],
+            url = "https://github.com/hermeticbuild/hermetic-launcher/releases/download/binaries-20260619/{}".format(filename),
+        )
+    return ctx.extension_metadata(
+        reproducible = True,
+        root_module_direct_deps = [],
+        root_module_direct_dev_deps = "all",
+    )
+
+v1_compatibility_repositories = module_extension(
+    implementation = _v1_compatibility_repositories_impl,
+)

--- a/runfiles-stub/BUILD.bazel
+++ b/runfiles-stub/BUILD.bazel
@@ -1,3 +1,4 @@
+load("@rules_rust//rust:defs.bzl", "rust_test")
 load("//:defs.bzl", "rust_release_binary")
 
 rust_release_binary(
@@ -22,4 +23,13 @@ rust_release_binary(
         ],
         "//conditions:default": [],
     }),
+)
+
+rust_test(
+    name = "native_path_test",
+    srcs = [
+        "src/native_path.rs",
+        "tests/native_path_test.rs",
+    ],
+    edition = "2021",
 )

--- a/runfiles-stub/src/common.rs
+++ b/runfiles-stub/src/common.rs
@@ -17,6 +17,11 @@ pub fn cstr_len(s: &[u8]) -> usize {
 /// returned unchanged; a relative one is joined onto the current working
 /// directory. Best-effort: if the cwd is unavailable, the path is returned as-is.
 pub fn absolutize(path: Vec<u8>) -> Vec<u8> {
+    #[cfg(any(target_os = "linux", target_os = "macos"))]
+    if crate::native_path::unix_path_is_absolute(&path) {
+        return path;
+    }
+    #[cfg(target_os = "windows")]
     if let Ok(s) = core::str::from_utf8(&path) {
         if platform::is_absolute(s) {
             return path;

--- a/runfiles-stub/src/linux.rs
+++ b/runfiles-stub/src/linux.rs
@@ -7,7 +7,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use crate::common::Manifest;
-use crate::run::Launch;
+use crate::run::{Launch, ResolvedArg};
 use crate::runfiles::Runfiles;
 
 // Compiler intrinsics and glibc-compat symbols. These are needed because we link
@@ -343,6 +343,24 @@ pub fn path_exists(path: &[u8]) -> bool {
     }
 }
 
+pub fn utf8_path_exists(path: &str) -> bool {
+    let mut terminated = Vec::from(path.as_bytes());
+    terminated.push(0);
+    path_exists(&terminated)
+}
+
+pub fn executable_relative(executable: &[u8], fallback: &str) -> Option<ResolvedArg> {
+    crate::native_path::unix_executable_relative(executable, fallback.as_bytes())
+        .map(ResolvedArg::Bytes)
+}
+
+pub fn resolved_arg_exists(arg: &ResolvedArg) -> bool {
+    let ResolvedArg::Bytes(path) = arg;
+    let mut terminated = path.clone();
+    terminated.push(0);
+    path_exists(&terminated)
+}
+
 // getcwd(2) into `buf`. Returns the number of bytes written (including the
 // trailing NUL) on success, or a negative value on error.
 fn getcwd(buf: &mut [u8]) -> isize {
@@ -474,12 +492,7 @@ fn read_environ() -> (Vec<u8>, Vec<*const u8>) {
 
 // Build modified environment with runfiles variables; pointers point into data.
 fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u8>) {
-    let (base_data, base_ptrs) = read_environ();
-
-    let rf = match runfiles {
-        Some(r) => r,
-        None => return (base_data, base_ptrs),
-    };
+    let (base_data, _) = read_environ();
 
     let mut env_data = Vec::new();
     let mut env_ptrs = Vec::new();
@@ -493,15 +506,17 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u
         ptrs.push(start_pos as *const u8);
     };
 
-    if let Some(ref path) = rf.manifest_path {
-        add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
-    }
-    if let Some(ref path) = rf.dir_path {
-        add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_DIR", path);
-        add_env_var(&mut env_data, &mut env_ptrs, b"JAVA_RUNFILES", path);
+    if let Some(rf) = runfiles {
+        if let Some(ref path) = rf.manifest_path {
+            add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
+        }
+        if let Some(ref path) = rf.dir_path {
+            add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_DIR", path);
+            add_env_var(&mut env_data, &mut env_ptrs, b"JAVA_RUNFILES", path);
+        }
     }
 
-    // Copy existing environment (skip runfiles vars we're setting).
+    // Copy the existing environment without inherited runfiles variables.
     for env_entry in base_data.split(|&b| b == 0) {
         if env_entry.is_empty() {
             continue;
@@ -558,6 +573,10 @@ impl RuntimeArgs {
         let raw = unsafe { core::slice::from_raw_parts(self.execfn, len) }.to_vec();
         Some(crate::common::absolutize(raw))
     }
+
+    pub fn fallback_executable_path(&self) -> Option<Vec<u8>> {
+        self.executable_path()
+    }
 }
 
 pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
@@ -583,7 +602,8 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
     // Build the argv pointer array: embedded resolved + runtime + NULL.
     let mut ptrs: Vec<*const u8> = Vec::with_capacity(launch.resolved.len() + runtime.len() + 1);
     for a in launch.resolved {
-        ptrs.push(a.as_ptr());
+        let ResolvedArg::Bytes(bytes) = a;
+        ptrs.push(bytes.as_ptr());
     }
     for a in &runtime {
         ptrs.push(a.as_ptr());
@@ -592,13 +612,14 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
 
     // The program to execute is the fully-resolved arg0; argv[0] may be overridden
     // with the runfiles-relative path (read program before overwriting ptrs[0]).
-    let program = launch.resolved[0].as_ptr();
+    let ResolvedArg::Bytes(program) = &launch.resolved[0];
+    let program = program.as_ptr();
     if let Some(override0) = launch.argv0_override {
         ptrs[0] = override0.as_ptr();
     }
 
-    let (_env_data, env_ptrs) = if launch.export_env {
-        build_runfiles_environ(launch.runfiles)
+    let (_env_data, env_ptrs) = if launch.export_runfiles_env {
+        build_runfiles_environ(launch.child_runfiles)
     } else {
         read_environ()
     };

--- a/runfiles-stub/src/macos.rs
+++ b/runfiles-stub/src/macos.rs
@@ -10,7 +10,7 @@ use alloc::string::String;
 use alloc::vec::Vec;
 
 use crate::common::{cstr_len, Manifest};
-use crate::run::Launch;
+use crate::run::{Launch, ResolvedArg};
 use crate::runfiles::Runfiles;
 
 // Compiler intrinsics. Provided in-tree because we own the entry point and make no
@@ -301,6 +301,24 @@ pub fn path_exists(path: &[u8]) -> bool {
     unsafe { syscall2!(i32; SYS_ACCESS, path.as_ptr(), 0i32) == 0 }
 }
 
+pub fn utf8_path_exists(path: &str) -> bool {
+    let mut terminated = Vec::from(path.as_bytes());
+    terminated.push(0);
+    path_exists(&terminated)
+}
+
+pub fn executable_relative(executable: &[u8], fallback: &str) -> Option<ResolvedArg> {
+    crate::native_path::unix_executable_relative(executable, fallback.as_bytes())
+        .map(ResolvedArg::Bytes)
+}
+
+pub fn resolved_arg_exists(arg: &ResolvedArg) -> bool {
+    let ResolvedArg::Bytes(path) = arg;
+    let mut terminated = path.clone();
+    terminated.push(0);
+    path_exists(&terminated)
+}
+
 fn fcntl(fd: i32, cmd: i32, arg: *mut u8) -> i32 {
     unsafe { syscall3!(i32; SYS_FCNTL, fd, cmd, arg) }
 }
@@ -427,7 +445,7 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u
         }
     }
 
-    // Copy existing environment, filtering out the runfiles vars we just set.
+    // Copy the existing environment without inherited runfiles variables.
     unsafe {
         each_env(|entry| {
             let should_skip = entry.starts_with(b"RUNFILES_MANIFEST_FILE=")
@@ -505,6 +523,10 @@ impl RuntimeArgs {
         }
         Some(crate::common::absolutize(path.to_vec()))
     }
+
+    pub fn fallback_executable_path(&self) -> Option<Vec<u8>> {
+        self.executable_path()
+    }
 }
 
 pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
@@ -529,7 +551,8 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
         // Build the argv pointer array: embedded resolved + runtime + NULL.
         let mut ptrs: Vec<*const u8> = Vec::with_capacity(launch.resolved.len() + runtime.len() + 1);
         for a in launch.resolved {
-            ptrs.push(a.as_ptr());
+            let ResolvedArg::Bytes(bytes) = a;
+            ptrs.push(bytes.as_ptr());
         }
         for a in &runtime {
             ptrs.push(a.as_ptr());
@@ -538,14 +561,15 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
 
         // The program to execute is the fully-resolved arg0; argv[0] may be overridden
         // with the runfiles-relative path (read program before overwriting ptrs[0]).
-        let program = launch.resolved[0].as_ptr();
+        let ResolvedArg::Bytes(program) = &launch.resolved[0];
+        let program = program.as_ptr();
         if let Some(override0) = launch.argv0_override {
             ptrs[0] = override0.as_ptr();
         }
 
         // Build the environment.
-        let (_env_data, env_ptrs) = if launch.export_env {
-            build_runfiles_environ(launch.runfiles)
+        let (_env_data, env_ptrs) = if launch.export_runfiles_env {
+            build_runfiles_environ(launch.child_runfiles)
         } else {
             (Vec::new(), clone_environ())
         };

--- a/runfiles-stub/src/main.rs
+++ b/runfiles-stub/src/main.rs
@@ -23,6 +23,7 @@ fn panic(_info: &PanicInfo) -> ! {
 
 mod allocator;
 mod common;
+mod native_path;
 mod placeholders;
 mod run;
 mod runfiles;

--- a/runfiles-stub/src/native_path.rs
+++ b/runfiles-stub/src/native_path.rs
@@ -1,0 +1,189 @@
+extern crate alloc;
+
+use alloc::vec::Vec;
+
+#[cfg(any(test, target_os = "windows"))]
+const WINDOWS_SEPARATOR: u16 = b'\\' as u16;
+
+#[cfg(any(test, target_os = "linux", target_os = "macos"))]
+pub fn unix_path_is_absolute(path: &[u8]) -> bool {
+    path.first() == Some(&b'/')
+}
+
+/// Join a UTF-8 fallback to the byte path used to launch a Unix executable.
+/// The executable prefix stays opaque so valid non-UTF-8 path bytes survive.
+#[cfg(any(test, target_os = "linux", target_os = "macos"))]
+pub fn unix_executable_relative(executable: &[u8], fallback: &[u8]) -> Option<Vec<u8>> {
+    let separator = executable.iter().rposition(|byte| *byte == b'/')?;
+    let mut path = Vec::from(&executable[..separator]);
+    if path.last() != Some(&b'/') {
+        path.push(b'/');
+    }
+    path.extend_from_slice(fallback);
+    Some(path)
+}
+
+/// Join a UTF-16 fallback to the path of a Windows executable without
+/// narrowing any code units.
+#[cfg(any(test, target_os = "windows"))]
+pub fn windows_executable_relative(executable: &[u16], fallback: &str) -> Option<Vec<u16>> {
+    let separator = executable
+        .iter()
+        .rposition(|unit| *unit == b'/' as u16 || *unit == b'\\' as u16)?;
+    let mut path = Vec::from(&executable[..separator]);
+    if !matches!(path.last(), Some(unit) if *unit == b'/' as u16 || *unit == b'\\' as u16) {
+        path.push(b'\\' as u16);
+    }
+    path.extend(fallback.encode_utf16().map(|unit| {
+        if unit == b'/' as u16 {
+            b'\\' as u16
+        } else {
+            unit
+        }
+    }));
+    Some(path)
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn windows_is_separator(unit: u16) -> bool {
+    unit == b'/' as u16 || unit == WINDOWS_SEPARATOR
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn windows_starts_with_ascii(path: &[u16], prefix: &[u8]) -> bool {
+    path.len() >= prefix.len()
+        && path[..prefix.len()]
+            .iter()
+            .zip(prefix)
+            .all(|(&unit, &byte)| {
+                let unit = if (b'a' as u16..=b'z' as u16).contains(&unit) {
+                    unit - 32
+                } else {
+                    unit
+                };
+                let byte = byte.to_ascii_uppercase() as u16;
+                unit == byte
+            })
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn windows_next_component<'a>(path: &'a [u16], position: &mut usize) -> Option<&'a [u16]> {
+    while *position < path.len() && windows_is_separator(path[*position]) {
+        *position += 1;
+    }
+    if *position == path.len() {
+        return None;
+    }
+    let start = *position;
+    while *position < path.len() && !windows_is_separator(path[*position]) {
+        *position += 1;
+    }
+    Some(&path[start..*position])
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn windows_normalized_components(path: &[u16], mut position: usize) -> Vec<&[u16]> {
+    let mut components = Vec::new();
+    while let Some(component) = windows_next_component(path, &mut position) {
+        if component == [b'.' as u16] || component.is_empty() {
+            continue;
+        }
+        if component == [b'.' as u16, b'.' as u16] {
+            components.pop();
+            continue;
+        }
+        components.push(component);
+    }
+    components
+}
+
+#[cfg(any(test, target_os = "windows"))]
+fn windows_push_components(path: &mut Vec<u16>, components: &[&[u16]]) {
+    for component in components {
+        if path.last() != Some(&WINDOWS_SEPARATOR) {
+            path.push(WINDOWS_SEPARATOR);
+        }
+        path.extend_from_slice(component);
+    }
+}
+
+/// Convert an absolute DOS or UNC path to normalized Win32 verbatim form.
+/// Relative and drive-relative paths are rejected so their current-directory
+/// semantics are not accidentally changed.
+#[cfg(any(test, target_os = "windows"))]
+pub fn windows_extended_path(path: &[u16]) -> Option<Vec<u16>> {
+    let path = path.strip_suffix(&[0]).unwrap_or(path);
+    let has_verbatim_prefix = windows_starts_with_ascii(path, b"\\\\?\\");
+
+    let unc_start = if windows_starts_with_ascii(path, b"\\\\?\\UNC\\") {
+        Some(8)
+    } else if !has_verbatim_prefix
+        && path.len() >= 2
+        && windows_is_separator(path[0])
+        && windows_is_separator(path[1])
+    {
+        Some(2)
+    } else {
+        None
+    };
+    if let Some(mut position) = unc_start {
+        let server = windows_next_component(path, &mut position)?;
+        let share = windows_next_component(path, &mut position)?;
+        if server.is_empty()
+            || share.is_empty()
+            || server == [b'.' as u16]
+            || server == [b'.' as u16, b'.' as u16]
+            || share == [b'.' as u16]
+            || share == [b'.' as u16, b'.' as u16]
+        {
+            return None;
+        }
+
+        let mut extended: Vec<u16> = b"\\\\?\\UNC\\".iter().map(|&byte| byte as u16).collect();
+        extended.extend_from_slice(server);
+        extended.push(WINDOWS_SEPARATOR);
+        extended.extend_from_slice(share);
+        let components = windows_normalized_components(path, position);
+        windows_push_components(&mut extended, &components);
+        return Some(extended);
+    }
+
+    let drive_start = if has_verbatim_prefix { 4 } else { 0 };
+    let drive = path.get(drive_start).copied().unwrap_or(0);
+    if path.len() < drive_start + 3
+        || !((b'A' as u16..=b'Z' as u16).contains(&drive)
+            || (b'a' as u16..=b'z' as u16).contains(&drive))
+        || path[drive_start + 1] != b':' as u16
+        || !windows_is_separator(path[drive_start + 2])
+    {
+        return None;
+    }
+
+    let mut extended: Vec<u16> = b"\\\\?\\".iter().map(|&byte| byte as u16).collect();
+    extended.extend_from_slice(&path[drive_start..drive_start + 2]);
+    extended.push(WINDOWS_SEPARATOR);
+    let components = windows_normalized_components(path, drive_start + 3);
+    windows_push_components(&mut extended, &components);
+    Some(extended)
+}
+
+/// Return a NUL-terminated path for a Win32 file/process API. Absolute DOS and
+/// UNC paths use verbatim form to avoid MAX_PATH; relative paths retain their
+/// original current-directory semantics.
+#[cfg(any(test, target_os = "windows"))]
+pub fn windows_api_path(path: &[u16]) -> Vec<u16> {
+    let path = path.strip_suffix(&[0]).unwrap_or(path);
+    let mut api_path = windows_extended_path(path).unwrap_or_else(|| {
+        path.iter()
+            .map(|&unit| {
+                if unit == b'/' as u16 {
+                    WINDOWS_SEPARATOR
+                } else {
+                    unit
+                }
+            })
+            .collect()
+    });
+    api_path.push(0);
+    api_path
+}

--- a/runfiles-stub/src/placeholders.rs
+++ b/runfiles-stub/src/placeholders.rs
@@ -21,7 +21,7 @@ macro_rules! define_placeholders {
 
         #[used]
         #[link_section = $section]
-        static mut EXPORT_RUNFILES_ENV: [u8; 32] = *b"@@RUNFILES_EXPORT_ENV@@\0\0\0\0\0\0\0\0\0";
+        static mut EXPORT_RUNFILES_ENV: [u8; 32] = *b"@@RUNFILES_EXPORT_ENV@@V2\0\0\0\0\0\0\0";
 
         // The ten argument placeholders as one contiguous 2D array rather than ten
         // separate statics. `arg()` indexes it with pointer arithmetic, which lowers
@@ -30,7 +30,8 @@ macro_rules! define_placeholders {
         // arm64 macOS) that table needs load-time rebasing — which would force a
         // writable, file-backed `__DATA` page back into existence. The bytes on disk
         // (2560 contiguous '@') are identical either way, so the finalizer's
-        // 256-byte-run scan is unaffected.
+        // 256-byte-run scan is unaffected. A fallback, when present, follows
+        // the argument's terminating NUL in the same slot.
         #[used]
         #[link_section = $section]
         static mut ARGS: [[u8; ARG_SIZE]; 10] = [[b'@'; ARG_SIZE]; 10];
@@ -72,6 +73,14 @@ pub fn arg(i: usize) -> &'static [u8] {
     let base = core::ptr::addr_of!(ARGS) as *const u8;
     let ptr = unsafe { base.add(idx * ARG_SIZE) };
     read(ptr, ARG_SIZE)
+}
+
+pub fn fallback(i: usize) -> &'static [u8] {
+    let arg = arg(i);
+    match arg.iter().position(|byte| *byte == 0) {
+        Some(arg_len) if arg_len + 1 < arg.len() => &arg[arg_len + 1..],
+        _ => &[],
+    }
 }
 
 /// True if the placeholder still holds its unpatched template value.

--- a/runfiles-stub/src/run.rs
+++ b/runfiles-stub/src/run.rs
@@ -13,17 +13,29 @@ use alloc::vec::Vec;
 use crate::common::cstr_len;
 use crate::placeholders::{self, is_template_placeholder};
 use crate::platform;
-use crate::runfiles::Runfiles;
+use crate::runfiles::{path_exists, Runfiles};
+
+pub enum ResolvedArg {
+    /// Native path bytes on Unix; UTF-8 runfiles and embedded arguments on Windows.
+    Bytes(Vec<u8>),
+    /// A path obtained from a native Windows API. Keeping it wide preserves
+    /// executable locations that cannot be represented by narrowing UTF-16.
+    #[cfg(target_os = "windows")]
+    Wide(Vec<u16>),
+}
 
 /// Everything the backend needs to launch the target, in OS-neutral form.
-/// `resolved[0]` is the program to execute; bytes are NUL-terminated.
+/// `resolved[0]` is the program to execute; native code units are NUL-terminated.
 pub struct Launch<'a> {
-    pub resolved: &'a [Vec<u8>],
+    pub resolved: &'a [ResolvedArg],
     /// Runfiles-relative argv[0] (used by Unix to preserve symlink walks; ignored on Windows).
     #[allow(dead_code)] // unused on Windows (CreateProcessW derives argv[0] from the command line)
     pub argv0_override: Option<&'a [u8]>,
-    pub runfiles: Option<&'a Runfiles>,
-    pub export_env: bool,
+    /// Replace inherited runfiles variables when true; preserve them when false.
+    pub export_runfiles_env: bool,
+    /// The related runfiles context to export. None with export enabled scrubs
+    /// inherited runfiles variables after fallback selected physical paths.
+    pub child_runfiles: Option<&'a Runfiles>,
 }
 
 /// Print `msg` followed by the platform newline.
@@ -90,26 +102,53 @@ pub fn main(rt: platform::RuntimeArgs) -> ! {
         true
     };
 
-    // Decide whether runfiles are needed at all.
+    // Always try runfiles first when an argument is transformed. A launcher
+    // without transformed arguments can still require runfiles solely to export
+    // them. Otherwise initialization may fail only when every transformed
+    // argument can fall back.
     let argc_mask = if argc >= 32 { 0xFFFFFFFF } else { (1u32 << argc) - 1 };
-    let needs_transform = (transform_flags & argc_mask) != 0;
-    let needs_runfiles = needs_transform || export_runfiles_env;
+    let transformed_args = transform_flags & argc_mask;
+    let mut fallback_args = 0u32;
+    for i in 0..argc {
+        if cstr_len(placeholders::fallback(i)) != 0 {
+            fallback_args |= 1 << i;
+        }
+    }
+    let needs_transform = transformed_args != 0;
+    let requires_runfiles = if needs_transform {
+        (transformed_args & !fallback_args) != 0
+    } else {
+        export_runfiles_env
+    };
 
-    let runfiles = if needs_runfiles {
+    let runfiles = if needs_transform || export_runfiles_env {
         match Runfiles::create(&rt) {
             Some(rf) => Some(rf),
-            None => {
+            None if requires_runfiles => {
                 eline(b"ERROR: Failed to initialize runfiles");
                 eline(b"Set RUNFILES_DIR or RUNFILES_MANIFEST_FILE, or ensure <executable>.runfiles/ directory exists");
                 platform::exit(1);
             }
+            None => None,
         }
     } else {
         None
     };
 
+    // Keep the OS-reported executable path in its native representation.
+    // Fallback joining must preserve both non-UTF-8 Unix bytes and UTF-16
+    // Windows paths rather than narrowing them through a shared String.
+    let executable_path = if fallback_args != 0 {
+        rt.fallback_executable_path()
+    } else {
+        None
+    };
+
     // Resolve each embedded argument (NUL-terminated). resolved[0] is the program.
-    let mut resolved: Vec<Vec<u8>> = Vec::with_capacity(argc);
+    let mut resolved: Vec<ResolvedArg> = Vec::with_capacity(argc);
+    let mut arg0_from_runfiles = false;
+    let mut any_arg_from_runfiles = false;
+    let mut any_fallback_selected = false;
     for i in 0..argc {
         let arg_data = placeholders::arg(i);
         let arg_len = cstr_len(arg_data);
@@ -121,48 +160,103 @@ pub fn main(rt: platform::RuntimeArgs) -> ! {
         }
         let arg_slice = &arg_data[..arg_len];
         let should_transform = (transform_flags & (1 << i)) != 0;
+        let has_fallback = (fallback_args & (1 << i)) != 0;
 
-        // Resolve through runfiles when marked and possible; otherwise use as-is.
-        let mut bytes = if should_transform {
-            match runfiles.as_ref().and_then(|rf| {
-                core::str::from_utf8(arg_slice).ok().and_then(|s| rf.rlocation(s))
-            }) {
-                Some(resolved_str) => Vec::from(resolved_str.as_bytes()),
-                None => arg_slice.to_vec(),
+        // A fallback-enabled argument accepts its runfiles candidate only when
+        // that selected path exists. Otherwise an absent directory entry would
+        // suppress the usable fallback and fail later in the child or exec call.
+        let mut resolved_from_runfiles = false;
+        let mut resolved_arg = if should_transform {
+            let runfiles_path = runfiles.as_ref().and_then(|rf| {
+                core::str::from_utf8(arg_slice)
+                    .ok()
+                    .and_then(|s| rf.rlocation(s))
+            });
+            let runfiles_path = runfiles_path.filter(|path| !has_fallback || path_exists(path));
+            if let Some(resolved_str) = runfiles_path {
+                resolved_from_runfiles = true;
+                ResolvedArg::Bytes(Vec::from(resolved_str.as_bytes()))
+            } else if has_fallback {
+                let fallback_data = placeholders::fallback(i);
+                let fallback_len = cstr_len(fallback_data);
+                let fallback = core::str::from_utf8(&fallback_data[..fallback_len]).ok();
+                let fallback_path = executable_path.as_deref().and_then(|executable| {
+                    let fallback = fallback?;
+                    if fallback.is_empty() {
+                        return None;
+                    }
+                    platform::executable_relative(executable, fallback)
+                });
+                // The fallback becomes the selected executable or data argument,
+                // so reject it here rather than hand a nonexistent path to the
+                // child and obscure why fallback resolution failed.
+                match fallback_path.filter(platform::resolved_arg_exists) {
+                    Some(path) => {
+                        any_fallback_selected = true;
+                        path
+                    }
+                    None => {
+                        platform::print(b"ERROR: No usable runfiles or executable-relative fallback for argument ");
+                        platform::print(&[b'0' + i as u8]);
+                        platform::print(platform::NEWLINE);
+                        platform::exit(1);
+                    }
+                }
+            } else {
+                ResolvedArg::Bytes(arg_slice.to_vec())
             }
         } else {
-            arg_slice.to_vec()
+            ResolvedArg::Bytes(arg_slice.to_vec())
         };
-        bytes.push(0);
-        resolved.push(bytes);
+        if i == 0 {
+            arg0_from_runfiles = resolved_from_runfiles;
+        }
+        any_arg_from_runfiles |= resolved_from_runfiles;
+        match &mut resolved_arg {
+            ResolvedArg::Bytes(bytes) => bytes.push(0),
+            #[cfg(target_os = "windows")]
+            ResolvedArg::Wide(wide) => wide.push(0),
+        }
+        resolved.push(resolved_arg);
     }
 
-    // Preserve argv[0] as a runfiles-relative path so tools that walk argv[0]'s
-    // parent symlinks (e.g. aspect_rules_py's venv_shim) can locate .runfiles. The
-    // fully-resolved path is still used as the program to execute.
-    let argv0_override: Option<Vec<u8>> = runfiles
-        .as_ref()
-        .and_then(|rf| rf.dir_path.as_ref())
-        .and_then(|dir| {
-            let arg0 = placeholders::arg(0);
-            let arg0_len = cstr_len(arg0);
-            if arg0_len == 0 {
-                return None;
-            }
-            let mut path = Vec::from(dir.as_bytes());
-            if !dir.ends_with('/') {
-                path.push(b'/');
-            }
-            path.extend_from_slice(&arg0[..arg0_len]);
-            path.push(0);
-            Some(path)
-        });
+    // Preserve argv[0] as a runfiles-relative path when runfiles selected the
+    // executable. Adjacent manifest discovery also records its logical
+    // <launcher>.runfiles directory so tools can walk that path to locate the
+    // runfiles tree even when the manifest maps execution to another location.
+    // A fallback must instead use its fully resolved executable path.
+    let argv0_override: Option<Vec<u8>> = if arg0_from_runfiles {
+        runfiles
+            .as_ref()
+            .and_then(|rf| rf.dir_path.as_deref())
+            .and_then(|dir| {
+                let arg0 = placeholders::arg(0);
+                let arg0_len = cstr_len(arg0);
+                if arg0_len == 0 {
+                    return None;
+                }
+                let mut path = Vec::from(dir.as_bytes());
+                if !dir.ends_with('/') {
+                    path.push(b'/');
+                }
+                path.extend_from_slice(&arg0[..arg0_len]);
+                path.push(0);
+                Some(path)
+            })
+    } else {
+        None
+    };
 
     let launch = Launch {
         resolved: &resolved,
         argv0_override: argv0_override.as_deref(),
-        runfiles: runfiles.as_ref(),
-        export_env: export_runfiles_env,
+        export_runfiles_env,
+        child_runfiles: if export_runfiles_env && (!any_fallback_selected || any_arg_from_runfiles)
+        {
+            runfiles.as_ref()
+        } else {
+            None
+        },
     };
     platform::launch(&launch, &rt)
 }

--- a/runfiles-stub/src/run.rs
+++ b/runfiles-stub/src/run.rs
@@ -147,6 +147,7 @@ pub fn main(rt: platform::RuntimeArgs) -> ! {
     // Resolve each embedded argument (NUL-terminated). resolved[0] is the program.
     let mut resolved: Vec<ResolvedArg> = Vec::with_capacity(argc);
     let mut arg0_from_runfiles = false;
+    let mut arg0_fallback_selected = false;
     let mut any_arg_from_runfiles = false;
     let mut any_fallback_selected = false;
     for i in 0..argc {
@@ -192,6 +193,9 @@ pub fn main(rt: platform::RuntimeArgs) -> ! {
                 // child and obscure why fallback resolution failed.
                 match fallback_path.filter(platform::resolved_arg_exists) {
                     Some(path) => {
+                        if i == 0 {
+                            arg0_fallback_selected = true;
+                        }
                         any_fallback_selected = true;
                         path
                     }
@@ -251,7 +255,11 @@ pub fn main(rt: platform::RuntimeArgs) -> ! {
         resolved: &resolved,
         argv0_override: argv0_override.as_deref(),
         export_runfiles_env,
-        child_runfiles: if export_runfiles_env && (!any_fallback_selected || any_arg_from_runfiles)
+        // Data arguments can come from the parent runfiles without making that
+        // context belong to an executable selected by adjacent fallback.
+        child_runfiles: if export_runfiles_env
+            && !arg0_fallback_selected
+            && (!any_fallback_selected || any_arg_from_runfiles)
         {
             runfiles.as_ref()
         } else {

--- a/runfiles-stub/src/runfiles.rs
+++ b/runfiles-stub/src/runfiles.rs
@@ -82,12 +82,7 @@ impl Runfiles {
 
                 // Try <executable>.runfiles directory
                 let runfiles_dir = String::from(exe_str) + ".runfiles";
-
-                // Add null terminator for the existence check
-                let mut dir_with_null = Vec::from(runfiles_dir.as_bytes());
-                dir_with_null.push(0);
-
-                if platform::path_exists(&dir_with_null) {
+                if path_exists(&runfiles_dir) {
                     return Some(Self {
                         mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
                         manifest_path: None,
@@ -119,6 +114,10 @@ impl Runfiles {
             }
         }
     }
+}
+
+pub(crate) fn path_exists(path: &str) -> bool {
+    platform::utf8_path_exists(path)
 }
 
 /// Maximum number of relative manifest hops to follow before giving up. Bazel

--- a/runfiles-stub/src/windows.rs
+++ b/runfiles-stub/src/windows.rs
@@ -1,13 +1,14 @@
 // Windows backend: kernel32 (Win32) primitives, a `main` entry that parses the
 // command line, and a CreateProcessW-based launch (spawn + wait + propagate exit code).
-// Runtime args stay UTF-16; embedded args are widened from UTF-8.
+// Runtime args and executable-relative paths stay UTF-16; embedded args are
+// decoded from UTF-8.
 
 use alloc::string::String;
 use alloc::vec;
 use alloc::vec::Vec;
 
 use crate::common::Manifest;
-use crate::run::Launch;
+use crate::run::{Launch, ResolvedArg};
 use crate::runfiles::Runfiles;
 
 // Windows API types
@@ -15,16 +16,16 @@ type DWORD = u32;
 type BOOL = i32;
 type HANDLE = *mut core::ffi::c_void;
 type LPVOID = *mut core::ffi::c_void;
-type LPCSTR = *const u8;
-type LPSTR = *mut u8;
 
 const INVALID_HANDLE_VALUE: HANDLE = -1isize as HANDLE;
+const INVALID_FILE_ATTRIBUTES: DWORD = 0xFFFFFFFF;
 const STD_OUTPUT_HANDLE: DWORD = 0xFFFFFFF5u32;
 const GENERIC_READ: DWORD = 0x80000000;
 const OPEN_EXISTING: DWORD = 3;
 const FILE_ATTRIBUTE_NORMAL: DWORD = 0x80;
 const INFINITE: DWORD = 0xFFFFFFFF;
 const CREATE_UNICODE_ENVIRONMENT: DWORD = 0x00000400;
+const ERROR_INSUFFICIENT_BUFFER: DWORD = 122;
 
 // File sharing and memory-mapping parameters (for the runfiles manifest)
 const FILE_SHARE_READ: DWORD = 0x00000001;
@@ -76,8 +77,8 @@ extern "system" {
         lpNumberOfBytesWritten: *mut DWORD,
         lpOverlapped: LPVOID,
     ) -> BOOL;
-    fn CreateFileA(
-        lpFileName: LPCSTR,
+    fn CreateFileW(
+        lpFileName: *const u16,
         dwDesiredAccess: DWORD,
         dwShareMode: DWORD,
         lpSecurityAttributes: LPVOID,
@@ -85,14 +86,15 @@ extern "system" {
         dwFlagsAndAttributes: DWORD,
         hTemplateFile: HANDLE,
     ) -> HANDLE;
+    fn GetFileAttributesW(lpFileName: *const u16) -> DWORD;
     fn GetFileSizeEx(hFile: HANDLE, lpFileSize: *mut i64) -> BOOL;
-    fn CreateFileMappingA(
+    fn CreateFileMappingW(
         hFile: HANDLE,
         lpFileMappingAttributes: LPVOID,
         flProtect: DWORD,
         dwMaximumSizeHigh: DWORD,
         dwMaximumSizeLow: DWORD,
-        lpName: LPCSTR,
+        lpName: *const u16,
     ) -> HANDLE;
     fn MapViewOfFile(
         hFileMappingObject: HANDLE,
@@ -102,7 +104,7 @@ extern "system" {
         dwNumberOfBytesToMap: usize,
     ) -> LPVOID;
     fn CloseHandle(hObject: HANDLE) -> BOOL;
-    fn GetEnvironmentVariableA(lpName: LPCSTR, lpBuffer: LPSTR, nSize: DWORD) -> DWORD;
+    fn GetEnvironmentVariableW(lpName: *const u16, lpBuffer: *mut u16, nSize: DWORD) -> DWORD;
     fn CreateProcessW(
         lpApplicationName: *const u16,
         lpCommandLine: *mut u16,
@@ -121,6 +123,7 @@ extern "system" {
     fn GetEnvironmentStringsW() -> *mut u16;
     fn FreeEnvironmentStringsW(lpszEnvironmentBlock: *mut u16) -> BOOL;
     fn GetCurrentProcess() -> HANDLE;
+    fn GetLastError() -> DWORD;
     fn QueryFullProcessImageNameW(
         hProcess: HANDLE,
         dwFlags: DWORD,
@@ -156,43 +159,60 @@ pub fn exit(code: i32) -> ! {
     unsafe { ExitProcess(code as u32) }
 }
 
-// Directory/file existence check by trying to open it (needs backup semantics for dirs).
-pub fn path_exists(path: &[u8]) -> bool {
-    const FILE_FLAG_BACKUP_SEMANTICS: DWORD = 0x02000000;
-    unsafe {
-        let handle = CreateFileA(
-            path.as_ptr(),
-            GENERIC_READ,
-            0,
-            core::ptr::null_mut(),
-            OPEN_EXISTING,
-            FILE_FLAG_BACKUP_SEMANTICS,
-            core::ptr::null_mut(),
-        );
-        if handle != INVALID_HANDLE_VALUE {
-            CloseHandle(handle);
-            true
-        } else {
-            false
-        }
+fn wide_path_exists(path: &[u16]) -> bool {
+    let api_path = crate::native_path::windows_api_path(path);
+    unsafe { GetFileAttributesW(api_path.as_ptr()) != INVALID_FILE_ATTRIBUTES }
+}
+
+pub fn utf8_path_exists(path: &str) -> bool {
+    let wide: Vec<u16> = path.encode_utf16().collect();
+    wide_path_exists(&wide)
+}
+
+pub fn executable_relative(executable: &[u16], fallback: &str) -> Option<ResolvedArg> {
+    crate::native_path::windows_executable_relative(executable, fallback).map(ResolvedArg::Wide)
+}
+
+pub fn resolved_arg_exists(arg: &ResolvedArg) -> bool {
+    match arg {
+        ResolvedArg::Bytes(path) => match core::str::from_utf8(path) {
+            Ok(path) => utf8_path_exists(path),
+            Err(_) => false,
+        },
+        ResolvedArg::Wide(path) => wide_path_exists(path),
     }
 }
 
 // Path used to launch this process, via QueryFullProcessImageNameW (the
 // documented API for a process's own image path). With dwFlags = 0 it returns a
-// fully-qualified Win32 path, i.e. already absolute. UTF-16 is narrowed to bytes
-// the same way argv is elsewhere in this backend. None on failure.
-fn launch_path() -> Option<Vec<u8>> {
-    let mut wide = vec![0u16; 4096];
-    let mut size: DWORD = wide.len() as DWORD;
-    let ok = unsafe {
-        QueryFullProcessImageNameW(GetCurrentProcess(), 0, wide.as_mut_ptr(), &mut size)
-    };
-    if ok == 0 || size == 0 || size as usize > wide.len() {
-        return None;
+// fully-qualified Win32 path, i.e. already absolute. Keep it in UTF-16 so
+// executable-relative fallbacks preserve every code unit. None on failure.
+fn launch_path() -> Option<Vec<u16>> {
+    // This is the documented approximate upper bound for an extended-length
+    // Windows path. Filesystem operations below use explicit verbatim paths;
+    // process creation remains subject to the Windows command-line limit.
+    const MAX_PATH_UNITS: usize = 32768;
+
+    let mut capacity = 4096;
+    loop {
+        let mut wide = vec![0u16; capacity];
+        let mut size: DWORD = wide.len() as DWORD;
+        let ok = unsafe {
+            QueryFullProcessImageNameW(GetCurrentProcess(), 0, wide.as_mut_ptr(), &mut size)
+        };
+        if ok != 0 {
+            if size == 0 || size as usize > wide.len() {
+                return None;
+            }
+            // `size` is the number of characters written, excluding the NUL
+            // terminator.
+            return Some(wide[..size as usize].to_vec());
+        }
+        if unsafe { GetLastError() } != ERROR_INSUFFICIENT_BUFFER || capacity == MAX_PATH_UNITS {
+            return None;
+        }
+        capacity = core::cmp::min(capacity * 2, MAX_PATH_UNITS);
     }
-    // `size` is the number of characters written, excluding the NUL terminator.
-    Some(wide[..size as usize].iter().map(|&w| (w & 0xFF) as u8).collect())
 }
 
 // QueryFullProcessImageNameW already yields an absolute path, so the cwd is
@@ -202,22 +222,25 @@ pub fn current_dir() -> Option<Vec<u8>> {
     None
 }
 
-// Environment variable lookup (two-call GetEnvironmentVariableA pattern).
+// Environment variable lookup (two-call GetEnvironmentVariableW pattern).
 pub fn get_env_var(name: &[u8]) -> Option<String> {
     unsafe {
-        let mut name_with_null = name.to_vec();
+        let mut name_with_null: Vec<u16> = name.iter().map(|&byte| byte as u16).collect();
         name_with_null.push(0);
 
-        let size = GetEnvironmentVariableA(name_with_null.as_ptr(), core::ptr::null_mut(), 0);
+        let size = GetEnvironmentVariableW(name_with_null.as_ptr(), core::ptr::null_mut(), 0);
         if size == 0 {
             return None;
         }
-        let mut buf = vec![0u8; size as usize];
-        let actual_size =
-            GetEnvironmentVariableA(name_with_null.as_ptr(), buf.as_mut_ptr(), buf.len() as DWORD);
+        let mut buf = vec![0u16; size as usize];
+        let actual_size = GetEnvironmentVariableW(
+            name_with_null.as_ptr(),
+            buf.as_mut_ptr(),
+            buf.len() as DWORD,
+        );
         if actual_size > 0 && actual_size < buf.len() as DWORD {
             buf.truncate(actual_size as usize);
-            String::from_utf8(buf).ok()
+            String::from_utf16(&buf).ok()
         } else {
             None
         }
@@ -226,11 +249,19 @@ pub fn get_env_var(name: &[u8]) -> Option<String> {
 
 // Memory-map the manifest read-only. `path` is NUL-terminated by the caller.
 pub fn load_manifest(path: &[u8]) -> Option<Manifest> {
+    let path = if path.last() == Some(&0) {
+        &path[..path.len() - 1]
+    } else {
+        path
+    };
+    let wide_path: Vec<u16> = core::str::from_utf8(path).ok()?.encode_utf16().collect();
+    let api_path = crate::native_path::windows_api_path(&wide_path);
+
     unsafe {
         // FILE_SHARE_READ lets the child process (which inherits
         // RUNFILES_MANIFEST_FILE) open the same manifest for reading.
-        let file = CreateFileA(
-            path.as_ptr(),
+        let file = CreateFileW(
+            api_path.as_ptr(),
             GENERIC_READ,
             FILE_SHARE_READ,
             core::ptr::null_mut(),
@@ -249,8 +280,8 @@ pub fn load_manifest(path: &[u8]) -> Option<Manifest> {
         }
         let len = size as usize;
 
-        // CreateFileMappingA returns NULL (not INVALID_HANDLE_VALUE) on failure.
-        let mapping = CreateFileMappingA(
+        // CreateFileMappingW returns NULL (not INVALID_HANDLE_VALUE) on failure.
+        let mapping = CreateFileMappingW(
             file,
             core::ptr::null_mut(),
             PAGE_READONLY,
@@ -285,15 +316,13 @@ pub fn load_manifest(path: &[u8]) -> Option<Manifest> {
 fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
     let mut buf: Vec<u16> = Vec::with_capacity(8192);
 
-    // Append "KEY=VALUE\0", widening bytes to UTF-16.
+    // Append "KEY=VALUE\0" as UTF-16.
     let push_var = |buf: &mut Vec<u16>, key: &[u8], value: &str| {
         for &b in key {
             buf.push(b as u16);
         }
         buf.push(b'=' as u16);
-        for &b in value.as_bytes() {
-            buf.push(b as u16);
-        }
+        buf.extend(value.encode_utf16());
         buf.push(0);
     };
 
@@ -327,22 +356,31 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
                 }
                 let entry_ptr = env_block.add(entry_start);
 
-                // Skip existing runfiles vars (we re-insert our own).
-                let prefixed = |needle: &[u8]| -> bool {
-                    entry_len > needle.len()
-                        && (0..needle.len()).all(|i| *entry_ptr.add(i) == needle[i] as u16)
+                // Remove inherited runfiles variables before optionally inserting
+                // the values selected for this launch.
+                let ascii_upper = |unit: u16| {
+                    if (b'a' as u16..=b'z' as u16).contains(&unit) {
+                        unit - 32
+                    } else {
+                        unit
+                    }
                 };
-                let should_skip = prefixed(b"RUNFILES_MANIFEST_FILE=")
-                    || prefixed(b"RUNFILES_DIR=")
-                    || prefixed(b"JAVA_RUNFILES=");
+                let prefixed_case_insensitive = |needle: &[u8]| -> bool {
+                    entry_len >= needle.len()
+                        && (0..needle.len()).all(|i| {
+                            ascii_upper(*entry_ptr.add(i)) == ascii_upper(needle[i] as u16)
+                        })
+                };
+                let should_skip = prefixed_case_insensitive(b"RUNFILES_MANIFEST_FILE=")
+                    || prefixed_case_insensitive(b"RUNFILES_DIR=")
+                    || prefixed_case_insensitive(b"JAVA_RUNFILES=");
 
                 if !should_skip {
                     // Case-insensitive "does this entry sort after `target`?"
                     let var_comes_after = |target: &[u8]| -> bool {
-                        let upper = |c: u16| if (b'a' as u16..=b'z' as u16).contains(&c) { c - 32 } else { c };
                         for i in 0..target.len().min(entry_len) {
-                            let e = upper(*entry_ptr.add(i));
-                            let t = upper(target[i] as u16);
+                            let e = ascii_upper(*entry_ptr.add(i));
+                            let t = ascii_upper(target[i] as u16);
                             if e != t {
                                 return e > t;
                             }
@@ -408,7 +446,11 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
         }
     }
 
-    // Final NUL: with the last entry's NUL this forms the double-NUL block terminator.
+    // An empty environment still requires two NUL code units. Otherwise the
+    // last entry already supplied the first terminator.
+    if buf.is_empty() {
+        buf.push(0);
+    }
     buf.push(0);
     buf
 }
@@ -498,9 +540,17 @@ pub struct RuntimeArgs {
 
 impl RuntimeArgs {
     /// Absolute path of the launching executable (QueryFullProcessImageNameW),
-    /// for runfiles self-location. Independent of the command-line argv[0].
+    /// converted to the UTF-8 representation used by runfiles self-location.
+    /// Executable-relative fallbacks use `fallback_executable_path` instead.
     pub fn executable_path(&self) -> Option<Vec<u8>> {
-        launch_path().map(crate::common::absolutize)
+        String::from_utf16(&launch_path()?)
+            .ok()
+            .map(String::into_bytes)
+            .map(crate::common::absolutize)
+    }
+
+    pub fn fallback_executable_path(&self) -> Option<Vec<u16>> {
+        launch_path()
     }
 }
 
@@ -554,11 +604,36 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
 
         // Build the UTF-16 command line: embedded args (widened) + runtime args (native).
         let mut cmdline_wide: Vec<u16> = Vec::with_capacity(8192);
+        let mut application_name = Vec::new();
 
         for (i, arg) in launch.resolved.iter().enumerate() {
-            // Embedded args are NUL-terminated; widen without the trailing NUL.
-            let bytes = if arg.last() == Some(&0) { &arg[..arg.len() - 1] } else { &arg[..] };
-            let wide: Vec<u16> = bytes.iter().map(|&b| b as u16).collect();
+            let wide: Vec<u16> = match arg {
+                ResolvedArg::Bytes(bytes) => {
+                    let bytes = if bytes.last() == Some(&0) {
+                        &bytes[..bytes.len() - 1]
+                    } else {
+                        &bytes[..]
+                    };
+                    match core::str::from_utf8(bytes) {
+                        Ok(value) => value.encode_utf16().collect(),
+                        Err(_) => {
+                            print(b"ERROR: Embedded argument is not valid UTF-8\r\n");
+                            ExitProcess(1);
+                        }
+                    }
+                }
+                ResolvedArg::Wide(path) => {
+                    if path.last() == Some(&0) {
+                        path[..path.len() - 1].to_vec()
+                    } else {
+                        path.clone()
+                    }
+                }
+            };
+
+            if i == 0 {
+                application_name = crate::native_path::windows_api_path(&wide);
+            }
 
             // Quote arg0 always (Bazel launcher.cc convention); others as needed.
             append_arg(&mut cmdline_wide, &wide, i == 0);
@@ -577,24 +652,33 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
 
         cmdline_wide.push(0);
 
-        // Build the environment with runfiles vars if export is enabled.
-        // `env_storage` keeps the block alive while CreateProcessW reads it.
-        let env_storage: Vec<u16>;
-        let envp = if launch.export_env {
-            env_storage = build_runfiles_environ(launch.runfiles);
-            env_storage.as_ptr() as *mut core::ffi::c_void
+        // A NULL environment inherits the caller's variables unchanged. When
+        // export is enabled, replace or remove the three runfiles variables.
+        let env_storage = if launch.export_runfiles_env {
+            Some(build_runfiles_environ(launch.child_runfiles))
         } else {
-            core::ptr::null_mut()
+            None
         };
-        let creation_flags = if launch.export_env { CREATE_UNICODE_ENVIRONMENT } else { 0 };
+        let envp = env_storage
+            .as_ref()
+            .map_or(core::ptr::null_mut(), |storage| {
+                storage.as_ptr() as *mut core::ffi::c_void
+            });
+        let creation_flags = if launch.export_runfiles_env {
+            CREATE_UNICODE_ENVIRONMENT
+        } else {
+            0
+        };
 
         let mut si: STARTUPINFOW = core::mem::zeroed();
         si.cb = core::mem::size_of::<STARTUPINFOW>() as DWORD;
         let mut pi: PROCESS_INFORMATION = core::mem::zeroed();
 
-        // NULL lpApplicationName + quoted executable in the command line (Bazel approach).
+        // Pass the resolved executable separately so CreateProcessW does not
+        // apply its command-line module-name limit. Keep arg0 in the command
+        // line as well so the child observes the same argv[0] as before.
         let success = CreateProcessW(
-            core::ptr::null(),
+            application_name.as_ptr(),
             cmdline_wide.as_mut_ptr(),
             core::ptr::null_mut(),
             core::ptr::null_mut(),

--- a/runfiles-stub/src/windows.rs
+++ b/runfiles-stub/src/windows.rs
@@ -604,7 +604,7 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
 
         // Build the UTF-16 command line: embedded args (widened) + runtime args (native).
         let mut cmdline_wide: Vec<u16> = Vec::with_capacity(8192);
-        let mut application_name = Vec::new();
+        let mut application_name = None;
 
         for (i, arg) in launch.resolved.iter().enumerate() {
             let wide: Vec<u16> = match arg {
@@ -632,7 +632,11 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
             };
 
             if i == 0 {
-                application_name = crate::native_path::windows_api_path(&wide);
+                application_name =
+                    crate::native_path::windows_extended_path(&wide).map(|mut path| {
+                        path.push(0);
+                        path
+                    });
             }
 
             // Quote arg0 always (Bazel launcher.cc convention); others as needed.
@@ -674,11 +678,16 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
         si.cb = core::mem::size_of::<STARTUPINFOW>() as DWORD;
         let mut pi: PROCESS_INFORMATION = core::mem::zeroed();
 
-        // Pass the resolved executable separately so CreateProcessW does not
-        // apply its command-line module-name limit. Keep arg0 in the command
-        // line as well so the child observes the same argv[0] as before.
+        // Pass absolute resolved paths separately so CreateProcessW does not
+        // apply its command-line module-name limit. A relative argv[0] must
+        // remain command-line-only: non-NULL partial application names use the
+        // current directory and do not search PATH or infer an .exe extension.
+        // https://learn.microsoft.com/windows/win32/api/processthreadsapi/nf-processthreadsapi-createprocessw
+        let application_name = application_name
+            .as_ref()
+            .map_or(core::ptr::null(), |path| path.as_ptr());
         let success = CreateProcessW(
-            application_name.as_ptr(),
+            application_name,
             cmdline_wide.as_mut_ptr(),
             core::ptr::null_mut(),
             core::ptr::null_mut(),

--- a/runfiles-stub/src/windows.rs
+++ b/runfiles-stub/src/windows.rs
@@ -18,7 +18,6 @@ type HANDLE = *mut core::ffi::c_void;
 type LPVOID = *mut core::ffi::c_void;
 
 const INVALID_HANDLE_VALUE: HANDLE = -1isize as HANDLE;
-const INVALID_FILE_ATTRIBUTES: DWORD = 0xFFFFFFFF;
 const STD_OUTPUT_HANDLE: DWORD = 0xFFFFFFF5u32;
 const GENERIC_READ: DWORD = 0x80000000;
 const OPEN_EXISTING: DWORD = 3;
@@ -29,6 +28,9 @@ const ERROR_INSUFFICIENT_BUFFER: DWORD = 122;
 
 // File sharing and memory-mapping parameters (for the runfiles manifest)
 const FILE_SHARE_READ: DWORD = 0x00000001;
+const FILE_SHARE_WRITE: DWORD = 0x00000002;
+const FILE_SHARE_DELETE: DWORD = 0x00000004;
+const FILE_FLAG_BACKUP_SEMANTICS: DWORD = 0x02000000;
 const PAGE_READONLY: DWORD = 0x02;
 const FILE_MAP_READ: DWORD = 0x04;
 
@@ -86,7 +88,6 @@ extern "system" {
         dwFlagsAndAttributes: DWORD,
         hTemplateFile: HANDLE,
     ) -> HANDLE;
-    fn GetFileAttributesW(lpFileName: *const u16) -> DWORD;
     fn GetFileSizeEx(hFile: HANDLE, lpFileSize: *mut i64) -> BOOL;
     fn CreateFileMappingW(
         hFile: HANDLE,
@@ -161,7 +162,27 @@ pub fn exit(code: i32) -> ! {
 
 fn wide_path_exists(path: &[u16]) -> bool {
     let api_path = crate::native_path::windows_api_path(path);
-    unsafe { GetFileAttributesW(api_path.as_ptr()) != INVALID_FILE_ATTRIBUTES }
+    unsafe {
+        // Follow reparse points so a dangling symlink does not suppress an
+        // executable-relative fallback. Zero desired access avoids imposing
+        // read permissions; backup semantics permits directory candidates.
+        // https://learn.microsoft.com/windows/win32/fileio/symbolic-link-effects-on-file-systems-functions
+        let handle = CreateFileW(
+            api_path.as_ptr(),
+            0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
+            core::ptr::null_mut(),
+            OPEN_EXISTING,
+            FILE_FLAG_BACKUP_SEMANTICS,
+            core::ptr::null_mut(),
+        );
+        if handle == INVALID_HANDLE_VALUE {
+            false
+        } else {
+            CloseHandle(handle);
+            true
+        }
+    }
 }
 
 pub fn utf8_path_exists(path: &str) -> bool {

--- a/runfiles-stub/tests/native_path_test.rs
+++ b/runfiles-stub/tests/native_path_test.rs
@@ -61,3 +61,14 @@ fn windows_api_path_preserves_relative_semantics() {
         "relative\\dir\\tool.exe",
     );
 }
+
+#[test]
+fn windows_extended_path_rejects_relative_paths() {
+    for path in ["tool.exe", "dir\\tool.exe", "C:tool.exe", "\\tool.exe"] {
+        let wide: Vec<u16> = path.encode_utf16().collect();
+        assert!(
+            native_path::windows_extended_path(&wide).is_none(),
+            "{path} is not a fully qualified path",
+        );
+    }
+}

--- a/runfiles-stub/tests/native_path_test.rs
+++ b/runfiles-stub/tests/native_path_test.rs
@@ -1,0 +1,63 @@
+#[path = "../src/native_path.rs"]
+mod native_path;
+
+#[test]
+fn executable_relative_path_preserves_non_utf8_prefix() {
+    let executable = b"/tmp/launcher-\xff/stub";
+
+    assert!(native_path::unix_path_is_absolute(executable));
+    let path = native_path::unix_executable_relative(executable, b"../bin/tool").unwrap();
+
+    assert_eq!(path, b"/tmp/launcher-\xff/../bin/tool");
+}
+
+#[test]
+fn windows_executable_relative_preserves_long_utf16_path() {
+    let mut executable: Vec<u16> = "C:\\launcher\\".encode_utf16().collect();
+    executable.extend(core::iter::repeat_n(b'x' as u16, 260));
+    executable.extend("\\stub.exe".encode_utf16());
+
+    let resolved =
+        native_path::windows_executable_relative(&executable, "../bin/工具.exe").unwrap();
+    assert!(resolved.len() > 260);
+    assert_eq!(
+        String::from_utf16(&resolved).unwrap(),
+        format!("C:\\launcher\\{}\\..\\bin\\工具.exe", "x".repeat(260)),
+    );
+}
+
+#[test]
+fn windows_api_path_normalizes_drive_path_for_win32() {
+    let path: Vec<u16> = "C:/launcher/one/../two/tool.exe".encode_utf16().collect();
+    let api_path = native_path::windows_api_path(&path);
+
+    assert_eq!(
+        String::from_utf16(&api_path[..api_path.len() - 1]).unwrap(),
+        "\\\\?\\C:\\launcher\\two\\tool.exe",
+    );
+    assert_eq!(api_path.last(), Some(&0));
+}
+
+#[test]
+fn windows_api_path_normalizes_unc_path_for_win32() {
+    let path: Vec<u16> = "\\\\server\\share\\one\\..\\工具.exe"
+        .encode_utf16()
+        .collect();
+    let api_path = native_path::windows_api_path(&path);
+
+    assert_eq!(
+        String::from_utf16(&api_path[..api_path.len() - 1]).unwrap(),
+        "\\\\?\\UNC\\server\\share\\工具.exe",
+    );
+}
+
+#[test]
+fn windows_api_path_preserves_relative_semantics() {
+    let path: Vec<u16> = "relative/dir/tool.exe".encode_utf16().collect();
+    let api_path = native_path::windows_api_path(&path);
+
+    assert_eq!(
+        String::from_utf16(&api_path[..api_path.len() - 1]).unwrap(),
+        "relative\\dir\\tool.exe",
+    );
+}


### PR DESCRIPTION
Allow transformed arguments to use caller-owned paths relative to the
launcher when their runfiles entries are unavailable. This supports a
nested launcher inside another target's runfiles tree: when invoked
through a symlink without runfiles environment variables, it has no
sibling `.runfiles` directory but can still reach adjacent executables
and data.

Encode each fallback after its argument in the existing fixed-size slot
and identify fallback-capable templates with a V2 marker. V1 templates
reject fallback requests, while V1 and V2 finalizers remain compatible
when no fallback is requested.

Keep path discovery and process invocation in each platform's native
representation. When the executable uses its adjacent fallback, scrub
the parent runfiles context so the child can discover its own; resolving
a data argument from the parent does not transfer that ownership.