### PR TITLE
fix: select one runfiles source

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -209,7 +209,7 @@ jobs:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |
           $config = if ($env:BUILDBUDDY_API_KEY) { "--config=cache" } else { $null }
-          bazel --output_user_root=C:/b test $config --config=release //integration-tests:integration_test
+          bazel --output_user_root=C:/b test $config --config=release --test_output=errors //integration-tests:integration_test
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |

--- a/README.md
+++ b/README.md
@@ -146,17 +146,17 @@ execute; the rest are its leading arguments. Runtime arguments are unrestricted.
 
 ### Runfiles discovery
 
-At startup the finalized launcher locates runfiles in this order:
+At startup the finalized launcher selects one runfiles source from:
 
-1. `$RUNFILES_MANIFEST_FILE`
-2. `$RUNFILES_DIR`
-3. `<executable>.runfiles_manifest`
-4. `<executable>.runfiles/`
+1. `$RUNFILES_DIR` and `$RUNFILES_MANIFEST_FILE`
+2. `<executable>.runfiles/` and `<executable>.runfiles_manifest`
 
-Each argument marked `--transform` is resolved through runfiles (manifest lookup or
-directory join; tree-artifact prefixes supported). Absolute paths (leading `/`) pass
-through unchanged. The launcher then appends its own runtime arguments and replaces
-itself with the target.
+Valid environment-provided sources take precedence over adjacent sources. When both
+sources exist at the same precedence, the runfiles directory wins. Every argument
+marked `--transform` resolves only through the selected source (manifest lookup or
+directory join; tree-artifact prefixes supported), and only that source is exported to
+the child. Absolute paths (leading `/`) pass through unchanged. The launcher then
+appends its own runtime arguments and replaces itself with the target.
 
 ---
 

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -149,7 +149,9 @@ impl RunfilesSetup {
     /// Create a new runfiles setup in the given directory
     fn new(base_dir: &Path, name: &str) -> std::io::Result<Self> {
         let runfiles_dir = base_dir.join(format!("{}.runfiles", name));
-        let manifest_path = base_dir.join(format!("{}.runfiles_manifest", name));
+        // Keep manifest-mode tests independent from adjacent discovery. Tests
+        // that exercise conventional sibling sources opt in explicitly.
+        let manifest_path = base_dir.join(format!("{}.manifest", name));
 
         fs::create_dir_all(&runfiles_dir)?;
 
@@ -427,6 +429,205 @@ fn test_add_numbers_runtime_args(config: &TestConfig) -> Result<(), String> {
 
     println!("    PASS");
 
+    Ok(())
+}
+
+/// Test: runfiles source selection respects provenance, then prefers directories.
+fn test_runfiles_source_precedence(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: runfiles_source_precedence");
+
+    let test_dir = config.work_dir.join("test_runfiles_source_precedence");
+    fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {}", e))?;
+
+    let stub_name = format!("precedence_stub{}", EXE_EXT);
+    let mut runfiles = RunfilesSetup::new(&test_dir, &stub_name)
+        .map_err(|e| format!("Failed to create runfiles: {}", e))?;
+    runfiles.manifest_path = test_dir.join(format!("{}.runfiles_manifest", stub_name));
+    let executable_rlocation = format!("{}/bin/tool{}", WORKSPACE_NAME, EXE_EXT);
+    let print_env_binary = config.test_binaries_dir.join(format!("print-env{}", EXE_EXT));
+    runfiles
+        .add_file(&executable_rlocation, &print_env_binary)
+        .map_err(|e| format!("Failed to add directory executable: {}", e))?;
+
+    let add_binary = config.test_binaries_dir.join(format!("add-numbers{}", EXE_EXT));
+    let manifest_target = add_binary.to_string_lossy();
+    #[cfg(windows)]
+    let manifest_target = manifest_target.replace('\\', "/");
+    fs::write(
+        &runfiles.manifest_path,
+        format!("{} {}\n", executable_rlocation, manifest_target),
+    )
+    .map_err(|e| format!("Failed to write conflicting manifest: {}", e))?;
+
+    let stub_path = test_dir.join(&stub_name);
+    finalize_stub(
+        config,
+        &stub_path,
+        &[&executable_rlocation, "7", "8"],
+        &[0],
+    )?;
+
+    // Both environment sources have the same precedence, so the directory owns
+    // both resolution and the environment exported to the child.
+    let mut command = Command::new(&stub_path);
+    command
+        .env("RUNFILES_DIR", &runfiles.runfiles_dir)
+        .env("RUNFILES_MANIFEST_FILE", &runfiles.manifest_path)
+        .env_remove("JAVA_RUNFILES");
+    let output = command
+        .output()
+        .map_err(|e| format!("Failed to run stub with both runfiles variables: {}", e))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let expected_dir = format!("ENV:RUNFILES_DIR={}", runfiles.runfiles_dir.display());
+    let expected_java = format!("ENV:JAVA_RUNFILES={}", runfiles.runfiles_dir.display());
+    if !output.status.success()
+        || !stdout.contains("ARGC:3")
+        || !stdout.contains(&expected_dir)
+        || !stdout.contains(&expected_java)
+        || !stdout.contains("ENV:RUNFILES_MANIFEST_FILE=<unset>")
+    {
+        return Err(format!(
+            "Directory environment source did not win the tie.\nstdout: {}\nstderr: {}",
+            stdout, stderr
+        ));
+    }
+
+    // An environment manifest outranks an adjacent directory, so the manifest's
+    // conflicting add-numbers entry must be selected as the sole source.
+    let mut command = Command::new(&stub_path);
+    command
+        .env_remove("RUNFILES_DIR")
+        .env_remove("JAVA_RUNFILES")
+        .env("RUNFILES_MANIFEST_FILE", &runfiles.manifest_path);
+    let output = command
+        .output()
+        .map_err(|e| format!("Failed to run stub with environment manifest: {}", e))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() || !stdout.contains("SUM:15") {
+        return Err(format!(
+            "Environment manifest did not outrank adjacent directory.\nstdout: {}\nstderr: {}",
+            stdout, stderr
+        ));
+    }
+
+    // An invalid environment directory is not a source. Select the environment
+    // manifest and scrub stale directory variables from the child.
+    let manifest_export_path = test_dir.join("manifest_export.manifest");
+    let print_env_target = print_env_binary.to_string_lossy();
+    #[cfg(windows)]
+    let print_env_target = print_env_target.replace('\\', "/");
+    fs::write(
+        &manifest_export_path,
+        format!("{} {}\n", executable_rlocation, print_env_target),
+    )
+    .map_err(|e| format!("Failed to write manifest export fixture: {}", e))?;
+    let invalid_dir = test_dir.join("not_a_directory");
+    fs::write(&invalid_dir, b"not a directory")
+        .map_err(|e| format!("Failed to write invalid directory fixture: {}", e))?;
+    let mut command = Command::new(&stub_path);
+    #[cfg(not(windows))]
+    command
+        .env("RUNFILES_DIR", &invalid_dir)
+        .env("JAVA_RUNFILES", "stale")
+        .env("RUNFILES_MANIFEST_FILE", &manifest_export_path);
+    #[cfg(windows)]
+    command
+        .env("Runfiles_Dir", &invalid_dir)
+        .env("Java_Runfiles", "stale")
+        .env("Runfiles_Manifest_File", &manifest_export_path);
+    let output = command
+        .output()
+        .map_err(|e| format!("Failed to inspect manifest-selected environment: {}", e))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    let expected_manifest = format!(
+        "ENV:RUNFILES_MANIFEST_FILE={}",
+        manifest_export_path.display()
+    );
+    if !output.status.success()
+        || !stdout.contains(&expected_manifest)
+        || !stdout.contains("ENV:RUNFILES_DIR=<unset>")
+        || !stdout.contains("ENV:JAVA_RUNFILES=<unset>")
+    {
+        return Err(format!(
+            "Manifest selection did not scrub stale directory state.\nstdout: {}\nstderr: {}",
+            stdout, stderr
+        ));
+    }
+
+    // With no environment source, the adjacent directory and manifest have equal
+    // precedence, so the directory wins and is exported consistently.
+    let mut command = Command::new(&stub_path);
+    command
+        .env_remove("RUNFILES_DIR")
+        .env_remove("RUNFILES_MANIFEST_FILE")
+        .env_remove("JAVA_RUNFILES");
+    let output = command
+        .output()
+        .map_err(|e| format!("Failed to run stub with adjacent sources: {}", e))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success()
+        || !stdout.contains("ARGC:3")
+        || !stdout.contains(&expected_dir)
+        || !stdout.contains(&expected_java)
+        || !stdout.contains("ENV:RUNFILES_MANIFEST_FILE=<unset>")
+    {
+        return Err(format!(
+            "Adjacent directory did not win the tie.\nstdout: {}\nstderr: {}",
+            stdout, stderr,
+        ));
+    }
+
+    // Source selection is global, not per key. A missing directory entry must
+    // not fall through to either an environment or adjacent manifest.
+    let missing_rlocation = format!("{}/bin/missing{}", WORKSPACE_NAME, EXE_EXT);
+    let missing_stub_name = format!("missing_stub{}", EXE_EXT);
+    let missing_stub = test_dir.join(&missing_stub_name);
+    let missing_manifest = test_dir.join(format!("{}.runfiles_manifest", missing_stub_name));
+    let add_target = add_binary.to_string_lossy();
+    #[cfg(windows)]
+    let add_target = add_target.replace('\\', "/");
+    fs::write(
+        &missing_manifest,
+        format!("{} {}\n", missing_rlocation, add_target),
+    )
+    .map_err(|e| format!("Failed to write no-fallback fixture: {}", e))?;
+    finalize_stub(
+        config,
+        &missing_stub,
+        &[&missing_rlocation, "7", "8"],
+        &[0],
+    )?;
+    for (case, manifest_env) in [
+        ("environment manifest", Some(&missing_manifest)),
+        ("adjacent manifest", None),
+    ] {
+        let mut command = Command::new(&missing_stub);
+        command
+            .env("RUNFILES_DIR", &runfiles.runfiles_dir)
+            .env_remove("JAVA_RUNFILES");
+        if let Some(manifest) = manifest_env {
+            command.env("RUNFILES_MANIFEST_FILE", manifest);
+        } else {
+            command.env_remove("RUNFILES_MANIFEST_FILE");
+        }
+        let output = command
+            .output()
+            .map_err(|e| format!("Failed to test no-fallback {}: {}", case, e))?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if output.status.success() || stdout.contains("SUM:15") {
+            return Err(format!(
+                "Directory selection fell through to {}.\nstdout: {}\nstderr: {}",
+                case, stdout, stderr
+            ));
+        }
+    }
+
+    println!("    PASS (environment precedence, then directory preference)");
     Ok(())
 }
 
@@ -715,33 +916,24 @@ fn test_fallback_runfiles_manifest(config: &TestConfig) -> Result<(), String> {
     let test_dir = config.work_dir.join("test_fallback_manifest");
     fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {}", e))?;
 
-    // Create a stub with a .runfiles_manifest file next to it (not a directory)
+    // Create a stub with only a .runfiles_manifest file next to it.
     let stub_path = test_dir.join(format!("manifest_stub{}", EXE_EXT));
     let manifest_path = test_dir.join(format!("manifest_stub{}.runfiles_manifest", EXE_EXT));
 
-    // Create the runfiles directory structure for the files
+    // The logical sibling tree intentionally does not exist. The manifest maps
+    // execution elsewhere, while argv[0] retains the logical runfiles identity.
     let runfiles_dir = test_dir.join(format!("manifest_stub{}.runfiles", EXE_EXT));
-    let binary_dir = runfiles_dir.join(WORKSPACE_NAME).join("bin");
-    fs::create_dir_all(&binary_dir).map_err(|e| format!("Failed to create binary dir: {}", e))?;
-
-    let add_binary = config.test_binaries_dir.join(format!("add-numbers{}", EXE_EXT));
-    let dest_binary = binary_dir.join(format!("add-numbers{}", EXE_EXT));
-    fs::copy(&add_binary, &dest_binary).map_err(|e| format!("Failed to copy binary: {}", e))?;
-
-    #[cfg(unix)]
-    {
-        use std::os::unix::fs::PermissionsExt;
-        let mut perms = fs::metadata(&dest_binary)
-            .map_err(|e| format!("Failed to get permissions: {}", e))?
-            .permissions();
-        perms.set_mode(0o755);
-        fs::set_permissions(&dest_binary, perms)
-            .map_err(|e| format!("Failed to set permissions: {}", e))?;
-    }
+    let print_env_binary = config
+        .test_binaries_dir
+        .join(format!("print-env{}", EXE_EXT));
 
     // Write the manifest file (key value pairs separated by space)
-    let add_rlocation = format!("{}/bin/add-numbers{}", WORKSPACE_NAME, EXE_EXT);
-    let manifest_content = format!("{} {}\n", add_rlocation, dest_binary.display());
+    let print_env_rlocation = format!("{}/bin/print-env{}", WORKSPACE_NAME, EXE_EXT);
+    let manifest_content = format!(
+        "{} {}\n",
+        print_env_rlocation,
+        print_env_binary.display()
+    );
     fs::write(&manifest_path, manifest_content)
         .map_err(|e| format!("Failed to write manifest: {}", e))?;
 
@@ -749,7 +941,7 @@ fn test_fallback_runfiles_manifest(config: &TestConfig) -> Result<(), String> {
     finalize_stub(
         config,
         &stub_path,
-        &[&add_rlocation, "7", "8"],
+        &[&print_env_rlocation],
         &[0],
     )?;
 
@@ -757,6 +949,7 @@ fn test_fallback_runfiles_manifest(config: &TestConfig) -> Result<(), String> {
     let mut cmd = Command::new(&stub_path);
     cmd.env_remove("RUNFILES_DIR");
     cmd.env_remove("RUNFILES_MANIFEST_FILE");
+    cmd.env_remove("JAVA_RUNFILES");
 
     let output = cmd.output().map_err(|e| format!("Failed to run stub: {}", e))?;
 
@@ -770,9 +963,32 @@ fn test_fallback_runfiles_manifest(config: &TestConfig) -> Result<(), String> {
             exit_code, stdout, stderr
         ));
     }
+    let expected_manifest = format!("ENV:RUNFILES_MANIFEST_FILE={}", manifest_path.display());
+    if !stdout.contains(&expected_manifest)
+        || !stdout.contains("ENV:RUNFILES_DIR=<unset>")
+        || !stdout.contains("ENV:JAVA_RUNFILES=<unset>")
+    {
+        return Err(format!(
+            "Adjacent manifest was not exported as the sole runfiles source.\nstdout: {}",
+            stdout
+        ));
+    }
 
-    if !stdout.contains("SUM:15") {
-        return Err(format!("Unexpected output: {}. Expected 'SUM:15'", stdout));
+    #[cfg(unix)]
+    {
+        let expected = runfiles_dir.join(&print_env_rlocation);
+        let actual = stdout
+            .lines()
+            .next()
+            .and_then(|line| line.strip_prefix("ARGS:"))
+            .and_then(|args| args.split('|').next());
+        if actual != Some(expected.to_string_lossy().as_ref()) {
+            return Err(format!(
+                "Adjacent manifest did not preserve logical argv[0].\nexpected: {}\nstdout: {}",
+                expected.display(),
+                stdout
+            ));
+        }
     }
 
     println!("    PASS");
@@ -1010,6 +1226,25 @@ fn test_print_env(config: &TestConfig) -> Result<(), String> {
         return Err(format!("Stub failed with exit code {}: {}", exit_code, stderr));
     }
 
+    #[cfg(unix)]
+    {
+        let expected = runfiles
+            .get_path(&print_env_rlocation)
+            .ok_or_else(|| format!("Missing manifest entry for {}", print_env_rlocation))?;
+        let actual = stdout
+            .lines()
+            .next()
+            .and_then(|line| line.strip_prefix("ARGS:"))
+            .and_then(|args| args.split('|').next());
+        if actual != Some(expected.to_string_lossy().as_ref()) {
+            return Err(format!(
+                "Environment manifest changed argv[0].\nexpected: {}\nstdout: {}",
+                expected.display(),
+                stdout
+            ));
+        }
+    }
+
     // Verify embedded arguments are passed
     if !stdout.contains("--embedded-flag") {
         return Err(format!("Missing embedded flag in output: {}", stdout));
@@ -1173,6 +1408,7 @@ fn main() -> ExitCode {
     let tests: Vec<(&str, fn(&TestConfig) -> Result<(), String>)> = vec![
         ("hash_file", test_hash_file),
         ("add_numbers_runtime_args", test_add_numbers_runtime_args),
+        ("runfiles_source_precedence", test_runfiles_source_precedence),
         ("merge_json", test_merge_json),
         ("orchestrator_env_propagation", test_orchestrator_env_propagation),
         ("mixed_arguments", test_mixed_arguments),

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -66,6 +66,14 @@ fn resolve_runfile_path(runfiles: &Runfiles, path: PathBuf) -> PathBuf {
     rlocation!(runfiles, runfiles_key.as_str()).unwrap_or(path)
 }
 
+fn environment_path<'a>(stdout: &'a str, name: &str) -> Option<&'a Path> {
+    let prefix = format!("ENV:{}=", name);
+    stdout
+        .lines()
+        .find_map(|line| line.strip_prefix(&prefix))
+        .map(Path::new)
+}
+
 impl TestConfig {
     fn from_args() -> Result<Self, String> {
         let args: Vec<String> = env::args().collect();
@@ -479,12 +487,10 @@ fn test_runfiles_source_precedence(config: &TestConfig) -> Result<(), String> {
         .map_err(|e| format!("Failed to run stub with both runfiles variables: {}", e))?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let expected_dir = format!("ENV:RUNFILES_DIR={}", runfiles.runfiles_dir.display());
-    let expected_java = format!("ENV:JAVA_RUNFILES={}", runfiles.runfiles_dir.display());
     if !output.status.success()
         || !stdout.contains("ARGC:3")
-        || !stdout.contains(&expected_dir)
-        || !stdout.contains(&expected_java)
+        || environment_path(&stdout, "RUNFILES_DIR") != Some(runfiles.runfiles_dir.as_path())
+        || environment_path(&stdout, "JAVA_RUNFILES") != Some(runfiles.runfiles_dir.as_path())
         || !stdout.contains("ENV:RUNFILES_MANIFEST_FILE=<unset>")
     {
         return Err(format!(
@@ -542,12 +548,9 @@ fn test_runfiles_source_precedence(config: &TestConfig) -> Result<(), String> {
         .map_err(|e| format!("Failed to inspect manifest-selected environment: {}", e))?;
     let stdout = String::from_utf8_lossy(&output.stdout);
     let stderr = String::from_utf8_lossy(&output.stderr);
-    let expected_manifest = format!(
-        "ENV:RUNFILES_MANIFEST_FILE={}",
-        manifest_export_path.display()
-    );
     if !output.status.success()
-        || !stdout.contains(&expected_manifest)
+        || environment_path(&stdout, "RUNFILES_MANIFEST_FILE")
+            != Some(manifest_export_path.as_path())
         || !stdout.contains("ENV:RUNFILES_DIR=<unset>")
         || !stdout.contains("ENV:JAVA_RUNFILES=<unset>")
     {
@@ -571,8 +574,8 @@ fn test_runfiles_source_precedence(config: &TestConfig) -> Result<(), String> {
     let stderr = String::from_utf8_lossy(&output.stderr);
     if !output.status.success()
         || !stdout.contains("ARGC:3")
-        || !stdout.contains(&expected_dir)
-        || !stdout.contains(&expected_java)
+        || environment_path(&stdout, "RUNFILES_DIR") != Some(runfiles.runfiles_dir.as_path())
+        || environment_path(&stdout, "JAVA_RUNFILES") != Some(runfiles.runfiles_dir.as_path())
         || !stdout.contains("ENV:RUNFILES_MANIFEST_FILE=<unset>")
     {
         return Err(format!(
@@ -963,8 +966,7 @@ fn test_fallback_runfiles_manifest(config: &TestConfig) -> Result<(), String> {
             exit_code, stdout, stderr
         ));
     }
-    let expected_manifest = format!("ENV:RUNFILES_MANIFEST_FILE={}", manifest_path.display());
-    if !stdout.contains(&expected_manifest)
+    if environment_path(&stdout, "RUNFILES_MANIFEST_FILE") != Some(manifest_path.as_path())
         || !stdout.contains("ENV:RUNFILES_DIR=<unset>")
         || !stdout.contains("ENV:JAVA_RUNFILES=<unset>")
     {

--- a/runfiles-stub/src/linux.rs
+++ b/runfiles-stub/src/linux.rs
@@ -493,10 +493,10 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u
         ptrs.push(start_pos as *const u8);
     };
 
-    if let Some(ref path) = rf.manifest_path {
+    if let Some(path) = rf.manifest_path() {
         add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
     }
-    if let Some(ref path) = rf.dir_path {
+    if let Some(path) = rf.dir_path() {
         add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_DIR", path);
         add_env_var(&mut env_data, &mut env_ptrs, b"JAVA_RUNFILES", path);
     }

--- a/runfiles-stub/src/macos.rs
+++ b/runfiles-stub/src/macos.rs
@@ -418,10 +418,10 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u
     };
 
     if let Some(rf) = runfiles {
-        if let Some(ref path) = rf.manifest_path {
+        if let Some(path) = rf.manifest_path() {
             add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
         }
-        if let Some(ref path) = rf.dir_path {
+        if let Some(path) = rf.dir_path() {
             add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_DIR", path);
             add_env_var(&mut env_data, &mut env_ptrs, b"JAVA_RUNFILES", path);
         }

--- a/runfiles-stub/src/run.rs
+++ b/runfiles-stub/src/run.rs
@@ -137,23 +137,19 @@ pub fn main(rt: platform::RuntimeArgs) -> ! {
         resolved.push(bytes);
     }
 
-    // Preserve argv[0] as a runfiles-relative path so tools that walk argv[0]'s
-    // parent symlinks (e.g. aspect_rules_py's venv_shim) can locate .runfiles. The
-    // fully-resolved path is still used as the program to execute.
+    // Preserve argv[0] as a logical runfiles path so tools that walk its parent
+    // can locate .runfiles. A manifest can supply that identity even when its
+    // sibling directory is absent; the resolved path still selects the program.
     let argv0_override: Option<Vec<u8>> = runfiles
         .as_ref()
-        .and_then(|rf| rf.dir_path.as_ref())
-        .and_then(|dir| {
+        .and_then(|rf| {
             let arg0 = placeholders::arg(0);
             let arg0_len = cstr_len(arg0);
             if arg0_len == 0 {
                 return None;
             }
-            let mut path = Vec::from(dir.as_bytes());
-            if !dir.ends_with('/') {
-                path.push(b'/');
-            }
-            path.extend_from_slice(&arg0[..arg0_len]);
+            let arg0 = core::str::from_utf8(&arg0[..arg0_len]).ok()?;
+            let mut path = Vec::from(rf.argv0_rlocation(arg0)?.as_bytes());
             path.push(0);
             Some(path)
         });

--- a/runfiles-stub/src/runfiles.rs
+++ b/runfiles-stub/src/runfiles.rs
@@ -10,88 +10,60 @@ use alloc::vec::Vec;
 use crate::common::{cstr_len, Manifest};
 use crate::platform;
 
-pub enum RunfilesMode {
-    ManifestBased(Manifest),
-    DirectoryBased(String),
-}
-
-pub struct Runfiles {
-    mode: RunfilesMode,
-    // Paths for environment variables (when export_runfiles_env is true)
-    pub manifest_path: Option<String>, // RUNFILES_MANIFEST_FILE
-    pub dir_path: Option<String>,      // RUNFILES_DIR and JAVA_RUNFILES
+pub enum Runfiles {
+    Manifest {
+        manifest: Manifest,
+        path: String,
+        logical_dir: Option<String>,
+    },
+    Directory {
+        path: String,
+    },
 }
 
 impl Runfiles {
     pub fn create(rt: &platform::RuntimeArgs) -> Option<Self> {
-        // Try RUNFILES_MANIFEST_FILE first
-        if let Some(manifest_path) = platform::get_env_var(b"RUNFILES_MANIFEST_FILE") {
-            if !manifest_path.is_empty() {
-                // Create null-terminated path for load_manifest
-                let mut path_with_null = Vec::from(manifest_path.as_bytes());
-                path_with_null.push(0);
-
-                if let Some(manifest) = platform::load_manifest(&path_with_null) {
-                    return Some(Self {
-                        mode: RunfilesMode::ManifestBased(manifest),
-                        manifest_path: Some(manifest_path),
-                        dir_path: None,
-                    });
-                }
-            }
+        // Environment-provided sources take precedence over sources discovered
+        // next to the executable. At the same precedence, prefer a directory.
+        if let Some(runfiles_dir) = platform::get_env_var(b"RUNFILES_DIR")
+            .filter(|path| !path.is_empty() && dir_exists(path))
+        {
+            return Some(Self::Directory { path: runfiles_dir });
         }
-
-        // Try RUNFILES_DIR
-        if let Some(runfiles_dir) = platform::get_env_var(b"RUNFILES_DIR") {
-            if !runfiles_dir.is_empty() {
-                return Some(Self {
-                    mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
-                    manifest_path: None,
-                    dir_path: Some(runfiles_dir),
+        if let Some(manifest_path) = platform::get_env_var(b"RUNFILES_MANIFEST_FILE")
+            .filter(|path| !path.is_empty())
+        {
+            if let Some(manifest) = load_manifest(&manifest_path) {
+                return Some(Self::Manifest {
+                    manifest,
+                    path: manifest_path,
+                    logical_dir: None,
                 });
             }
         }
 
         // Locate runfiles next to the launching executable:
-        // <executable>.runfiles_manifest file first (preferred), then
-        // <executable>.runfiles directory. The executable path comes from the OS
-        // (an absolute, non-symlink-resolved launch path), not from argv[0].
+        // <executable>.runfiles directory first, then
+        // <executable>.runfiles_manifest file. The executable path comes from the
+        // OS (an absolute, non-symlink-resolved launch path), not from argv[0].
         if let Some(exe_path) = rt.executable_path() {
             let exe_len = cstr_len(&exe_path);
             if exe_len > 0 {
                 // Convert the executable path to a string (if valid UTF-8).
                 let exe_str = core::str::from_utf8(&exe_path[..exe_len]).ok()?;
-
-                // Try <executable>.runfiles_manifest file first
-                let manifest_file_path = String::from(exe_str) + ".runfiles_manifest";
-
-                // Add null terminator for the file open
-                let mut manifest_path_with_null = Vec::from(manifest_file_path.as_bytes());
-                manifest_path_with_null.push(0);
-
-                if let Some(manifest) = platform::load_manifest(&manifest_path_with_null) {
-                    // Also determine the runfiles directory for RUNFILES_DIR envvar
-                    let dir_path = String::from(exe_str) + ".runfiles";
-
-                    return Some(Self {
-                        mode: RunfilesMode::ManifestBased(manifest),
-                        manifest_path: Some(manifest_file_path),
-                        dir_path: Some(dir_path),
-                    });
+                let runfiles_dir = String::from(exe_str) + ".runfiles";
+                if dir_exists(&runfiles_dir) {
+                    return Some(Self::Directory { path: runfiles_dir });
                 }
 
-                // Try <executable>.runfiles directory
-                let runfiles_dir = String::from(exe_str) + ".runfiles";
-
-                // Add null terminator for the existence check
-                let mut dir_with_null = Vec::from(runfiles_dir.as_bytes());
-                dir_with_null.push(0);
-
-                if platform::path_exists(&dir_with_null) {
-                    return Some(Self {
-                        mode: RunfilesMode::DirectoryBased(runfiles_dir.clone()),
-                        manifest_path: None,
-                        dir_path: Some(runfiles_dir),
+                let manifest_path = String::from(exe_str) + ".runfiles_manifest";
+                if let Some(manifest) = load_manifest(&manifest_path) {
+                    return Some(Self::Manifest {
+                        manifest,
+                        path: manifest_path,
+                        // Preserve the logical path even though the sibling tree
+                        // is absent; the manifest selected the actual executable.
+                        logical_dir: Some(runfiles_dir),
                     });
                 }
             }
@@ -106,19 +78,60 @@ impl Runfiles {
             return None;
         }
 
-        match &self.mode {
-            RunfilesMode::ManifestBased(manifest) => resolve_manifest(manifest, path),
-            RunfilesMode::DirectoryBased(dir) => {
-                let mut result = dir.clone();
-                // Add separator if needed.
-                if !result.ends_with('/') && !result.ends_with(platform::SEP) {
-                    result.push(platform::SEP);
-                }
-                result.push_str(&platform::to_native_path(path));
-                Some(result)
-            }
+        match self {
+            Self::Manifest { manifest, .. } => resolve_manifest(manifest, path),
+            Self::Directory { path: dir } => Some(join_runfiles_path(dir, path)),
         }
     }
+
+    pub fn argv0_rlocation(&self, path: &str) -> Option<String> {
+        let dir = match self {
+            Self::Directory { path } => path,
+            Self::Manifest { logical_dir, .. } => logical_dir.as_ref()?,
+        };
+        Some(join_runfiles_path(dir, path))
+    }
+
+    pub fn manifest_path(&self) -> Option<&str> {
+        match self {
+            Self::Manifest { path, .. } => Some(path),
+            Self::Directory { .. } => None,
+        }
+    }
+
+    pub fn dir_path(&self) -> Option<&str> {
+        match self {
+            Self::Manifest { .. } => None,
+            Self::Directory { path } => Some(path),
+        }
+    }
+}
+
+fn dir_exists(path: &str) -> bool {
+    // A trailing separator makes the existing-path probe directory-specific on
+    // Unix and Windows: regular files cannot be traversed as directories.
+    let mut path_with_separator = String::from(path);
+    if !path.ends_with('/') && !path.ends_with(platform::SEP) {
+        path_with_separator.push(platform::SEP);
+    }
+    let mut path_with_null = Vec::from(path_with_separator.as_bytes());
+    path_with_null.push(0);
+    platform::path_exists(&path_with_null)
+}
+
+fn load_manifest(path: &str) -> Option<Manifest> {
+    let mut path_with_null = Vec::from(path.as_bytes());
+    path_with_null.push(0);
+    platform::load_manifest(&path_with_null)
+}
+
+fn join_runfiles_path(dir: &str, path: &str) -> String {
+    let mut result = String::from(dir);
+    if !result.ends_with('/') && !result.ends_with(platform::SEP) {
+        result.push(platform::SEP);
+    }
+    result.push_str(&platform::to_native_path(path));
+    result
 }
 
 /// Maximum number of relative manifest hops to follow before giving up. Bazel

--- a/runfiles-stub/src/windows.rs
+++ b/runfiles-stub/src/windows.rs
@@ -28,6 +28,8 @@ const CREATE_UNICODE_ENVIRONMENT: DWORD = 0x00000400;
 
 // File sharing and memory-mapping parameters (for the runfiles manifest)
 const FILE_SHARE_READ: DWORD = 0x00000001;
+const FILE_SHARE_WRITE: DWORD = 0x00000002;
+const FILE_SHARE_DELETE: DWORD = 0x00000004;
 const PAGE_READONLY: DWORD = 0x02;
 const FILE_MAP_READ: DWORD = 0x04;
 
@@ -160,10 +162,13 @@ pub fn exit(code: i32) -> ! {
 pub fn path_exists(path: &[u8]) -> bool {
     const FILE_FLAG_BACKUP_SEMANTICS: DWORD = 0x02000000;
     unsafe {
+        // Request no access and allow ordinary sharing: an existence probe
+        // should not fail merely because another process has the path open.
+        // https://learn.microsoft.com/windows/win32/api/fileapi/nf-fileapi-createfilea
         let handle = CreateFileA(
             path.as_ptr(),
-            GENERIC_READ,
             0,
+            FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE,
             core::ptr::null_mut(),
             OPEN_EXISTING,
             FILE_FLAG_BACKUP_SEMANTICS,
@@ -302,11 +307,11 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
         if env_block.is_null() {
             // No parent environment: add runfiles vars in sorted order.
             if let Some(rf) = runfiles {
-                if let Some(ref path) = rf.dir_path {
+                if let Some(path) = rf.dir_path() {
                     push_var(&mut buf, b"JAVA_RUNFILES", path);
                     push_var(&mut buf, b"RUNFILES_DIR", path);
                 }
-                if let Some(ref path) = rf.manifest_path {
+                if let Some(path) = rf.manifest_path() {
                     push_var(&mut buf, b"RUNFILES_MANIFEST_FILE", path);
                 }
             }
@@ -327,22 +332,31 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
                 }
                 let entry_ptr = env_block.add(entry_start);
 
-                // Skip existing runfiles vars (we re-insert our own).
-                let prefixed = |needle: &[u8]| -> bool {
-                    entry_len > needle.len()
-                        && (0..needle.len()).all(|i| *entry_ptr.add(i) == needle[i] as u16)
+                // Remove inherited runfiles variables before optionally inserting
+                // the values selected for this launch.
+                let ascii_upper = |unit: u16| {
+                    if (b'a' as u16..=b'z' as u16).contains(&unit) {
+                        unit - 32
+                    } else {
+                        unit
+                    }
                 };
-                let should_skip = prefixed(b"RUNFILES_MANIFEST_FILE=")
-                    || prefixed(b"RUNFILES_DIR=")
-                    || prefixed(b"JAVA_RUNFILES=");
+                let prefixed_case_insensitive = |needle: &[u8]| -> bool {
+                    entry_len >= needle.len()
+                        && (0..needle.len()).all(|i| {
+                            ascii_upper(*entry_ptr.add(i)) == ascii_upper(needle[i] as u16)
+                        })
+                };
+                let should_skip = prefixed_case_insensitive(b"RUNFILES_MANIFEST_FILE=")
+                    || prefixed_case_insensitive(b"RUNFILES_DIR=")
+                    || prefixed_case_insensitive(b"JAVA_RUNFILES=");
 
                 if !should_skip {
                     // Case-insensitive "does this entry sort after `target`?"
                     let var_comes_after = |target: &[u8]| -> bool {
-                        let upper = |c: u16| if (b'a' as u16..=b'z' as u16).contains(&c) { c - 32 } else { c };
                         for i in 0..target.len().min(entry_len) {
-                            let e = upper(*entry_ptr.add(i));
-                            let t = upper(target[i] as u16);
+                            let e = ascii_upper(*entry_ptr.add(i));
+                            let t = ascii_upper(target[i] as u16);
                             if e != t {
                                 return e > t;
                             }
@@ -352,7 +366,7 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
 
                     if !java_inserted && var_comes_after(b"JAVA_RUNFILES") {
                         if let Some(rf) = runfiles {
-                            if let Some(ref path) = rf.dir_path {
+                            if let Some(path) = rf.dir_path() {
                                 push_var(&mut buf, b"JAVA_RUNFILES", path);
                             }
                         }
@@ -360,7 +374,7 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
                     }
                     if !dir_inserted && var_comes_after(b"RUNFILES_DIR") {
                         if let Some(rf) = runfiles {
-                            if let Some(ref path) = rf.dir_path {
+                            if let Some(path) = rf.dir_path() {
                                 push_var(&mut buf, b"RUNFILES_DIR", path);
                             }
                         }
@@ -368,7 +382,7 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
                     }
                     if !manifest_inserted && var_comes_after(b"RUNFILES_MANIFEST_FILE") {
                         if let Some(rf) = runfiles {
-                            if let Some(ref path) = rf.manifest_path {
+                            if let Some(path) = rf.manifest_path() {
                                 push_var(&mut buf, b"RUNFILES_MANIFEST_FILE", path);
                             }
                         }
@@ -388,17 +402,17 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
             // Append any runfiles vars that sort after every existing entry.
             if let Some(rf) = runfiles {
                 if !java_inserted {
-                    if let Some(ref path) = rf.dir_path {
+                    if let Some(path) = rf.dir_path() {
                         push_var(&mut buf, b"JAVA_RUNFILES", path);
                     }
                 }
                 if !dir_inserted {
-                    if let Some(ref path) = rf.dir_path {
+                    if let Some(path) = rf.dir_path() {
                         push_var(&mut buf, b"RUNFILES_DIR", path);
                     }
                 }
                 if !manifest_inserted {
-                    if let Some(ref path) = rf.manifest_path {
+                    if let Some(path) = rf.manifest_path() {
                         push_var(&mut buf, b"RUNFILES_MANIFEST_FILE", path);
                     }
                 }


### PR DESCRIPTION
Select exactly one runfiles source before resolving transformed
arguments. Bazel can set both `RUNFILES_DIR` and
`RUNFILES_MANIFEST_FILE`; choosing the manifest first resolves generated
venvs into physical outputs even when their logical runfiles tree is
available, breaking layouts that rely on relative symlinks.

Give environment-provided sources precedence over adjacent discovery,
and prefer a directory within either tier. Use the selected source
consistently for lookup and child environment export, so a process never
executes from one source while inheriting the other.

Keep the logical sibling `.runfiles` spelling in `argv[0]` when an
adjacent manifest is the only source, without exporting the nonexistent
directory. On Windows, use nonexclusive existence probes and remove
inherited runfiles variables case-insensitively before exporting the
selected source.