### PR TITLE
feat: unset inherited environment variables

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ def _impl(ctx):
 | `append_embedded_arg(arg, …)` | Append a literal string argument. |
 | `append_raw_transformed_arg(arg, …)` | Append a string argument marked for resolution. |
 | `to_rlocation_path(file)` | Convert a `File` to its rlocation path string. |
-| `compile_stub(ctx, embedded_args, transformed_args, output_file, cfg, template_exec_group, template_file)` | Run the finalizer to emit the launcher. `cfg` is `"target"` (default) or `"exec"`. |
+| `compile_stub(ctx, embedded_args, transformed_args, output_file, cfg, template_exec_group, template_file, export_runfiles_env, environment_variables_to_unset)` | Run the finalizer to emit the launcher. `cfg` is `"target"` (default) or `"exec"`. Runfiles environment export defaults to true; `environment_variables_to_unset` removes named variables before launch. |
 
 Declare the relevant toolchains on your rule:
 
@@ -138,11 +138,16 @@ finalize-stub --template <PATH> [OPTIONS] -- <arg0> [arg1 ...]
                                  Repeatable or comma-separated. Default: none.
     --export-runfiles-env <B>    Export RUNFILES_DIR/RUNFILES_MANIFEST_FILE/JAVA_RUNFILES
                                  to the child (default: true)
+    --unset-env <NAME>           Remove NAME from the child environment. Repeatable.
 -v, --verbose                    Verbose output
 ```
 
 Up to 10 embedded arguments (`arg0`–`arg9`), each ≤ 256 bytes. `arg0` is the program to
 execute; the rest are its leading arguments. Runtime arguments are unrestricted.
+Environment variable names occupy at most 256 bytes in total, including NUL separators.
+Names must be nonempty and cannot contain `=`. They compare case-sensitively on Unix and
+case-insensitively on Windows. Explicit removal wins over `--export-runfiles-env`,
+including for the three runfiles variables.
 
 ### Runfiles discovery
 

--- a/finalize-stub/src/main.rs
+++ b/finalize-stub/src/main.rs
@@ -7,6 +7,7 @@ use std::process;
 
 const ARG_SIZE: usize = 256;
 const ARGC_SIZE: usize = 32;
+const UNSET_ENV_SIZE: usize = 256;
 
 /// Finalize a runfiles stub template with actual arguments
 #[derive(Parser)]
@@ -38,6 +39,10 @@ struct Cli {
     /// Export runfiles environment variables (RUNFILES_DIR, RUNFILES_MANIFEST_FILE, JAVA_RUNFILES) to the executed process
     #[arg(long, default_value = "true", action = clap::ArgAction::Set)]
     export_runfiles_env: bool,
+
+    /// Environment variable names to remove before starting the executed process
+    #[arg(long = "unset-env", action = ArgAction::Append, allow_hyphen_values = true)]
+    unset_environment: Vec<String>,
 
     /// Enable verbose output
     #[arg(short, long)]
@@ -92,13 +97,33 @@ fn replace_at(data: &mut [u8], offset: usize, new_value: &[u8], fixed_size: usiz
     Ok(())
 }
 
-fn finalize_stub(template_path: &str, output_path: Option<&str>, argv: &[String], transform_flags: u32, export_runfiles_env: bool, verbose: bool) -> Result<(), String> {
+fn finalize_stub(template_path: &str, output_path: Option<&str>, argv: &[String], transform_flags: u32, export_runfiles_env: bool, unset_environment: &[String], verbose: bool) -> Result<(), String> {
     if argv.is_empty() {
         return Err("At least one argument (argv[0]) is required".to_string());
     }
 
     if argv.len() > 10 {
         return Err("Maximum 10 arguments supported (argv[0] to argv[9])".to_string());
+    }
+
+    let mut unset_environment_data = Vec::new();
+    for name in unset_environment {
+        if name.is_empty() {
+            return Err("Environment variable name to unset cannot be empty".to_string());
+        }
+        if name.as_bytes().contains(&b'=') {
+            return Err(format!("Environment variable name to unset cannot contain '=': {name}"));
+        }
+        if !unset_environment_data.is_empty() {
+            unset_environment_data.push(0);
+        }
+        unset_environment_data.extend_from_slice(name.as_bytes());
+        if unset_environment_data.len() > UNSET_ENV_SIZE {
+            return Err(format!(
+                "Environment variable names to unset require {} bytes; maximum is {} bytes",
+                unset_environment_data.len(), UNSET_ENV_SIZE
+            ));
+        }
     }
 
     // Prevent overwriting the input file
@@ -150,6 +175,21 @@ fn finalize_stub(template_path: &str, output_path: Option<&str>, argv: &[String]
 
     if verbose {
         eprintln!("Replaced EXPORT_RUNFILES_ENV with: {}", export_str);
+    }
+
+    // Preserve compatibility with older templates when no environment names are
+    // requested. A nonempty list requires the corresponding runtime capability.
+    if !unset_environment_data.is_empty() {
+        const UNSET_MARKER: &[u8] = b"@@RUNFILES_UNSET_ENV=@@";
+        let mut unset_pattern = [0; UNSET_ENV_SIZE];
+        unset_pattern[..UNSET_MARKER.len()].copy_from_slice(UNSET_MARKER);
+        let unset_pos = find_pattern(&data, &unset_pattern)
+            .ok_or("UNSET_ENVIRONMENT placeholder not found; template does not support --unset-env")?;
+        replace_at(&mut data, unset_pos, &unset_environment_data, UNSET_ENV_SIZE)?;
+
+        if verbose {
+            eprintln!("Embedded {} environment variable name(s) to unset", unset_environment.len());
+        }
     }
 
     // Find and replace ARG placeholders
@@ -288,7 +328,7 @@ fn main() {
         flags
     };
 
-    match finalize_stub(&cli.template, cli.output.as_deref(), &cli.args, transform_flags, cli.export_runfiles_env, cli.verbose) {
+    match finalize_stub(&cli.template, cli.output.as_deref(), &cli.args, transform_flags, cli.export_runfiles_env, &cli.unset_environment, cli.verbose) {
         Ok(()) => {
             if cli.verbose {
                 if let Some(output) = cli.output {

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -250,9 +250,24 @@ fn finalize_stub(
     args: &[&str],
     transform_indices: &[usize],
 ) -> Result<(), String> {
+    finalize_stub_with_environment(config, output_path, args, transform_indices, true, &[])
+}
+
+fn finalize_stub_with_environment(
+    config: &TestConfig,
+    output_path: &Path,
+    args: &[&str],
+    transform_indices: &[usize],
+    export_runfiles_env: bool,
+    unset_environment: &[&str],
+) -> Result<(), String> {
     let mut cmd = Command::new(&config.finalizer_path);
     cmd.arg("--template").arg(&config.template_path);
     cmd.arg("--output").arg(output_path);
+    cmd.arg("--export-runfiles-env").arg(export_runfiles_env.to_string());
+    for name in unset_environment {
+        cmd.arg("--unset-env").arg(name);
+    }
 
     // Add transform flags
     if !transform_indices.is_empty() {
@@ -1060,6 +1075,236 @@ fn test_print_env(config: &TestConfig) -> Result<(), String> {
     Ok(())
 }
 
+/// Test: the finalized stub removes selected variables from the child environment.
+fn test_unset_environment(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: unset_environment");
+
+    let test_dir = config.work_dir.join("test_unset_environment");
+    fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {e}"))?;
+    let print_env_binary = config.test_binaries_dir.join(format!("print-env{EXE_EXT}"));
+    let print_env_rlocation = format!("{WORKSPACE_NAME}/bin/print-env{EXE_EXT}");
+    let mut runfiles = RunfilesSetup::new(&test_dir, "unset_env_stub")
+        .map_err(|e| format!("Failed to create runfiles: {e}"))?;
+    runfiles.add_file(&print_env_rlocation, &print_env_binary)
+        .map_err(|e| format!("Failed to add print-env: {e}"))?;
+    runfiles.write_manifest().map_err(|e| format!("Failed to write manifest: {e}"))?;
+
+    let exported_stub = test_dir.join(format!("unset_exported{EXE_EXT}"));
+    #[cfg(windows)]
+    let unset_names = ["@@RUNFILES_CUSTOM", "--HL_UNSET", "HL_UNSET_EXACT", "hl_unset_case", "RUNFILES_MANIFEST_FILE", "å_hl_unset"];
+    #[cfg(not(windows))]
+    let unset_names = ["@@RUNFILES_CUSTOM", "--HL_UNSET", "HL_UNSET_EXACT", "hl_unset_case", "RUNFILES_MANIFEST_FILE"];
+    finalize_stub_with_environment(
+        config, &exported_stub, &[&print_env_rlocation], &[0], true, &unset_names,
+    )?;
+
+    let mut command = Command::new(&exported_stub);
+    command
+        .env("RUNFILES_MANIFEST_FILE", &runfiles.manifest_path)
+        .env_remove("RUNFILES_DIR")
+        .env("@@RUNFILES_CUSTOM", "remove-marker-prefix")
+        .env("@@RUNFILES_CUSTOM_SUFFIX", "keep-marker-prefix")
+        .env("--HL_UNSET", "remove-hyphen-prefix")
+        .env("HL_UNSET_EXACT", "remove-me")
+        .env("HL_UNSET_CASE", "case-control")
+        .env("HL_KEEP_CONTROL", "keep-me");
+    #[cfg(windows)]
+    command.env("Å_HL_UNSET", "unicode-case-control");
+    let output = command.output().map_err(|e| format!("Failed to run exported environment stub: {e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        return Err(format!("Exported environment stub failed: {stderr}\nstdout: {stdout}"));
+    }
+    if stdout.lines().any(|line| line.starts_with("ALL_ENV:HL_UNSET_EXACT=")) {
+        return Err(format!("Explicitly unset variable reached child:\n{stdout}"));
+    }
+    if stdout.contains("ALL_ENV:@@RUNFILES_CUSTOM=remove-marker-prefix") {
+        return Err(format!("Marker-prefixed unset variable reached child:\n{stdout}"));
+    }
+    if stdout.contains("ALL_ENV:--HL_UNSET=remove-hyphen-prefix") {
+        return Err(format!("Hyphen-prefixed unset variable reached child:\n{stdout}"));
+    }
+    if !stdout.contains("ALL_ENV:@@RUNFILES_CUSTOM_SUFFIX=keep-marker-prefix") {
+        return Err(format!("Complete-name matching removed a prefixed variable:\n{stdout}"));
+    }
+    if !stdout.contains("ALL_ENV:HL_KEEP_CONTROL=keep-me") {
+        return Err(format!("Unrelated environment variable was lost:\n{stdout}"));
+    }
+    if !stdout.contains("ENV:RUNFILES_MANIFEST_FILE=<unset>") {
+        return Err(format!("Explicit removal did not override runfiles export:\n{stdout}"));
+    }
+    #[cfg(unix)]
+    if !stdout.contains("ALL_ENV:HL_UNSET_CASE=case-control") {
+        return Err(format!("Unix environment removal was not case-sensitive:\n{stdout}"));
+    }
+    #[cfg(windows)]
+    {
+        let lowercase = stdout.to_lowercase();
+        if lowercase.contains("all_env:hl_unset_case=") {
+            return Err(format!("Windows environment removal was not case-insensitive:\n{stdout}"));
+        }
+        if lowercase.contains("all_env:å_hl_unset=") {
+            return Err(format!("Windows environment removal did not use Unicode case semantics:\n{stdout}"));
+        }
+    }
+
+    // No transformed arguments and no runfiles export: this must execute without
+    // initializing runfiles while still constructing a filtered child environment.
+    let unexported_stub = test_dir.join(format!("unset_unexported{EXE_EXT}"));
+    finalize_stub_with_environment(
+        config,
+        &unexported_stub,
+        &[print_env_binary.to_string_lossy().as_ref()],
+        &[],
+        false,
+        &["HL_UNSET_EXACT"],
+    )?;
+    let output = Command::new(&unexported_stub)
+        .env_remove("RUNFILES_DIR")
+        .env_remove("RUNFILES_MANIFEST_FILE")
+        .env("HL_UNSET_EXACT", "remove-me")
+        .env("HL_KEEP_CONTROL", "keep-me")
+        .output()
+        .map_err(|e| format!("Failed to run unexported environment stub: {e}"))?;
+    let stdout = String::from_utf8_lossy(&output.stdout);
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if !output.status.success() {
+        return Err(format!("Unexported environment stub failed without runfiles: {stderr}\nstdout: {stdout}"));
+    }
+    if stdout.lines().any(|line| line.starts_with("ALL_ENV:HL_UNSET_EXACT=")) {
+        return Err(format!("Unexported stub retained unset variable:\n{stdout}"));
+    }
+    if !stdout.contains("ALL_ENV:HL_KEEP_CONTROL=keep-me") {
+        return Err(format!("Unexported stub lost control variable:\n{stdout}"));
+    }
+
+    #[cfg(windows)]
+    {
+        let output = Command::new(&unexported_stub)
+            .env_clear()
+            .env("HL_UNSET_EXACT", "remove-me")
+            .output()
+            .map_err(|e| format!("Failed to run stub with empty result environment: {e}"))?;
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if !output.status.success() {
+            return Err(format!("Stub rejected an empty result environment: {stderr}\nstdout: {stdout}"));
+        }
+        if stdout.to_lowercase().contains("all_env:hl_unset_exact=") {
+            return Err(format!("Empty result environment retained unset variable:\n{stdout}"));
+        }
+    }
+
+    println!("    PASS (exported and unexported child environments)");
+    Ok(())
+}
+
+/// Test: invalid environment-removal requests fail with identifying diagnostics.
+fn test_invalid_unset_environment(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: invalid_unset_environment");
+
+    let test_dir = config.work_dir.join("test_invalid_unset_environment");
+    fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {e}"))?;
+    let output_path = test_dir.join(format!("invalid{EXE_EXT}"));
+    let boundary_a = "a".repeat(127);
+    let boundary_b = "b".repeat(128);
+    let output = Command::new(&config.finalizer_path)
+        .arg("--template").arg(&config.template_path)
+        .arg("--output").arg(&output_path)
+        .arg("--unset-env").arg(&boundary_a)
+        .arg("--unset-env").arg(&boundary_b)
+        .arg("--").arg("unused")
+        .output()
+        .map_err(|e| format!("Failed to run finalizer: {e}"))?;
+    if !output.status.success() {
+        return Err(format!("Finalizer rejected a 256-byte unset payload: {}", String::from_utf8_lossy(&output.stderr)));
+    }
+
+    let long_name = "x".repeat(257);
+    let cases = [
+        ("", "cannot be empty"),
+        ("INVALID=NAME", "cannot contain '='"),
+        (long_name.as_str(), "maximum is 256 bytes"),
+    ];
+
+    for (name, expected_error) in cases {
+        let output = Command::new(&config.finalizer_path)
+            .arg("--template").arg(&config.template_path)
+            .arg("--output").arg(&output_path)
+            .arg("--unset-env").arg(name)
+            .arg("--").arg("unused")
+            .output()
+            .map_err(|e| format!("Failed to run finalizer: {e}"))?;
+        let stderr = String::from_utf8_lossy(&output.stderr);
+        if output.status.success() || !stderr.contains(expected_error) {
+            return Err(format!("Invalid unset name {name:?} did not fail with {expected_error:?}: {stderr}"));
+        }
+    }
+
+    println!("    PASS (empty, invalid, and oversized names rejected)");
+    Ok(())
+}
+
+/// Test: a new finalizer can use an older template when the unset list is empty.
+fn test_unset_environment_template_compatibility(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: unset_environment_template_compatibility");
+
+    const UNSET_ENV_SIZE: usize = 256;
+    const UNSET_MARKER: &[u8] = b"@@RUNFILES_UNSET_ENV=@@";
+    let test_dir = config.work_dir.join("test_unset_environment_template_compatibility");
+    fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {e}"))?;
+
+    let mut old_template_data = fs::read(&config.template_path)
+        .map_err(|e| format!("Failed to read template: {e}"))?;
+    let mut unset_pattern = [0; UNSET_ENV_SIZE];
+    unset_pattern[..UNSET_MARKER.len()].copy_from_slice(UNSET_MARKER);
+    let unset_offset = old_template_data.windows(UNSET_ENV_SIZE)
+        .position(|window| window == unset_pattern)
+        .ok_or("UNSET_ENVIRONMENT placeholder not found in current template")?;
+    old_template_data[unset_offset..unset_offset + UNSET_ENV_SIZE].fill(0);
+    let old_template = test_dir.join(format!("old_template{EXE_EXT}"));
+    fs::write(&old_template, old_template_data)
+        .map_err(|e| format!("Failed to write simulated old template: {e}"))?;
+
+    let print_env_binary = config.test_binaries_dir.join(format!("print-env{EXE_EXT}"));
+    let compatible_stub = test_dir.join(format!("compatible{EXE_EXT}"));
+    let output = Command::new(&config.finalizer_path)
+        .arg("--template").arg(&old_template)
+        .arg("--output").arg(&compatible_stub)
+        .arg("--export-runfiles-env").arg("false")
+        .arg("--").arg(&print_env_binary)
+        .output()
+        .map_err(|e| format!("Failed to finalize simulated old template: {e}"))?;
+    if !output.status.success() {
+        return Err(format!("Empty unset list rejected an old template: {}", String::from_utf8_lossy(&output.stderr)));
+    }
+    let output = Command::new(&compatible_stub)
+        .env_remove("RUNFILES_DIR")
+        .env_remove("RUNFILES_MANIFEST_FILE")
+        .output()
+        .map_err(|e| format!("Failed to run compatible stub: {e}"))?;
+    if !output.status.success() {
+        return Err(format!("Old-template-compatible stub failed: {}", String::from_utf8_lossy(&output.stderr)));
+    }
+
+    let incompatible_stub = test_dir.join(format!("incompatible{EXE_EXT}"));
+    let output = Command::new(&config.finalizer_path)
+        .arg("--template").arg(&old_template)
+        .arg("--output").arg(&incompatible_stub)
+        .arg("--unset-env").arg("HL_UNSET_EXACT")
+        .arg("--").arg(&print_env_binary)
+        .output()
+        .map_err(|e| format!("Failed to test old template capability error: {e}"))?;
+    let stderr = String::from_utf8_lossy(&output.stderr);
+    if output.status.success() || !stderr.contains("template does not support --unset-env") {
+        return Err(format!("Nonempty unset list did not reject an old template: {stderr}"));
+    }
+
+    println!("    PASS (empty list compatible; nonempty list rejected)");
+    Ok(())
+}
+
 /// Regression test for issue #35: a multi-megabyte manifest must not OOM.
 ///
 /// The previous implementation copied the entire manifest into a growable `Vec`
@@ -1181,6 +1426,9 @@ fn main() -> ExitCode {
         ("run_runfiles_discovery", test_run_runfiles_discovery),
         ("relative_manifest_symlinks", test_relative_manifest_symlinks),
         ("print_env", test_print_env),
+        ("unset_environment", test_unset_environment),
+        ("invalid_unset_environment", test_invalid_unset_environment),
+        ("unset_environment_template_compatibility", test_unset_environment_template_compatibility),
         ("large_manifest", test_large_manifest),
     ];
 

--- a/launcher/private/rules/lib.bzl
+++ b/launcher/private/rules/lib.bzl
@@ -41,12 +41,14 @@ def _append_raw_transformed_arg(*, arg, embedded_args, transformed_args):
     embedded_args.append(arg)
     return embedded_args, transformed_args
 
-def _compile_stub(*, ctx, embedded_args, transformed_args, output_file, cfg = "target", template_exec_group = None, template_file = None):
+def _compile_stub(*, ctx, embedded_args, transformed_args, output_file, cfg = "target", template_exec_group = None, template_file = None, export_runfiles_env = True, environment_variables_to_unset = []):
     template = _get_template(ctx, cfg = cfg, template_exec_group = template_exec_group, template_file = template_file)
     args = ctx.actions.args()
     args.add("--template", template)
     args.add("-o", output_file)
     args.add_joined("--transform", transformed_args, join_with = ",")
+    args.add("--export-runfiles-env", "true" if export_runfiles_env else "false")
+    args.add_all(environment_variables_to_unset, before_each = "--unset-env")
     args.add("--")
     args.add_all(embedded_args)
     ctx.actions.run(

--- a/runfiles-stub/src/linux.rs
+++ b/runfiles-stub/src/linux.rs
@@ -472,17 +472,16 @@ fn read_environ() -> (Vec<u8>, Vec<*const u8>) {
     (environ_data, env_ptrs)
 }
 
-// Build modified environment with runfiles variables; pointers point into data.
-fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u8>) {
-    let (base_data, base_ptrs) = read_environ();
-
-    let rf = match runfiles {
-        Some(r) => r,
-        None => return (base_data, base_ptrs),
-    };
-
+// Build a filtered environment, optionally replacing the runfiles variables;
+// pointers point into data.
+fn build_environ(runfiles: Option<&Runfiles>, export_runfiles_env: bool, unset_environment: &[u8]) -> (Vec<u8>, Vec<*const u8>) {
+    let (base_data, _) = read_environ();
     let mut env_data = Vec::new();
     let mut env_ptrs = Vec::new();
+
+    let is_unset = |name: &[u8]| {
+        unset_environment.split(|&b| b == 0).any(|candidate| !candidate.is_empty() && candidate == name)
+    };
 
     let add_env_var = |data: &mut Vec<u8>, ptrs: &mut Vec<*const u8>, name: &[u8], value: &str| {
         let start_pos = data.len();
@@ -493,23 +492,34 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u
         ptrs.push(start_pos as *const u8);
     };
 
-    if let Some(ref path) = rf.manifest_path {
-        add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
-    }
-    if let Some(ref path) = rf.dir_path {
-        add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_DIR", path);
-        add_env_var(&mut env_data, &mut env_ptrs, b"JAVA_RUNFILES", path);
+    if export_runfiles_env {
+        if let Some(rf) = runfiles {
+            if let Some(ref path) = rf.manifest_path {
+                if !is_unset(b"RUNFILES_MANIFEST_FILE") {
+                    add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
+                }
+            }
+            if let Some(ref path) = rf.dir_path {
+                if !is_unset(b"RUNFILES_DIR") {
+                    add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_DIR", path);
+                }
+                if !is_unset(b"JAVA_RUNFILES") {
+                    add_env_var(&mut env_data, &mut env_ptrs, b"JAVA_RUNFILES", path);
+                }
+            }
+        }
     }
 
-    // Copy existing environment (skip runfiles vars we're setting).
+    // Explicit removals take precedence over implicit runfiles replacements.
     for env_entry in base_data.split(|&b| b == 0) {
         if env_entry.is_empty() {
             continue;
         }
-        let is_runfiles_var = env_entry.starts_with(b"RUNFILES_MANIFEST_FILE=")
-            || env_entry.starts_with(b"RUNFILES_DIR=")
-            || env_entry.starts_with(b"JAVA_RUNFILES=");
-        if !is_runfiles_var {
+        let name = env_entry.iter().position(|&b| b == b'=').map(|i| &env_entry[..i]);
+        let is_runfiles_var = export_runfiles_env && name.is_some_and(|name| {
+            name == b"RUNFILES_MANIFEST_FILE" || name == b"RUNFILES_DIR" || name == b"JAVA_RUNFILES"
+        });
+        if !is_runfiles_var && !name.is_some_and(is_unset) {
             let start_pos = env_data.len();
             env_data.extend_from_slice(env_entry);
             env_data.push(0);
@@ -597,8 +607,8 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
         ptrs[0] = override0.as_ptr();
     }
 
-    let (_env_data, env_ptrs) = if launch.export_env {
-        build_runfiles_environ(launch.runfiles)
+    let (_env_data, env_ptrs) = if launch.export_env || !launch.unset_environment.is_empty() {
+        build_environ(launch.runfiles, launch.export_env, launch.unset_environment)
     } else {
         read_environ()
     };

--- a/runfiles-stub/src/macos.rs
+++ b/runfiles-stub/src/macos.rs
@@ -401,11 +401,15 @@ pub fn get_env_var(name: &[u8]) -> Option<String> {
     found
 }
 
-// Build modified environment with runfiles variables, returning (data, pointers).
-// The caller must keep `data` alive while the pointers are used.
-fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u8>) {
+// Build a filtered environment, optionally replacing the runfiles variables.
+// The caller must keep `data` alive while the returned pointers are used.
+fn build_environ(runfiles: Option<&Runfiles>, export_runfiles_env: bool, unset_environment: &[u8]) -> (Vec<u8>, Vec<*const u8>) {
     let mut env_data = Vec::new();
     let mut env_ptrs = Vec::new();
+
+    let is_unset = |name: &[u8]| {
+        unset_environment.split(|&b| b == 0).any(|candidate| !candidate.is_empty() && candidate == name)
+    };
 
     // Append "name=value\0" to env_data, recording its offset (fixed up to a pointer later).
     let add_env_var = |data: &mut Vec<u8>, ptrs: &mut Vec<*const u8>, name: &[u8], value: &str| {
@@ -417,22 +421,32 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> (Vec<u8>, Vec<*const u
         ptrs.push(start_pos as *const u8);
     };
 
-    if let Some(rf) = runfiles {
-        if let Some(ref path) = rf.manifest_path {
-            add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
-        }
-        if let Some(ref path) = rf.dir_path {
-            add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_DIR", path);
-            add_env_var(&mut env_data, &mut env_ptrs, b"JAVA_RUNFILES", path);
+    if export_runfiles_env {
+        if let Some(rf) = runfiles {
+            if let Some(ref path) = rf.manifest_path {
+                if !is_unset(b"RUNFILES_MANIFEST_FILE") {
+                    add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_MANIFEST_FILE", path);
+                }
+            }
+            if let Some(ref path) = rf.dir_path {
+                if !is_unset(b"RUNFILES_DIR") {
+                    add_env_var(&mut env_data, &mut env_ptrs, b"RUNFILES_DIR", path);
+                }
+                if !is_unset(b"JAVA_RUNFILES") {
+                    add_env_var(&mut env_data, &mut env_ptrs, b"JAVA_RUNFILES", path);
+                }
+            }
         }
     }
 
-    // Copy existing environment, filtering out the runfiles vars we just set.
+    // Explicit removals take precedence over implicit runfiles replacements.
     unsafe {
         each_env(|entry| {
-            let should_skip = entry.starts_with(b"RUNFILES_MANIFEST_FILE=")
-                || entry.starts_with(b"RUNFILES_DIR=")
-                || entry.starts_with(b"JAVA_RUNFILES=");
+            let name = entry.iter().position(|&b| b == b'=').map(|i| &entry[..i]);
+            let is_runfiles_var = export_runfiles_env && name.is_some_and(|name| {
+                name == b"RUNFILES_MANIFEST_FILE" || name == b"RUNFILES_DIR" || name == b"JAVA_RUNFILES"
+            });
+            let should_skip = is_runfiles_var || name.is_some_and(is_unset);
             if !should_skip {
                 let start_pos = env_data.len();
                 env_data.extend_from_slice(entry);
@@ -544,8 +558,8 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
         }
 
         // Build the environment.
-        let (_env_data, env_ptrs) = if launch.export_env {
-            build_runfiles_environ(launch.runfiles)
+        let (_env_data, env_ptrs) = if launch.export_env || !launch.unset_environment.is_empty() {
+            build_environ(launch.runfiles, launch.export_env, launch.unset_environment)
         } else {
             (Vec::new(), clone_environ())
         };

--- a/runfiles-stub/src/placeholders.rs
+++ b/runfiles-stub/src/placeholders.rs
@@ -8,6 +8,20 @@
 // template bytes into the code, so the patched values are actually read at runtime.
 
 pub const ARG_SIZE: usize = 256;
+pub const UNSET_ENV_SIZE: usize = 256;
+
+const fn unset_env_placeholder() -> [u8; UNSET_ENV_SIZE] {
+    // '=' cannot occur in a finalized environment variable name, so no valid
+    // payload can be mistaken for this unpatched marker.
+    const MARKER: &[u8] = b"@@RUNFILES_UNSET_ENV=@@";
+    let mut placeholder = [0; UNSET_ENV_SIZE];
+    let mut i = 0;
+    while i < MARKER.len() {
+        placeholder[i] = MARKER[i];
+        i += 1;
+    }
+    placeholder
+}
 
 macro_rules! define_placeholders {
     ($section:literal) => {
@@ -22,6 +36,10 @@ macro_rules! define_placeholders {
         #[used]
         #[link_section = $section]
         static mut EXPORT_RUNFILES_ENV: [u8; 32] = *b"@@RUNFILES_EXPORT_ENV@@\0\0\0\0\0\0\0\0\0";
+
+        #[used]
+        #[link_section = $section]
+        static mut UNSET_ENVIRONMENT: [u8; UNSET_ENV_SIZE] = unset_env_placeholder();
 
         // The ten argument placeholders as one contiguous 2D array rather than ten
         // separate statics. `arg()` indexes it with pointer arithmetic, which lowers
@@ -62,6 +80,9 @@ pub fn transform_flags() -> &'static [u8] {
 }
 pub fn export_runfiles_env() -> &'static [u8] {
     read(core::ptr::addr_of!(EXPORT_RUNFILES_ENV) as *const u8, 32)
+}
+pub fn unset_environment() -> &'static [u8] {
+    read(core::ptr::addr_of!(UNSET_ENVIRONMENT) as *const u8, UNSET_ENV_SIZE)
 }
 
 pub fn arg(i: usize) -> &'static [u8] {

--- a/runfiles-stub/src/run.rs
+++ b/runfiles-stub/src/run.rs
@@ -24,6 +24,8 @@ pub struct Launch<'a> {
     pub argv0_override: Option<&'a [u8]>,
     pub runfiles: Option<&'a Runfiles>,
     pub export_env: bool,
+    /// NUL-separated UTF-8 environment variable names to remove before launch.
+    pub unset_environment: &'a [u8],
 }
 
 /// Print `msg` followed by the platform newline.
@@ -88,6 +90,16 @@ pub fn main(rt: platform::RuntimeArgs) -> ! {
         export_str[0] != b'0'
     } else {
         true
+    };
+
+    // An untouched placeholder means an older finalizer produced this executable.
+    // Trim only trailing padding; internal NULs separate variable names.
+    let unset_environment = placeholders::unset_environment();
+    let unset_environment = if unset_environment.starts_with(b"@@RUNFILES_UNSET_ENV=@@") {
+        &[][..]
+    } else {
+        let len = unset_environment.iter().rposition(|&b| b != 0).map_or(0, |i| i + 1);
+        &unset_environment[..len]
     };
 
     // Decide whether runfiles are needed at all.
@@ -163,6 +175,7 @@ pub fn main(rt: platform::RuntimeArgs) -> ! {
         argv0_override: argv0_override.as_deref(),
         runfiles: runfiles.as_ref(),
         export_env: export_runfiles_env,
+        unset_environment,
     };
     platform::launch(&launch, &rt)
 }

--- a/runfiles-stub/src/windows.rs
+++ b/runfiles-stub/src/windows.rs
@@ -120,6 +120,13 @@ extern "system" {
     fn GetExitCodeProcess(hProcess: HANDLE, lpExitCode: *mut DWORD) -> BOOL;
     fn GetEnvironmentStringsW() -> *mut u16;
     fn FreeEnvironmentStringsW(lpszEnvironmentBlock: *mut u16) -> BOOL;
+    fn CompareStringOrdinal(
+        lpString1: *const u16,
+        cchCount1: i32,
+        lpString2: *const u16,
+        cchCount2: i32,
+        bIgnoreCase: BOOL,
+    ) -> i32;
     fn GetCurrentProcess() -> HANDLE;
     fn QueryFullProcessImageNameW(
         hProcess: HANDLE,
@@ -276,14 +283,33 @@ pub fn load_manifest(path: &[u8]) -> Option<Manifest> {
     }
 }
 
-// Build the UTF-16 environment block (sorted, double-NUL terminated) with the runfiles
-// variables merged in. Returns an owned Vec the caller keeps alive while CreateProcessW
-// reads it. Previously this used a 128 KB `static mut`; a heap Vec removes the mutable
-// static, the fixed size cap, and the abort-on-overflow path, while preserving the exact
-// sorted-insertion ordering. Windows requires the block sorted alphabetically by name;
-// GetEnvironmentStringsW() already returns it sorted, so we insert our vars in place.
-fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
+// Build a filtered UTF-16 environment block (sorted, double-NUL terminated),
+// optionally replacing the runfiles variables. GetEnvironmentStringsW() already
+// returns a sorted block, so we insert our variables in place.
+fn build_environ(runfiles: Option<&Runfiles>, export_runfiles_env: bool, unset_environment: &[u8]) -> Vec<u16> {
     let mut buf: Vec<u16> = Vec::with_capacity(8192);
+    let unset_names: Vec<Vec<u16>> = unset_environment
+        .split(|&b| b == 0)
+        .filter(|name| !name.is_empty())
+        .filter_map(|name| core::str::from_utf8(name).ok())
+        .map(|name| name.encode_utf16().collect())
+        .collect();
+
+    // Windows environment-variable names are case-insensitive Unicode strings.
+    let name_eq = |left: &[u16], right: &[u16]| unsafe {
+        CompareStringOrdinal(
+            left.as_ptr(), left.len() as i32,
+            right.as_ptr(), right.len() as i32,
+            1,
+        ) == 2
+    };
+    let is_unset = |name: &[u16]| unset_names.iter().any(|candidate| name_eq(name, candidate));
+    let java_runfiles: Vec<u16> = b"JAVA_RUNFILES".iter().map(|&b| b as u16).collect();
+    let runfiles_dir: Vec<u16> = b"RUNFILES_DIR".iter().map(|&b| b as u16).collect();
+    let runfiles_manifest: Vec<u16> = b"RUNFILES_MANIFEST_FILE".iter().map(|&b| b as u16).collect();
+    let export_java_runfiles = export_runfiles_env && !is_unset(&java_runfiles);
+    let export_runfiles_dir = export_runfiles_env && !is_unset(&runfiles_dir);
+    let export_runfiles_manifest = export_runfiles_env && !is_unset(&runfiles_manifest);
 
     // Append "KEY=VALUE\0", widening bytes to UTF-16.
     let push_var = |buf: &mut Vec<u16>, key: &[u8], value: &str| {
@@ -303,11 +329,17 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
             // No parent environment: add runfiles vars in sorted order.
             if let Some(rf) = runfiles {
                 if let Some(ref path) = rf.dir_path {
-                    push_var(&mut buf, b"JAVA_RUNFILES", path);
-                    push_var(&mut buf, b"RUNFILES_DIR", path);
+                    if export_java_runfiles {
+                        push_var(&mut buf, b"JAVA_RUNFILES", path);
+                    }
+                    if export_runfiles_dir {
+                        push_var(&mut buf, b"RUNFILES_DIR", path);
+                    }
                 }
                 if let Some(ref path) = rf.manifest_path {
-                    push_var(&mut buf, b"RUNFILES_MANIFEST_FILE", path);
+                    if export_runfiles_manifest {
+                        push_var(&mut buf, b"RUNFILES_MANIFEST_FILE", path);
+                    }
                 }
             }
         } else {
@@ -327,14 +359,17 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
                 }
                 let entry_ptr = env_block.add(entry_start);
 
-                // Skip existing runfiles vars (we re-insert our own).
-                let prefixed = |needle: &[u8]| -> bool {
-                    entry_len > needle.len()
-                        && (0..needle.len()).all(|i| *entry_ptr.add(i) == needle[i] as u16)
-                };
-                let should_skip = prefixed(b"RUNFILES_MANIFEST_FILE=")
-                    || prefixed(b"RUNFILES_DIR=")
-                    || prefixed(b"JAVA_RUNFILES=");
+                let mut name_len = 0;
+                while name_len < entry_len && *entry_ptr.add(name_len) != b'=' as u16 {
+                    name_len += 1;
+                }
+                let name = core::slice::from_raw_parts(entry_ptr, name_len);
+
+                let is_runfiles_var = export_runfiles_env
+                    && (name_eq(name, &runfiles_manifest)
+                        || name_eq(name, &runfiles_dir)
+                        || name_eq(name, &java_runfiles));
+                let should_skip = is_runfiles_var || is_unset(name);
 
                 if !should_skip {
                     // Case-insensitive "does this entry sort after `target`?"
@@ -351,25 +386,31 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
                     };
 
                     if !java_inserted && var_comes_after(b"JAVA_RUNFILES") {
-                        if let Some(rf) = runfiles {
-                            if let Some(ref path) = rf.dir_path {
-                                push_var(&mut buf, b"JAVA_RUNFILES", path);
+                        if export_java_runfiles {
+                            if let Some(rf) = runfiles {
+                                if let Some(ref path) = rf.dir_path {
+                                    push_var(&mut buf, b"JAVA_RUNFILES", path);
+                                }
                             }
                         }
                         java_inserted = true;
                     }
                     if !dir_inserted && var_comes_after(b"RUNFILES_DIR") {
-                        if let Some(rf) = runfiles {
-                            if let Some(ref path) = rf.dir_path {
-                                push_var(&mut buf, b"RUNFILES_DIR", path);
+                        if export_runfiles_dir {
+                            if let Some(rf) = runfiles {
+                                if let Some(ref path) = rf.dir_path {
+                                    push_var(&mut buf, b"RUNFILES_DIR", path);
+                                }
                             }
                         }
                         dir_inserted = true;
                     }
                     if !manifest_inserted && var_comes_after(b"RUNFILES_MANIFEST_FILE") {
-                        if let Some(rf) = runfiles {
-                            if let Some(ref path) = rf.manifest_path {
-                                push_var(&mut buf, b"RUNFILES_MANIFEST_FILE", path);
+                        if export_runfiles_manifest {
+                            if let Some(rf) = runfiles {
+                                if let Some(ref path) = rf.manifest_path {
+                                    push_var(&mut buf, b"RUNFILES_MANIFEST_FILE", path);
+                                }
                             }
                         }
                         manifest_inserted = true;
@@ -387,17 +428,17 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
 
             // Append any runfiles vars that sort after every existing entry.
             if let Some(rf) = runfiles {
-                if !java_inserted {
+                if export_java_runfiles && !java_inserted {
                     if let Some(ref path) = rf.dir_path {
                         push_var(&mut buf, b"JAVA_RUNFILES", path);
                     }
                 }
-                if !dir_inserted {
+                if export_runfiles_dir && !dir_inserted {
                     if let Some(ref path) = rf.dir_path {
                         push_var(&mut buf, b"RUNFILES_DIR", path);
                     }
                 }
-                if !manifest_inserted {
+                if export_runfiles_manifest && !manifest_inserted {
                     if let Some(ref path) = rf.manifest_path {
                         push_var(&mut buf, b"RUNFILES_MANIFEST_FILE", path);
                     }
@@ -409,6 +450,10 @@ fn build_runfiles_environ(runfiles: Option<&Runfiles>) -> Vec<u16> {
     }
 
     // Final NUL: with the last entry's NUL this forms the double-NUL block terminator.
+    // An empty block needs both terminators explicitly.
+    if buf.is_empty() {
+        buf.push(0);
+    }
     buf.push(0);
     buf
 }
@@ -577,16 +622,17 @@ pub fn launch(launch: &Launch, rt: &RuntimeArgs) -> ! {
 
         cmdline_wide.push(0);
 
-        // Build the environment with runfiles vars if export is enabled.
-        // `env_storage` keeps the block alive while CreateProcessW reads it.
+        // Build a child environment only when transformation is requested. Passing
+        // NULL preserves Windows' native environment inheritance fast path.
         let env_storage: Vec<u16>;
-        let envp = if launch.export_env {
-            env_storage = build_runfiles_environ(launch.runfiles);
+        let transform_environment = launch.export_env || !launch.unset_environment.is_empty();
+        let envp = if transform_environment {
+            env_storage = build_environ(launch.runfiles, launch.export_env, launch.unset_environment);
             env_storage.as_ptr() as *mut core::ffi::c_void
         } else {
             core::ptr::null_mut()
         };
-        let creation_flags = if launch.export_env { CREATE_UNICODE_ENVIRONMENT } else { 0 };
+        let creation_flags = if transform_environment { CREATE_UNICODE_ENVIRONMENT } else { 0 };
 
         let mut si: STARTUPINFOW = core::mem::zeroed();
         si.cb = core::mem::size_of::<STARTUPINFOW>() as DWORD;


### PR DESCRIPTION
Allow low-level launcher users to remove selected inherited
environment variables before the target process starts. Some programs
consume startup-sensitive variables before wrapper code in the target
language can run, so sanitizing inside the target is too late.

Encode the names in a dedicated 256-byte placeholder and rebuild the
child environment only when runfiles export or explicit removal requires
it. Unix compares names exactly; Windows uses ordinal,
case-insensitive UTF-16 comparison. Explicit removals take precedence
over runfiles environment export.

Leave the new slot untouched when no names are requested. Existing
finalizers can therefore use new templates, and new finalizers can use
old templates until a caller requests the new capability.