### PR TITLE
fix(macos): prevent optimized bzero recursion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -152,7 +152,7 @@ jobs:
           fi
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
-        run: bazel test ${BUILDBUDDY_API_KEY:+--config=remote} //integration-tests:integration_test
+        run: bazel test ${BUILDBUDDY_API_KEY:+--config=remote} --config=release //integration-tests:integration_test
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: bazel test ${BUILDBUDDY_API_KEY:+--config=cache} //...
@@ -179,7 +179,7 @@ jobs:
           fi
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
-        run: bazel test ${BUILDBUDDY_API_KEY:+--config=cache} //integration-tests:integration_test
+        run: bazel test ${BUILDBUDDY_API_KEY:+--config=cache} --config=release //integration-tests:integration_test
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: bazel test ${BUILDBUDDY_API_KEY:+--config=cache} //...
@@ -209,7 +209,7 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
           $config = if ($env:BUILDBUDDY_API_KEY) { "--config=cache" } else { $null }
-          bazel --output_user_root=C:/b test $config //integration-tests:integration_test
+          bazel --output_user_root=C:/b test $config --config=release //integration-tests:integration_test
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |

--- a/integration-tests/BUILD.bazel
+++ b/integration-tests/BUILD.bazel
@@ -42,8 +42,9 @@ config_setting(
 
 # The released artifacts for the host platform: the runfiles-stub template and the
 # finalizer, each already platform-transitioned and run through the optimization
-# pipeline (the exact bytes a release ships). The integration test exercises these
-# end to end instead of a separately-transitioned, unoptimized build.
+# pipeline. CI runs the integration test with --config=release because the platform
+# transition does not set Rust optimization or LTO; both are part of the shipped
+# binary contract.
 alias(
     name = "release-template",
     actual = select({

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -782,10 +782,9 @@ fn test_fallback_runfiles_manifest(config: &TestConfig) -> Result<(), String> {
 
 /// Regression test: runfiles discovery under `bazel run` semantics.
 ///
-/// argv[0] is not guaranteed to be a reliable, absolute path that points at the
-/// executable. Instead, it may be relative (and it may be completely fake).
-/// The stub should use reliable, operating-system specific APIs to find it's own
-/// path and not rely on argv[0] at all.
+/// Both the path used to launch the executable and argv[0] may be relative;
+/// argv[0] may also be completely fake. The stub should use reliable,
+/// operating-system specific APIs to find its own path and not rely on argv[0].
 ///
 /// `bazel test` masks the bug because it pre-sets RUNFILES_DIR, and the other
 /// fallback tests above invoke the stub by its *absolute* path, so neither
@@ -829,24 +828,50 @@ fn test_run_runfiles_discovery(config: &TestConfig) -> Result<(), String> {
         // The working directory `bazel run` leaves us in: inside the runfiles tree.
         let cwd_inside_runfiles = runfiles_dir.join(WORKSPACE_NAME);
 
-        // Exec the stub by its absolute path (so the OS can self-locate the running
-        // binary) but with a *relative* argv[0], exactly as `bazel run` does.
-        let mut cmd = Command::new(&stub_path);
+        // Execute the release artifact itself by a relative path, not merely
+        // with a relative argv[0]. This covers the optimized macOS stub's cwd
+        // lookup while retaining the argv[0] shape used by `bazel run`.
+        let relative_stub_path = PathBuf::from("../..").join(&stub_name);
+        let mut cmd = Command::new(&relative_stub_path);
         cmd.arg0(format!("bazel-bin/{}", stub_name));
         cmd.current_dir(&cwd_inside_runfiles);
         cmd.env_remove("RUNFILES_DIR");
         cmd.env_remove("RUNFILES_MANIFEST_FILE");
         cmd.env_remove("JAVA_RUNFILES");
+        cmd.stdout(std::process::Stdio::piped());
+        cmd.stderr(std::process::Stdio::piped());
 
-        let output = cmd.output().map_err(|e| format!("Failed to run stub: {}", e))?;
+        let mut child = cmd.spawn().map_err(|e| format!("Failed to run stub: {}", e))?;
+        let deadline = std::time::Instant::now() + std::time::Duration::from_secs(10);
+        loop {
+            if child
+                .try_wait()
+                .map_err(|e| format!("Failed to wait for stub: {}", e))?
+                .is_some()
+            {
+                break;
+            }
+            if std::time::Instant::now() >= deadline {
+                let _ = child.kill();
+                let _ = child.wait();
+                return Err(format!(
+                    "Stub timed out when executed by relative path {}",
+                    relative_stub_path.display()
+                ));
+            }
+            std::thread::sleep(std::time::Duration::from_millis(10));
+        }
+        let output = child
+            .wait_with_output()
+            .map_err(|e| format!("Failed to collect stub output: {}", e))?;
         let stdout = String::from_utf8_lossy(&output.stdout);
         let stderr = String::from_utf8_lossy(&output.stderr);
         let exit_code = output.status.code().unwrap_or(-1);
 
         if exit_code != 0 {
             return Err(format!(
-                "Stub failed with exit code {} (rules_py #1113 regression: relative argv[0] \
-                 + cwd inside the runfiles tree).\nstdout: {}\nstderr: {}",
+                "Stub failed with exit code {} (rules_py #1113 regression: relative executable \
+                 and argv[0] with cwd inside the runfiles tree).\nstdout: {}\nstderr: {}",
                 exit_code, stdout, stderr
             ));
         }
@@ -854,7 +879,7 @@ fn test_run_runfiles_discovery(config: &TestConfig) -> Result<(), String> {
             return Err(format!("Unexpected output: {}. Expected 'SUM:15'", stdout));
         }
 
-        println!("    PASS (relative argv[0], cwd inside runfiles)");
+        println!("    PASS (relative executable and argv[0], cwd inside runfiles)");
     }
 
     #[cfg(not(unix))]

--- a/runfiles-stub/src/macos.rs
+++ b/runfiles-stub/src/macos.rs
@@ -36,10 +36,15 @@ pub unsafe extern "C" fn memset(s: *mut u8, c: i32, n: usize) -> *mut u8 {
     s
 }
 
-// ld64 references `_bzero` for zero-fills; route it through memset.
+// Optimized Darwin codegen emits bzero for zero-fills. Use volatile writes so
+// LLVM cannot replace this implementation with a recursive call to bzero.
 #[no_mangle]
 pub unsafe extern "C" fn bzero(s: *mut u8, n: usize) {
-    memset(s, 0, n);
+    let mut i = 0;
+    while i < n {
+        core::ptr::write_volatile(s.add(i), 0);
+        i += 1;
+    }
 }
 
 #[no_mangle]


### PR DESCRIPTION
Prevent optimized macOS launchers from hanging before runfiles
discovery.

rules_py's PEP 517 build action executes its generated Python helper
through a Bazel exec path relative to the action execroot. That exposed a
release-only failure: `current_dir()` zeroes its `F_GETPATH` buffer,
optimized Darwin code generation lowers the zero fill to `bzero`, and LTO
rewrites the in-tree `bzero` wrapper into a self-tail-call. The launcher
therefore loops before it can absolutize the executable path.

Implement `bzero` with volatile byte writes. Exercise the release artifact
through an actual relative program path with a timeout, and run integration
tests with the release optimization settings. The prior test changed only
`argv[0]` and compiled the release target under fastbuild, so it could not
reproduce the failure.