### PR TITLE
test: run e2e tests against both prebuilt and source-built launcher s…

### DIFF
--- a/.bazelignore
+++ b/.bazelignore
@@ -1,2 +1,2 @@
 launcher/private/smoke
-e2e
+e2e/bzlmod

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,12 @@ jobs:
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: bazel test ${BUILDBUDDY_API_KEY:+--config=remote} --config=release //integration-tests:integration_test
+      # End-to-end launcher_binary tests, run against BOTH the prebuilt (downloaded)
+      # and the source-built stubs (see //e2e). --config=release builds the
+      # source-built stubs exactly as they ship.
+      - env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: bazel test ${BUILDBUDDY_API_KEY:+--config=cache} --config=release //e2e:all
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: bazel test ${BUILDBUDDY_API_KEY:+--config=cache} //...
@@ -180,6 +186,12 @@ jobs:
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: bazel test ${BUILDBUDDY_API_KEY:+--config=cache} --config=release //integration-tests:integration_test
+      # End-to-end launcher_binary tests, run against BOTH the prebuilt (downloaded)
+      # and the source-built stubs (see //e2e). --config=release builds the
+      # source-built stubs exactly as they ship.
+      - env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: bazel test ${BUILDBUDDY_API_KEY:+--config=cache} --config=release //e2e:all
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: bazel test ${BUILDBUDDY_API_KEY:+--config=cache} //...
@@ -210,6 +222,14 @@ jobs:
         run: |
           $config = if ($env:BUILDBUDDY_API_KEY) { "--config=cache" } else { $null }
           bazel --output_user_root=C:/b test $config --config=release --test_output=errors //integration-tests:integration_test
+      # End-to-end launcher_binary tests, run against BOTH the prebuilt (downloaded)
+      # and the source-built stubs (see //e2e). --config=release builds the
+      # source-built stubs exactly as they ship.
+      - env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: |
+          $config = if ($env:BUILDBUDDY_API_KEY) { "--config=cache" } else { $null }
+          bazel --output_user_root=C:/b test $config --config=release --test_output=errors //e2e:all
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: |

--- a/MODULE.bazel
+++ b/MODULE.bazel
@@ -12,9 +12,24 @@ register_toolchains("//launcher/private/prebuilt:all")
 
 # Only dev dependencies below this line
 
+# Toolchains backed by the stubs built from source in this repo. Registered as a
+# dev dependency so this only takes effect when hermetic_launcher is the root
+# module: downstream modules keep getting the prebuilt toolchains above and never
+# need the Rust build tooling. The in-repo e2e tests run against both (see //e2e).
+register_toolchains(
+    "//launcher/private/source_built:all",
+    dev_dependency = True,
+)
+
 bazel_dep(name = "bazel_lib", version = "3.2.2", dev_dependency = True)
 bazel_dep(name = "rules_shell", version = "0.8.0", dev_dependency = True)
 bazel_dep(name = "rules_cc", version = "0.2.18", dev_dependency = True)
+
+# For the root //e2e chain test (a cc/go/py/sh launcher_binary), which mirrors the
+# downstream BCR test module in e2e/bzlmod but also runs against the source-built
+# stubs. Dev-only, so downstream modules never pull these in.
+bazel_dep(name = "rules_go", version = "0.60.0", dev_dependency = True)
+bazel_dep(name = "rules_python", version = "1.7.0", dev_dependency = True)
 bazel_dep(name = "rules_platform", version = "0.1.0", dev_dependency = True)
 bazel_dep(name = "rules_rs", version = "0.0.77", dev_dependency = True)
 single_version_override(
@@ -34,7 +49,10 @@ use_repo(
     "default_rust_toolchains",
 )
 
-register_toolchains("@default_rust_toolchains//:all", dev_dependency = True)
+register_toolchains(
+    "@default_rust_toolchains//:all",
+    dev_dependency = True,
+)
 
 rules_rust = use_extension("@rules_rs//rs:rules_rust.bzl", "rules_rust", dev_dependency = True)
 rules_rust.patch(
@@ -112,3 +130,10 @@ register_toolchains(
     "@llvm//toolchain:all",
     dev_dependency = True,
 )
+
+# Toolchains for the root //e2e chain test's cc/go/py/sh payloads.
+go_sdk = use_extension("@rules_go//go:extensions.bzl", "go_sdk", dev_dependency = True)
+go_sdk.download(version = "1.25.6")
+
+python = use_extension("@rules_python//python/extensions:python.bzl", "python", dev_dependency = True)
+python.toolchain(python_version = "3.14")

--- a/MODULE.bazel.lock
+++ b/MODULE.bazel.lock
@@ -23,6 +23,7 @@
     "https://bcr.bazel.build/modules/apple_support/1.24.2/source.json": "2c22c9827093250406c5568da6c54e6fdf0ef06238def3d99c71b12feb057a8d",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/MODULE.bazel": "37c764292861c2f70314efa9846bb6dbb44fc0308903b3285da6528305450183",
     "https://bcr.bazel.build/modules/aspect_tools_telemetry/0.3.3/source.json": "605086bbc197743a0d360f7ddc550a1d4dfa0441bc807236e17170f636153348",
+    "https://bcr.bazel.build/modules/bazel_features/1.1.0/MODULE.bazel": "cfd42ff3b815a5f39554d97182657f8c4b9719568eb7fded2b9135f084bf760b",
     "https://bcr.bazel.build/modules/bazel_features/1.1.1/MODULE.bazel": "27b8c79ef57efe08efccbd9dd6ef70d61b4798320b8d3c134fd571f78963dbcd",
     "https://bcr.bazel.build/modules/bazel_features/1.10.0/MODULE.bazel": "f75e8807570484a99be90abcd52b5e1f390362c258bcb73106f4544957a48101",
     "https://bcr.bazel.build/modules/bazel_features/1.11.0/MODULE.bazel": "f9382337dd5a474c3b7d334c2f83e50b6eaedc284253334cf823044a26de03e8",
@@ -39,6 +40,7 @@
     "https://bcr.bazel.build/modules/bazel_features/1.30.0/MODULE.bazel": "a14b62d05969a293b80257e72e597c2da7f717e1e69fa8b339703ed6731bec87",
     "https://bcr.bazel.build/modules/bazel_features/1.33.0/MODULE.bazel": "8b8dc9d2a4c88609409c3191165bccec0e4cb044cd7a72ccbe826583303459f6",
     "https://bcr.bazel.build/modules/bazel_features/1.34.0/MODULE.bazel": "e8475ad7c8965542e0c7aac8af68eb48c4af904be3d614b6aa6274c092c2ea1e",
+    "https://bcr.bazel.build/modules/bazel_features/1.36.0/MODULE.bazel": "596cb62090b039caf1cad1d52a8bc35cf188ca9a4e279a828005e7ee49a1bec3",
     "https://bcr.bazel.build/modules/bazel_features/1.4.1/MODULE.bazel": "e45b6bb2350aff3e442ae1111c555e27eac1d915e77775f6fdc4b351b758b5d7",
     "https://bcr.bazel.build/modules/bazel_features/1.42.0/MODULE.bazel": "e8ca15cb2639c5f12183db6dcb678735555d0cdd739b32a0418b6532b5e565f8",
     "https://bcr.bazel.build/modules/bazel_features/1.42.1/MODULE.bazel": "275a59b5406ff18c01739860aa70ad7ccb3cfb474579411decca11c93b951080",
@@ -72,6 +74,11 @@
     "https://bcr.bazel.build/modules/bzip2/1.0.8.bcr.3/source.json": "8be4a3ef2599693f759e5c0990a4cc5a246ac08db4c900a38f852ba25b5c39be",
     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.3/MODULE.bazel": "f1b7bb2dd53e8f2ef984b39485ec8a44e9076dda5c4b8efd2fb4c6a6e856a31d",
     "https://bcr.bazel.build/modules/gawk/5.3.2.bcr.3/source.json": "ebe931bfe362e4b41e59ee00a528db6074157ff2ced92eb9e970acab2e1089c9",
+    "https://bcr.bazel.build/modules/gazelle/0.32.0/MODULE.bazel": "b499f58a5d0d3537f3cf5b76d8ada18242f64ec474d8391247438bf04f58c7b8",
+    "https://bcr.bazel.build/modules/gazelle/0.33.0/MODULE.bazel": "a13a0f279b462b784fb8dd52a4074526c4a2afe70e114c7d09066097a46b3350",
+    "https://bcr.bazel.build/modules/gazelle/0.34.0/MODULE.bazel": "abdd8ce4d70978933209db92e436deb3a8b737859e9354fb5fd11fb5c2004c8a",
+    "https://bcr.bazel.build/modules/gazelle/0.36.0/MODULE.bazel": "e375d5d6e9a6ca59b0cb38b0540bc9a05b6aa926d322f2de268ad267a2ee74c0",
+    "https://bcr.bazel.build/modules/gazelle/0.36.0/source.json": "0823f097b127e0201ae55d85647c94095edfe27db0431a7ae880dcab08dfaa04",
     "https://bcr.bazel.build/modules/google_benchmark/1.8.2/MODULE.bazel": "a70cf1bba851000ba93b58ae2f6d76490a9feb74192e57ab8e8ff13c34ec50cb",
     "https://bcr.bazel.build/modules/googletest/1.11.0/MODULE.bazel": "3a83f095183f66345ca86aa13c58b59f9f94a2f81999c093d4eeaa2d262d12f4",
     "https://bcr.bazel.build/modules/googletest/1.14.0.bcr.1/MODULE.bazel": "22c31a561553727960057361aa33bf20fb2e98584bc4fec007906e27053f80c6",
@@ -102,10 +109,14 @@
     "https://bcr.bazel.build/modules/platforms/1.1.0/source.json": "fcf351c47596c939140ab0d333dfdd08ed1ea6ce33c2fe70c12493a301cf1344",
     "https://bcr.bazel.build/modules/protobuf/21.7/MODULE.bazel": "a5a29bb89544f9b97edce05642fac225a808b5b7be74038ea3640fae2f8e66a7",
     "https://bcr.bazel.build/modules/protobuf/27.0/MODULE.bazel": "7873b60be88844a0a1d8f80b9d5d20cfbd8495a689b8763e76c6372998d3f64c",
+    "https://bcr.bazel.build/modules/protobuf/27.1/MODULE.bazel": "703a7b614728bb06647f965264967a8ef1c39e09e8f167b3ca0bb1fd80449c0d",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc2/MODULE.bazel": "6241d35983510143049943fc0d57937937122baf1b287862f9dc8590fc4c37df",
     "https://bcr.bazel.build/modules/protobuf/29.0-rc3/MODULE.bazel": "33c2dfa286578573afc55a7acaea3cada4122b9631007c594bf0729f41c8de92",
+    "https://bcr.bazel.build/modules/protobuf/29.0/MODULE.bazel": "319dc8bf4c679ff87e71b1ccfb5a6e90a6dbc4693501d471f48662ac46d04e4e",
     "https://bcr.bazel.build/modules/protobuf/29.1/MODULE.bazel": "557c3457560ff49e122ed76c0bc3397a64af9574691cb8201b4e46d4ab2ecb95",
     "https://bcr.bazel.build/modules/protobuf/3.19.0/MODULE.bazel": "6b5fbb433f760a99a22b18b6850ed5784ef0e9928a72668b66e4d7ccd47db9b0",
+    "https://bcr.bazel.build/modules/protobuf/3.19.2/MODULE.bazel": "532ffe5f2186b69fdde039efe6df13ba726ff338c6bc82275ad433013fa10573",
+    "https://bcr.bazel.build/modules/protobuf/3.19.6/MODULE.bazel": "9233edc5e1f2ee276a60de3eaa47ac4132302ef9643238f23128fea53ea12858",
     "https://bcr.bazel.build/modules/protobuf/32.1/MODULE.bazel": "89cd2866a9cb07fee9ff74c41ceace11554f32e0d849de4e23ac55515cfada4d",
     "https://bcr.bazel.build/modules/protobuf/33.4/MODULE.bazel": "114775b816b38b6d0ca620450d6b02550c60ceedfdc8d9a229833b34a223dc42",
     "https://bcr.bazel.build/modules/protobuf/34.0.bcr.1/MODULE.bazel": "74e541b0ba877813da786a11707d4e394433c157841d5111a36be0d44b907931",
@@ -143,6 +154,11 @@
     "https://bcr.bazel.build/modules/rules_cc/0.2.8/MODULE.bazel": "f1df20f0bf22c28192a794f29b501ee2018fa37a3862a1a2132ae2940a23a642",
     "https://bcr.bazel.build/modules/rules_foreign_cc/0.9.0/MODULE.bazel": "c9e8c682bf75b0e7c704166d79b599f93b72cfca5ad7477df596947891feeef6",
     "https://bcr.bazel.build/modules/rules_fuzzing/0.5.2/MODULE.bazel": "40c97d1144356f52905566c55811f13b299453a14ac7769dfba2ac38192337a8",
+    "https://bcr.bazel.build/modules/rules_go/0.41.0/MODULE.bazel": "55861d8e8bb0e62cbd2896f60ff303f62ffcb0eddb74ecb0e5c0cbe36fc292c8",
+    "https://bcr.bazel.build/modules/rules_go/0.42.0/MODULE.bazel": "8cfa875b9aa8c6fce2b2e5925e73c1388173ea3c32a0db4d2b4804b453c14270",
+    "https://bcr.bazel.build/modules/rules_go/0.46.0/MODULE.bazel": "3477df8bdcc49e698b9d25f734c4f3a9f5931ff34ee48a2c662be168f5f2d3fd",
+    "https://bcr.bazel.build/modules/rules_go/0.60.0/MODULE.bazel": "4a57ff2ffc2a3570e3c5646575c5a4b07287e91bcdac5d1f72383d51502b48cb",
+    "https://bcr.bazel.build/modules/rules_go/0.60.0/source.json": "1e21368c5e0c3013a110bd79a8fcff8ca46b5bcb2b561713a7273cbfcff7c464",
     "https://bcr.bazel.build/modules/rules_java/4.0.0/MODULE.bazel": "5a78a7ae82cd1a33cef56dc578c7d2a46ed0dca12643ee45edbb8417899e6f74",
     "https://bcr.bazel.build/modules/rules_java/5.3.5/MODULE.bazel": "a4ec4f2db570171e3e5eb753276ee4b389bae16b96207e9d3230895c99644b86",
     "https://bcr.bazel.build/modules/rules_java/6.5.2/MODULE.bazel": "1d440d262d0e08453fa0c4d8f699ba81609ed0e9a9a0f02cd10b3e7942e61e31",
@@ -177,6 +193,7 @@
     "https://bcr.bazel.build/modules/rules_proto/5.3.0-21.7/MODULE.bazel": "e8dff86b0971688790ae75528fe1813f71809b5afd57facb44dad9e8eca631b7",
     "https://bcr.bazel.build/modules/rules_proto/6.0.0-rc1/MODULE.bazel": "1e5b502e2e1a9e825eef74476a5a1ee524a92297085015a052510b09a1a09483",
     "https://bcr.bazel.build/modules/rules_proto/6.0.2/MODULE.bazel": "ce916b775a62b90b61888052a416ccdda405212b6aaeb39522f7dc53431a5e73",
+    "https://bcr.bazel.build/modules/rules_proto/7.0.2/MODULE.bazel": "bf81793bd6d2ad89a37a40693e56c61b0ee30f7a7fdbaf3eabbf5f39de47dea2",
     "https://bcr.bazel.build/modules/rules_proto/7.1.0/MODULE.bazel": "002d62d9108f75bb807cd56245d45648f38275cb3a99dcd45dfb864c5d74cb96",
     "https://bcr.bazel.build/modules/rules_proto/7.1.0/source.json": "39f89066c12c24097854e8f57ab8558929f9c8d474d34b2c00ac04630ad8940e",
     "https://bcr.bazel.build/modules/rules_python/0.10.2/MODULE.bazel": "cc82bc96f2997baa545ab3ce73f196d040ffb8756fd2d66125a530031cd90e5f",
@@ -219,6 +236,7 @@
     "https://bcr.bazel.build/modules/xz/5.4.5.bcr.8/MODULE.bazel": "e48a69bd54053c2ec5fffc2a29fb70122afd3e83ab6c07068f63bc6553fa57cc",
     "https://bcr.bazel.build/modules/xz/5.4.5.bcr.8/source.json": "bd7e928ccd63505b44f4784f7bbf12cc11f9ff23bf3ca12ff2c91cd74846099e",
     "https://bcr.bazel.build/modules/zlib/1.2.11/MODULE.bazel": "07b389abc85fdbca459b69e2ec656ae5622873af3f845e1c9d80fe179f3effa0",
+    "https://bcr.bazel.build/modules/zlib/1.2.12/MODULE.bazel": "3b1a8834ada2a883674be8cbd36ede1b6ec481477ada359cd2d3ddc562340b27",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/MODULE.bazel": "eec517b5bbe5492629466e11dae908d043364302283de25581e3eb944326c4ca",
     "https://bcr.bazel.build/modules/zlib/1.3.1.bcr.5/source.json": "22bc55c47af97246cfc093d0acf683a7869377de362b5d1c552c2c2e16b7a806",
     "https://bcr.bazel.build/modules/zlib/1.3.1/MODULE.bazel": "751c9940dcfe869f5f7274e1295422a34623555916eb98c174c1e945594bf198"
@@ -241,21 +259,6 @@
                 "rules_rs": "0.0.77",
                 "aspect_tools_telemetry": "0.3.3"
               }
-            }
-          }
-        }
-      }
-    },
-    "@@protobuf+//python/dist:system_python.bzl%system_python_extension": {
-      "general": {
-        "bzlTransitiveDigest": "pmsA+awieucfllLc2n7k8xEoPp0i5LF9Hw6mGX0cqSQ=",
-        "usagesDigest": "A+RWmbKdBBwZcBbNGNvfPbqG2vYZRjVrFp6x1iRUrAk=",
-        "recordedInputs": [],
-        "generatedRepoSpecs": {
-          "system_python": {
-            "repoRuleId": "@@protobuf+//python/dist:system_python.bzl%system_python",
-            "attributes": {
-              "minimum_python_version": "3.9"
             }
           }
         }
@@ -540,6 +543,332 @@
     }
   },
   "facts": {
+    "@@rules_go+//go:extensions.bzl%go_sdk": {
+      "1.25.0": {
+        "aix_ppc64": [
+          "go1.25.0.aix-ppc64.tar.gz",
+          "e5234a7dac67bc86c528fe9752fc9d63557918627707a733ab4cac1a6faed2d4"
+        ],
+        "darwin_amd64": [
+          "go1.25.0.darwin-amd64.tar.gz",
+          "5bd60e823037062c2307c71e8111809865116714d6f6b410597cf5075dfd80ef"
+        ],
+        "darwin_arm64": [
+          "go1.25.0.darwin-arm64.tar.gz",
+          "544932844156d8172f7a28f77f2ac9c15a23046698b6243f633b0a0b00c0749c"
+        ],
+        "dragonfly_amd64": [
+          "go1.25.0.dragonfly-amd64.tar.gz",
+          "5ed3cf9a810a1483822538674f1336c06b51aa1b94d6d545a1a0319a48177120"
+        ],
+        "freebsd_386": [
+          "go1.25.0.freebsd-386.tar.gz",
+          "abea5d5c6697e6b5c224731f2158fe87c602996a2a233ac0c4730cd57bf8374e"
+        ],
+        "freebsd_amd64": [
+          "go1.25.0.freebsd-amd64.tar.gz",
+          "86e6fe0a29698d7601c4442052dac48bd58d532c51cccb8f1917df648138730b"
+        ],
+        "freebsd_arm": [
+          "go1.25.0.freebsd-arm.tar.gz",
+          "d90b78e41921f72f30e8bbc81d9dec2cff7ff384a33d8d8debb24053e4336bfe"
+        ],
+        "freebsd_arm64": [
+          "go1.25.0.freebsd-arm64.tar.gz",
+          "451d0da1affd886bfb291b7c63a6018527b269505db21ce6e14724f22ab0662e"
+        ],
+        "freebsd_riscv64": [
+          "go1.25.0.freebsd-riscv64.tar.gz",
+          "7b565f76bd8bda46549eeaaefe0e53b251e644c230577290c0f66b1ecdb3cdbe"
+        ],
+        "illumos_amd64": [
+          "go1.25.0.illumos-amd64.tar.gz",
+          "b1e1fdaab1ad25aa1c08d7a36c97d45d74b98b89c3f78c6d2145f77face54a2c"
+        ],
+        "linux_386": [
+          "go1.25.0.linux-386.tar.gz",
+          "8c602dd9d99bc9453b3995d20ce4baf382cc50855900a0ece5de9929df4a993a"
+        ],
+        "linux_amd64": [
+          "go1.25.0.linux-amd64.tar.gz",
+          "2852af0cb20a13139b3448992e69b868e50ed0f8a1e5940ee1de9e19a123b613"
+        ],
+        "linux_arm64": [
+          "go1.25.0.linux-arm64.tar.gz",
+          "05de75d6994a2783699815ee553bd5a9327d8b79991de36e38b66862782f54ae"
+        ],
+        "linux_armv6l": [
+          "go1.25.0.linux-armv6l.tar.gz",
+          "a5a8f8198fcf00e1e485b8ecef9ee020778bf32a408a4e8873371bfce458cd09"
+        ],
+        "linux_loong64": [
+          "go1.25.0.linux-loong64.tar.gz",
+          "cab86b1cf761b1cb3bac86a8877cfc92e7b036fc0d3084123d77013d61432afc"
+        ],
+        "linux_mips": [
+          "go1.25.0.linux-mips.tar.gz",
+          "d66b6fb74c3d91b9829dc95ec10ca1f047ef5e89332152f92e136cf0e2da5be1"
+        ],
+        "linux_mips64": [
+          "go1.25.0.linux-mips64.tar.gz",
+          "4082e4381a8661bc2a839ff94ba3daf4f6cde20f8fb771b5b3d4762dc84198a2"
+        ],
+        "linux_mips64le": [
+          "go1.25.0.linux-mips64le.tar.gz",
+          "70002c299ec7f7175ac2ef673b1b347eecfa54ae11f34416a6053c17f855afcc"
+        ],
+        "linux_mipsle": [
+          "go1.25.0.linux-mipsle.tar.gz",
+          "b00a3a39eff099f6df9f1c7355bf28e4589d0586f42d7d4a394efb763d145a73"
+        ],
+        "linux_ppc64": [
+          "go1.25.0.linux-ppc64.tar.gz",
+          "df166f33bd98160662560a72ff0b4ba731f969a80f088922bddcf566a88c1ec1"
+        ],
+        "linux_ppc64le": [
+          "go1.25.0.linux-ppc64le.tar.gz",
+          "0f18a89e7576cf2c5fa0b487a1635d9bcbf843df5f110e9982c64df52a983ad0"
+        ],
+        "linux_riscv64": [
+          "go1.25.0.linux-riscv64.tar.gz",
+          "c018ff74a2c48d55c8ca9b07c8e24163558ffec8bea08b326d6336905d956b67"
+        ],
+        "linux_s390x": [
+          "go1.25.0.linux-s390x.tar.gz",
+          "34e5a2e19f2292fbaf8783e3a241e6e49689276aef6510a8060ea5ef54eee408"
+        ],
+        "netbsd_386": [
+          "go1.25.0.netbsd-386.tar.gz",
+          "f8586cdb7aa855657609a5c5f6dbf523efa00c2bbd7c76d3936bec80aa6c0aba"
+        ],
+        "netbsd_amd64": [
+          "go1.25.0.netbsd-amd64.tar.gz",
+          "ae8dc1469385b86a157a423bb56304ba45730de8a897615874f57dd096db2c2a"
+        ],
+        "netbsd_arm": [
+          "go1.25.0.netbsd-arm.tar.gz",
+          "1ff7e4cc764425fc9dd6825eaee79d02b3c7cafffbb3691687c8d672ade76cb7"
+        ],
+        "netbsd_arm64": [
+          "go1.25.0.netbsd-arm64.tar.gz",
+          "e1b310739f26724216aa6d7d7208c4031f9ff54c9b5b9a796ddc8bebcb4a5f16"
+        ],
+        "openbsd_386": [
+          "go1.25.0.openbsd-386.tar.gz",
+          "4802a9b20e533da91adb84aab42e94aa56cfe3e5475d0550bed3385b182e69d8"
+        ],
+        "openbsd_amd64": [
+          "go1.25.0.openbsd-amd64.tar.gz",
+          "c016cd984bebe317b19a4f297c4f50def120dc9788490540c89f28e42f1dabe1"
+        ],
+        "openbsd_arm": [
+          "go1.25.0.openbsd-arm.tar.gz",
+          "a1e31d0bf22172ddde42edf5ec811ef81be43433df0948ece52fecb247ccfd8d"
+        ],
+        "openbsd_arm64": [
+          "go1.25.0.openbsd-arm64.tar.gz",
+          "343ea8edd8c218196e15a859c6072d0dd3246fbbb168481ab665eb4c4140458d"
+        ],
+        "openbsd_ppc64": [
+          "go1.25.0.openbsd-ppc64.tar.gz",
+          "694c14da1bcaeb5e3332d49bdc2b6d155067648f8fe1540c5de8f3cf8e157154"
+        ],
+        "openbsd_riscv64": [
+          "go1.25.0.openbsd-riscv64.tar.gz",
+          "aa510ad25cf54c06cd9c70b6d80ded69cb20188ac6e1735655eef29ff7e7885f"
+        ],
+        "plan9_386": [
+          "go1.25.0.plan9-386.tar.gz",
+          "46f8cef02086cf04bf186c5912776b56535178d4cb319cd19c9fdbdd29231986"
+        ],
+        "plan9_amd64": [
+          "go1.25.0.plan9-amd64.tar.gz",
+          "29b34391d84095e44608a228f63f2f88113a37b74a79781353ec043dfbcb427b"
+        ],
+        "plan9_arm": [
+          "go1.25.0.plan9-arm.tar.gz",
+          "0a047107d13ebe7943aaa6d54b1d7bbd2e45e68ce449b52915a818da715799c2"
+        ],
+        "solaris_amd64": [
+          "go1.25.0.solaris-amd64.tar.gz",
+          "9977f9e4351984364a3b2b78f8b88bfd1d339812356d5237678514594b7d3611"
+        ],
+        "windows_386": [
+          "go1.25.0.windows-386.zip",
+          "df9f39db82a803af0db639e3613a36681ab7a42866b1384b3f3a1045663961a7"
+        ],
+        "windows_amd64": [
+          "go1.25.0.windows-amd64.zip",
+          "89efb4f9b30812eee083cc1770fdd2913c14d301064f6454851428f9707d190b"
+        ],
+        "windows_arm64": [
+          "go1.25.0.windows-arm64.zip",
+          "27bab004c72b3d7bd05a69b6ec0fc54a309b4b78cc569dd963d8b3ec28bfdb8c"
+        ]
+      },
+      "1.25.6": {
+        "aix_ppc64": [
+          "go1.25.6.aix-ppc64.tar.gz",
+          "13c8bca505dd902091304da8abfacaf3512f40c3faefae70db33337d9a42c90e"
+        ],
+        "darwin_amd64": [
+          "go1.25.6.darwin-amd64.tar.gz",
+          "e2b5b237f5c262931b8e280ac4b8363f156e19bfad5270c099998932819670b7"
+        ],
+        "darwin_arm64": [
+          "go1.25.6.darwin-arm64.tar.gz",
+          "984521ae978a5377c7d782fd2dd953291840d7d3d0bd95781a1f32f16d94a006"
+        ],
+        "dragonfly_amd64": [
+          "go1.25.6.dragonfly-amd64.tar.gz",
+          "6fdcdd4f769fe73a9c5602eb25533954903520f2a2a1953415ec4f8abf5bda52"
+        ],
+        "freebsd_386": [
+          "go1.25.6.freebsd-386.tar.gz",
+          "be22b65ded1d4015d7d9d328284c985932771d120a371c7df41b2d4d1a91e943"
+        ],
+        "freebsd_amd64": [
+          "go1.25.6.freebsd-amd64.tar.gz",
+          "61e1d50e332359474ff6dcf4bc0bd34ba2d2cf4ef649593a5faa527f0ab84e2b"
+        ],
+        "freebsd_arm": [
+          "go1.25.6.freebsd-arm.tar.gz",
+          "546c2c6e325e72531bf6c8122a2360db8f8381e2dc1e8d147ecb0cb49b5f5f93"
+        ],
+        "freebsd_arm64": [
+          "go1.25.6.freebsd-arm64.tar.gz",
+          "648484146702dd58db0e2c3d15bda3560340d149ed574936e63285a823116b77"
+        ],
+        "freebsd_riscv64": [
+          "go1.25.6.freebsd-riscv64.tar.gz",
+          "663d7a9532bb4ac03c7a36b13b677b36d71031cd757b8acaee085e36c9ec8bc2"
+        ],
+        "illumos_amd64": [
+          "go1.25.6.illumos-amd64.tar.gz",
+          "c6adb151f8f50a25ef5a3f7b1be67155045daa766261e686ea210b93b46bbbd5"
+        ],
+        "linux_386": [
+          "go1.25.6.linux-386.tar.gz",
+          "59fe62eee3cca65332acef3ebe9b6ff3272467e0a08bf7f68f96334902bf23b9"
+        ],
+        "linux_amd64": [
+          "go1.25.6.linux-amd64.tar.gz",
+          "f022b6aad78e362bcba9b0b94d09ad58c5a70c6ba3b7582905fababf5fe0181a"
+        ],
+        "linux_arm64": [
+          "go1.25.6.linux-arm64.tar.gz",
+          "738ef87d79c34272424ccdf83302b7b0300b8b096ed443896089306117943dd5"
+        ],
+        "linux_armv6l": [
+          "go1.25.6.linux-armv6l.tar.gz",
+          "679f0e70b27c637116791e3c98afbf8c954deb2cd336364944d014f8e440e2ae"
+        ],
+        "linux_loong64": [
+          "go1.25.6.linux-loong64.tar.gz",
+          "433fe54d8797700b44fc4f1d085f9cd50ab3511b9b484fdfbb7b6c32a2be2486"
+        ],
+        "linux_mips": [
+          "go1.25.6.linux-mips.tar.gz",
+          "a5beaf2d135b8e9a2f3d91fa7e7d3761ffc97630484168bbc9a21f3901119c11"
+        ],
+        "linux_mips64": [
+          "go1.25.6.linux-mips64.tar.gz",
+          "f2d72c1ac315d453f429f48900f43cd8d0aa296a2b82fa90dba7dfb907483fd8"
+        ],
+        "linux_mips64le": [
+          "go1.25.6.linux-mips64le.tar.gz",
+          "9b808ef978fd6414edd16736daa4a601c7e2dadff3bd640ade8a976535c974d4"
+        ],
+        "linux_mipsle": [
+          "go1.25.6.linux-mipsle.tar.gz",
+          "4e0b190b05c8359455d96d379c751d403554dcadf6765932845b2886e555bfd6"
+        ],
+        "linux_ppc64": [
+          "go1.25.6.linux-ppc64.tar.gz",
+          "5d0f479023b1481c9188cc066eca1293e6f8a67a882a6d93afafccfb51981476"
+        ],
+        "linux_ppc64le": [
+          "go1.25.6.linux-ppc64le.tar.gz",
+          "bee02dbe034b12b839ae7807a85a61c13bee09ee38f2eeba2074bd26c0c0ab73"
+        ],
+        "linux_riscv64": [
+          "go1.25.6.linux-riscv64.tar.gz",
+          "82a6b989afda1681ecb1f4fa96f1006484f42643eb5e76bed58f7f97316bf84b"
+        ],
+        "linux_s390x": [
+          "go1.25.6.linux-s390x.tar.gz",
+          "3d97cc5670a0da9cb177037782129f0bf499ecb47abc40488248548abd2c2c35"
+        ],
+        "netbsd_386": [
+          "go1.25.6.netbsd-386.tar.gz",
+          "eb526fff2568fc9938d6eda6f0f50449661c693fcd89ab6f84e5e77e0a98d99b"
+        ],
+        "netbsd_amd64": [
+          "go1.25.6.netbsd-amd64.tar.gz",
+          "959d786e3384403ac9d957c04d71da905b02f457406ca123662cbd4688f9ce6e"
+        ],
+        "netbsd_arm": [
+          "go1.25.6.netbsd-arm.tar.gz",
+          "fe6c3957f7feaf17ac72ca27590cc4914c19162fc0912869048cb3dc92f5c3fd"
+        ],
+        "netbsd_arm64": [
+          "go1.25.6.netbsd-arm64.tar.gz",
+          "ddb5ec67fc4a0510b23560b7c01413bd9dde513cebfb5441a93e934f7e0c6853"
+        ],
+        "openbsd_386": [
+          "go1.25.6.openbsd-386.tar.gz",
+          "167a18ff7db53f1652f3a65c905056bc14e7ab4319357498d0af998a83f457a9"
+        ],
+        "openbsd_amd64": [
+          "go1.25.6.openbsd-amd64.tar.gz",
+          "06ec42383ff1e17abc0472e0a92eb028cb40b16ea09e2a86f80fbe60912d62de"
+        ],
+        "openbsd_arm": [
+          "go1.25.6.openbsd-arm.tar.gz",
+          "751df8eadd0f3d7be8ea6cda3af1e2e942099f6c97abcc0cfb5c8a0ac8e0cf3f"
+        ],
+        "openbsd_arm64": [
+          "go1.25.6.openbsd-arm64.tar.gz",
+          "d9828a6162c0c0fdb2d7e9dc8285c43b18a3dab62bf5e83b5891a4384f3157ad"
+        ],
+        "openbsd_ppc64": [
+          "go1.25.6.openbsd-ppc64.tar.gz",
+          "73090f93dc861f2be9dc06d8209f32cd7ce7864b9b3e28f0cd54a9e031672699"
+        ],
+        "openbsd_riscv64": [
+          "go1.25.6.openbsd-riscv64.tar.gz",
+          "6d4932cb639c1172cf5861b031bd0a24f7341ef579aac15b392779e10c69343b"
+        ],
+        "plan9_386": [
+          "go1.25.6.plan9-386.tar.gz",
+          "b9db67922a94abe580e7bde9172eee2c223ade914cd12790d955a24554c134d5"
+        ],
+        "plan9_amd64": [
+          "go1.25.6.plan9-amd64.tar.gz",
+          "aa1ff9aa3e1ed09ecb21d09d736997d2de9f373fea9402815b3221946d17dcd5"
+        ],
+        "plan9_arm": [
+          "go1.25.6.plan9-arm.tar.gz",
+          "94ec04501527876a542960096f0199495cbd9f9103b229d5299382aa51d9cc32"
+        ],
+        "solaris_amd64": [
+          "go1.25.6.solaris-amd64.tar.gz",
+          "9a1e89979be591b44e63be766c6571f5dc27b5fc3b79965c943186fcdaca0386"
+        ],
+        "windows_386": [
+          "go1.25.6.windows-386.zip",
+          "873da5cec02b6657ecd5b85e562a38fb5faf1b6e9ea81b2eb0b9a9b5aea5cb35"
+        ],
+        "windows_amd64": [
+          "go1.25.6.windows-amd64.zip",
+          "19b4733b727ba5c611b5656187f3ac367d278d64c3d4199a845e39c0fdac5335"
+        ],
+        "windows_arm64": [
+          "go1.25.6.windows-arm64.zip",
+          "8f2d8e6dd0849a2ec0ade1683bcfb7809e64d264a4273d8437841000a28ffb60"
+        ]
+      }
+    },
     "@@rules_rs+//rs:extensions.bzl%crate": {
       "addr2line_0.25.1": "{\"dependencies\":[{\"name\":\"alloc\",\"optional\":true,\"package\":\"rustc-std-workspace-alloc\",\"req\":\"^1.0.0\"},{\"kind\":\"dev\",\"name\":\"backtrace\",\"req\":\"^0.3.13\"},{\"features\":[\"wrap_help\"],\"name\":\"clap\",\"optional\":true,\"req\":\"^4.3.21\"},{\"name\":\"core\",\"optional\":true,\"package\":\"rustc-std-workspace-core\",\"req\":\"^1.0.0\"},{\"default_features\":false,\"features\":[\"alloc\"],\"name\":\"cpp_demangle\",\"optional\":true,\"req\":\"^0.4\"},{\"kind\":\"dev\",\"name\":\"criterion\",\"req\":\"^0.7.0\"},{\"default_features\":false,\"name\":\"fallible-iterator\",\"optional\":true,\"req\":\"^0.3.0\"},{\"kind\":\"dev\",\"name\":\"findshlibs\",\"req\":\"^0.10\"},{\"default_features\":false,\"features\":[\"read\"],\"name\":\"gimli\",\"req\":\"^0.32.0\"},{\"kind\":\"dev\",\"name\":\"libtest-mimic\",\"req\":\"^0.8.1\"},{\"name\":\"memmap2\",\"optional\":true,\"req\":\"^0.9.4\"},{\"default_features\":false,\"features\":[\"read\",\"compression\"],\"name\":\"object\",\"optional\":true,\"req\":\"^0.37.0\"},{\"name\":\"rustc-demangle\",\"optional\":true,\"req\":\"^0.1\"},{\"default_features\":false,\"name\":\"smallvec\",\"optional\":true,\"req\":\"^1\"},{\"name\":\"typed-arena\",\"optional\":true,\"req\":\"^2\"}],\"features\":{\"all\":[\"bin\",\"wasm\"],\"bin\":[\"loader\",\"rustc-demangle\",\"cpp_demangle\",\"fallible-iterator\",\"smallvec\",\"dep:clap\"],\"cargo-all\":[],\"default\":[\"rustc-demangle\",\"cpp_demangle\",\"loader\",\"fallible-iterator\",\"smallvec\"],\"loader\":[\"std\",\"dep:object\",\"dep:memmap2\",\"dep:typed-arena\"],\"rustc-dep-of-std\":[\"core\",\"alloc\",\"gimli/rustc-dep-of-std\"],\"std\":[\"gimli/std\"],\"wasm\":[\"object/wasm\"]}}",
       "adler2_2.0.1": "{\"dependencies\":[{\"name\":\"core\",\"optional\":true,\"package\":\"rustc-std-workspace-core\",\"req\":\"^1.0.0\"}],\"features\":{\"default\":[\"std\"],\"rustc-dep-of-std\":[\"core\"],\"std\":[]}}",
@@ -1040,7 +1369,7 @@
       "xml-rs_0.8.28": "{\"dependencies\":[],\"features\":{}}",
       "xz2_0.1.7": "{\"dependencies\":[{\"name\":\"futures\",\"optional\":true,\"req\":\"^0.1.26\"},{\"name\":\"lzma-sys\",\"req\":\"^0.1.18\"},{\"kind\":\"dev\",\"name\":\"quickcheck\",\"req\":\"^1.0.1\"},{\"kind\":\"dev\",\"name\":\"rand\",\"req\":\"^0.8.0\"},{\"kind\":\"dev\",\"name\":\"tokio-core\",\"req\":\"^0.1.17\"},{\"name\":\"tokio-io\",\"optional\":true,\"req\":\"^0.1.12\"}],\"features\":{\"static\":[\"lzma-sys/static\"],\"tokio\":[\"tokio-io\",\"futures\"]}}",
       "yansi_1.0.1": "{\"dependencies\":[{\"name\":\"is-terminal\",\"optional\":true,\"req\":\"^0.4.11\"}],\"features\":{\"_nightly\":[],\"alloc\":[],\"default\":[\"std\"],\"detect-env\":[\"std\"],\"detect-tty\":[\"is-terminal\",\"std\"],\"hyperlink\":[\"std\"],\"std\":[\"alloc\"]}}",
-      "yasna_0.5.2": "{\"dependencies\":[{\"default_features\":false,\"features\":[\"std\"],\"name\":\"bit-vec\",\"optional\":true,\"req\":\"^0.6.1\"},{\"name\":\"num-bigint\",\"optional\":true,\"req\":\"^0.4\"},{\"default_features\":false,\"features\":[\"std\"],\"name\":\"time\",\"optional\":true,\"req\":\"^0.3.1\"},{\"default_features\":false,\"kind\":\"dev\",\"name\":\"num-traits\",\"req\":\"^0.2\"}],\"features\":{\"default\":[],\"std\":[]}}",
+      "yasna_0.5.2": "{\"dependencies\":[{\"default_features\":false,\"features\":[\"std\"],\"name\":\"bit-vec\",\"optional\":true,\"req\":\"^0.6.1\"},{\"name\":\"num-bigint\",\"optional\":true,\"req\":\"^0.4\"},{\"default_features\":false,\"kind\":\"dev\",\"name\":\"num-traits\",\"req\":\"^0.2\"},{\"default_features\":false,\"features\":[\"std\"],\"name\":\"time\",\"optional\":true,\"req\":\"^0.3.1\"}],\"features\":{\"default\":[],\"std\":[]}}",
       "yoke-derive_0.8.1": "{\"dependencies\":[{\"name\":\"proc-macro2\",\"req\":\"^1.0.61\"},{\"name\":\"quote\",\"req\":\"^1.0.28\"},{\"features\":[\"fold\"],\"name\":\"syn\",\"req\":\"^2.0.21\"},{\"name\":\"synstructure\",\"req\":\"^0.13.0\"}],\"features\":{}}",
       "yoke_0.8.1": "{\"dependencies\":[{\"kind\":\"dev\",\"name\":\"bincode\",\"req\":\"^1.3.1\"},{\"default_features\":false,\"kind\":\"dev\",\"name\":\"postcard\",\"req\":\"^1.0.3\"},{\"default_features\":false,\"kind\":\"dev\",\"name\":\"serde\",\"req\":\"^1.0.220\"},{\"default_features\":false,\"name\":\"stable_deref_trait\",\"req\":\"^1.2.0\"},{\"default_features\":false,\"name\":\"yoke-derive\",\"optional\":true,\"req\":\"^0.8.0\"},{\"default_features\":false,\"name\":\"zerofrom\",\"optional\":true,\"req\":\"^0.1.3\"}],\"features\":{\"alloc\":[\"stable_deref_trait/alloc\",\"zerofrom/alloc\"],\"default\":[\"alloc\",\"zerofrom\"],\"derive\":[\"dep:yoke-derive\",\"zerofrom/derive\"],\"serde\":[],\"zerofrom\":[\"dep:zerofrom\"]}}",
       "zerocopy-derive_0.8.31": "{\"dependencies\":[{\"kind\":\"dev\",\"name\":\"dissimilar\",\"req\":\"^1.0.9\"},{\"kind\":\"dev\",\"name\":\"libc\",\"req\":\"=0.2.163\"},{\"kind\":\"dev\",\"name\":\"once_cell\",\"req\":\"=1.9\"},{\"kind\":\"dev\",\"name\":\"prettyplease\",\"req\":\"=0.2.17\"},{\"name\":\"proc-macro2\",\"req\":\"^1.0.1\"},{\"kind\":\"dev\",\"name\":\"proc-macro2\",\"req\":\"=1.0.80\"},{\"name\":\"quote\",\"req\":\"^1.0.40\"},{\"kind\":\"dev\",\"name\":\"quote\",\"req\":\"=1.0.40\"},{\"kind\":\"dev\",\"name\":\"rustversion\",\"req\":\"^1.0\"},{\"kind\":\"dev\",\"name\":\"static_assertions\",\"req\":\"^1.1\"},{\"features\":[\"full\"],\"name\":\"syn\",\"req\":\"^2.0.46\"},{\"features\":[\"diff\"],\"kind\":\"dev\",\"name\":\"trybuild\",\"req\":\"=1.0.89\"}],\"features\":{}}",

--- a/README.md
+++ b/README.md
@@ -205,8 +205,16 @@ bash tools/build-release-binaries.sh artifacts
 
 # Tests
 bazel test //integration-tests:integration_test   # finalize + run on the host platform
+bazel test //e2e:all                               # launcher_binary chain vs. BOTH stub sources
 (cd e2e/bzlmod && bazel test //...)                # launcher_binary wrapping cc/go/py/sh
 ```
+
+`//e2e:all` runs the same launcher chain twice — `e2e_chain_prebuilt` against the
+prebuilt stubs downloaded from the release, and `e2e_chain_source_built` against the
+stubs freshly built from this checkout (a per-target transition flips
+`//launcher/private:stub_source`; add `--config=release` to build them exactly as they
+ship). `e2e/bzlmod` is the downstream/BCR test module: it consumes the published
+launcher as an external Bazel module, so it only exercises the prebuilt stubs.
 
 `flake.nix` provides a dev shell (Rust, Wine for Windows testing, gdb).
 

--- a/e2e/BUILD.bazel
+++ b/e2e/BUILD.bazel
@@ -1,0 +1,66 @@
+load("@rules_cc//cc:cc_binary.bzl", "cc_binary")
+load("@rules_go//go:def.bzl", "go_binary")
+load("@rules_python//python:py_binary.bzl", "py_binary")
+load("@rules_shell//shell:sh_binary.bzl", "sh_binary")
+load("//e2e:defs.bzl", "launcher_e2e_test")
+load("//launcher:launcher_binary.bzl", "launcher_binary")
+
+# The same cc/go/py/sh launcher chain as the downstream BCR test module in
+# e2e/bzlmod, but run against BOTH stub sources (see :defs.bzl). e2e/bzlmod stays a
+# standalone module that consumes the published (prebuilt) launcher exactly as an
+# external user would; this package additionally builds the stubs from source, which
+# needs the root module's Rust dev toolchains. The sources are intentionally kept in
+# sync with e2e/bzlmod's copies.
+
+cc_binary(
+    name = "hello_cc",
+    srcs = ["hello_cc.cc"],
+)
+
+go_binary(
+    name = "hello_go",
+    srcs = ["hello_go.go"],
+    importpath = "example.com/hello_go",
+    # Build without cgo. hello_go is pure Go, but rules_go otherwise compiles the
+    # cgo-enabled Go stdlib, and this (root) workspace's C toolchain is LLVM/clang
+    # (BAZEL_DO_NOT_DETECT_CPP_TOOLCHAIN=1, no MSVC autodetect). On Windows that
+    # fails building runtime/cgo: clang rejects Go's `-mthreads` under
+    # -Werror,-Wunused-command-line-argument. (e2e/bzlmod avoids this via MSVC.)
+    pure = "on",
+)
+
+py_binary(
+    name = "hello_py",
+    srcs = ["hello_py.py"],
+)
+
+sh_binary(
+    name = "hello_sh",
+    srcs = ["hello_sh.sh"],
+)
+
+# Chain: Go -> Python -> C++ -> Shell
+# Single launcher_binary with Go as entrypoint, passing rlocationpaths
+# for the rest of the chain as embedded args.
+launcher_binary(
+    name = "launch_chain",
+    data = [
+        ":hello_cc",
+        ":hello_py",
+        ":hello_sh",
+    ],
+    embedded_args = [
+        "$(rlocationpath :hello_py)",
+        "$(rlocationpath :hello_cc)",
+        "$(rlocationpath :hello_sh)",
+    ],
+    entrypoint = ":hello_go",
+)
+
+# Emits e2e_chain_prebuilt + e2e_chain_source_built (grouped by the e2e_chain
+# test_suite), so `bazel test //e2e:all` runs the chain against the downloaded
+# stubs and the freshly source-built stubs.
+launcher_e2e_test(
+    name = "e2e_chain",
+    launcher = ":launch_chain",
+)

--- a/e2e/defs.bzl
+++ b/e2e/defs.bzl
@@ -1,0 +1,75 @@
+"""Test helpers for running a launcher_binary against both stub sources.
+
+`launcher_e2e_test` runs a launcher (built with the `launcher_binary` rule) as a
+test twice: once against the prebuilt stubs downloaded from the GitHub release, and
+once against the stubs built from source in this repo. A per-target transition pins
+`//launcher/private:stub_source` for each variant, so a single `bazel test //e2e:all`
+exercises both without needing two separate `bazel` invocations or config flags.
+"""
+
+_STUB_SOURCE = "//launcher/private:stub_source"
+
+def _stub_source_transition_impl(_settings, attr):
+    return {_STUB_SOURCE: attr.stub_source}
+
+_stub_source_transition = transition(
+    implementation = _stub_source_transition_impl,
+    inputs = [],
+    outputs = [_STUB_SOURCE],
+)
+
+def _flavored_launcher_test_impl(ctx):
+    # An attribute with a transition is accessed as a list.
+    launcher = ctx.attr.launcher
+    if type(launcher) == "list":
+        launcher = launcher[0]
+    src = launcher[DefaultInfo].files_to_run.executable
+    out = ctx.actions.declare_file(ctx.label.name + (".exe" if src.extension == "exe" else ""))
+    ctx.actions.symlink(output = out, target_file = src, is_executable = True)
+    runfiles = ctx.runfiles(files = [src]).merge(launcher[DefaultInfo].default_runfiles)
+    return [DefaultInfo(executable = out, runfiles = runfiles)]
+
+_flavored_launcher_test = rule(
+    doc = "Runs `launcher` as a test with //launcher/private:stub_source pinned to `stub_source`.",
+    implementation = _flavored_launcher_test_impl,
+    attrs = {
+        "launcher": attr.label(
+            doc = "The launcher_binary to run.",
+            mandatory = True,
+            cfg = _stub_source_transition,
+        ),
+        "stub_source": attr.string(
+            doc = "Which stub source to build the launcher against.",
+            mandatory = True,
+            values = ["prebuilt", "source_built"],
+        ),
+        "_allowlist_function_transition": attr.label(
+            default = "@bazel_tools//tools/allowlists/function_transition_allowlist",
+        ),
+    },
+    test = True,
+)
+
+def launcher_e2e_test(name, launcher, **kwargs):
+    """Runs `launcher` as a test against both the prebuilt and source-built stubs.
+
+    Emits `<name>_prebuilt` and `<name>_source_built` test targets plus a
+    `<name>` test_suite grouping them, so `bazel test //e2e:all` (or
+    `bazel test //e2e:<name>`) always runs both.
+
+    Args:
+        name: Base name; also the name of the grouping test_suite.
+        launcher: A `launcher_binary` target to run as the test.
+        **kwargs: Common attributes (tags, visibility, ...) applied to both tests.
+    """
+    tests = []
+    for stub_source in ["prebuilt", "source_built"]:
+        test_name = "{}_{}".format(name, stub_source)
+        tests.append(test_name)
+        _flavored_launcher_test(
+            name = test_name,
+            launcher = launcher,
+            stub_source = stub_source,
+            **kwargs
+        )
+    native.test_suite(name = name, tests = tests)

--- a/e2e/hello_cc.cc
+++ b/e2e/hello_cc.cc
@@ -1,0 +1,6 @@
+#include <iostream>
+
+int main() {
+    std::cout << "Hello from C++!" << std::endl;
+    return 0;
+}

--- a/e2e/hello_go.go
+++ b/e2e/hello_go.go
@@ -1,0 +1,40 @@
+package main
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"strings"
+)
+
+func main() {
+	fmt.Println("Hello from Go!")
+	if len(os.Args) < 4 {
+		fmt.Fprintf(os.Stderr, "usage: %s <py_binary> <cc_binary> <sh_binary>\n", os.Args[0])
+		os.Exit(1)
+	}
+
+	expected := []struct {
+		path   string
+		needle string
+	}{
+		{os.Args[1], "Hello from Python!"},
+		{os.Args[2], "Hello from C++!"},
+		{os.Args[3], "Hello from Shell!"},
+	}
+
+	for _, e := range expected {
+		out, err := exec.Command(e.path).Output()
+		if err != nil {
+			fmt.Fprintf(os.Stderr, "failed to run %s: %v\n", e.path, err)
+			os.Exit(1)
+		}
+		if !strings.Contains(string(out), e.needle) {
+			fmt.Fprintf(os.Stderr, "expected %q in output of %s, got: %s\n", e.needle, e.path, out)
+			os.Exit(1)
+		}
+		fmt.Print(string(out))
+	}
+
+	fmt.Println("PASS: all four languages produced output")
+}

--- a/e2e/hello_py.py
+++ b/e2e/hello_py.py
@@ -1,0 +1,9 @@
+import sys
+
+
+def main():
+    print("Hello from Python!")
+
+
+if __name__ == "__main__":
+    main()

--- a/e2e/hello_sh.sh
+++ b/e2e/hello_sh.sh
@@ -1,0 +1,2 @@
+#!/usr/bin/env bash
+echo "Hello from Shell!"

--- a/launcher/private/BUILD.bazel
+++ b/launcher/private/BUILD.bazel
@@ -1,4 +1,40 @@
 load("@bazel_skylib//:bzl_library.bzl", "bzl_library")
+load("@bazel_skylib//rules:common_settings.bzl", "string_flag")
+
+# Selects which set of launcher stub binaries the launcher toolchains provide:
+#
+#   "prebuilt"     - the templates/finalizers downloaded from the GitHub release
+#                    (see //launcher/private:extensions.bzl). This is the default
+#                    and the only source visible to downstream modules.
+#   "source_built" - the templates/finalizers built from source in this repo
+#                    (//runfiles-stub, //finalize-stub). Only registered when
+#                    hermetic_launcher is the root module (see MODULE.bazel), so
+#                    downstream consumers never need the Rust build tooling.
+#
+# The prebuilt and source_built toolchains carry matching `target_settings`, so
+# exactly one set matches for a given value of this flag. The in-repo e2e tests
+# flip it per-target with a transition to run against both (see //e2e).
+string_flag(
+    name = "stub_source",
+    build_setting_default = "prebuilt",
+    values = [
+        "prebuilt",
+        "source_built",
+    ],
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "stub_source_prebuilt",
+    flag_values = {":stub_source": "prebuilt"},
+    visibility = ["//visibility:public"],
+)
+
+config_setting(
+    name = "stub_source_source_built",
+    flag_values = {":stub_source": "source_built"},
+    visibility = ["//visibility:public"],
+)
 
 bzl_library(
     name = "extensions_bzl",
@@ -19,4 +55,14 @@ bzl_library(
     srcs = ["stub_template_toolchain.bzl"],
     visibility = ["//visibility:public"],
     deps = ["//launcher/private/providers:stub_template_toolchain_info_bzl"],
+)
+
+bzl_library(
+    name = "toolchains_bzl",
+    srcs = ["toolchains.bzl"],
+    visibility = ["//visibility:public"],
+    deps = [
+        ":stub_finalizer_toolchain_bzl",
+        ":stub_template_toolchain_bzl",
+    ],
 )

--- a/launcher/private/prebuilt/BUILD.bazel
+++ b/launcher/private/prebuilt/BUILD.bazel
@@ -1,204 +1,25 @@
-load("//launcher/private:stub_template_toolchain.bzl", "stub_template_toolchain")
-load("//launcher/private:stub_finalizer_toolchain.bzl", "stub_finalizer_toolchain")
+load("//launcher/private:toolchains.bzl", "launcher_stub_toolchains")
 
 package(default_visibility = ["//visibility:public"])
 
-stub_template_toolchain(
-    name = "template_aarch64_linux",
-    template_exe = "@runfiles_stub_aarch64_linux//file",
-)
-
-toolchain(
-    name = "template_aarch64_linux_toolchain",
-    target_compatible_with = [
-        "@platforms//cpu:aarch64",
-        "@platforms//os:linux",
-    ],
-    toolchain = ":template_aarch64_linux",
-    toolchain_type = "//launcher:template_toolchain_type",
-)
-
-toolchain(
-    name = "template_aarch64_linux_exec_toolchain",
-    exec_compatible_with = [
-        "@platforms//cpu:aarch64",
-        "@platforms//os:linux",
-    ],
-    toolchain = ":template_aarch64_linux",
-    toolchain_type = "//launcher:template_exec_toolchain_type",
-)
-
-stub_template_toolchain(
-    name = "template_aarch64_macos",
-    template_exe = "@runfiles_stub_aarch64_macos//file",
-)
-
-toolchain(
-    name = "template_aarch64_macos_toolchain",
-    target_compatible_with = [
-        "@platforms//cpu:aarch64",
-        "@platforms//os:macos",
-    ],
-    toolchain = ":template_aarch64_macos",
-    toolchain_type = "//launcher:template_toolchain_type",
-)
-
-toolchain(
-    name = "template_aarch64_macos_exec_toolchain",
-    exec_compatible_with = [
-        "@platforms//cpu:aarch64",
-        "@platforms//os:macos",
-    ],
-    toolchain = ":template_aarch64_macos",
-    toolchain_type = "//launcher:template_exec_toolchain_type",
-)
-
-stub_template_toolchain(
-    name = "template_x86_64_linux",
-    template_exe = "@runfiles_stub_x86_64_linux//file",
-)
-
-toolchain(
-    name = "template_x86_64_linux_toolchain",
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
-    ],
-    toolchain = ":template_x86_64_linux",
-    toolchain_type = "//launcher:template_toolchain_type",
-)
-
-toolchain(
-    name = "template_x86_64_linux_exec_toolchain",
-    exec_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
-    ],
-    toolchain = ":template_x86_64_linux",
-    toolchain_type = "//launcher:template_exec_toolchain_type",
-)
-
-stub_template_toolchain(
-    name = "template_x86_64_macos",
-    template_exe = "@runfiles_stub_x86_64_macos//file",
-)
-
-toolchain(
-    name = "template_x86_64_macos_toolchain",
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:macos",
-    ],
-    toolchain = ":template_x86_64_macos",
-    toolchain_type = "//launcher:template_toolchain_type",
-)
-
-toolchain(
-    name = "template_x86_64_macos_exec_toolchain",
-    exec_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:macos",
-    ],
-    toolchain = ":template_x86_64_macos",
-    toolchain_type = "//launcher:template_exec_toolchain_type",
-)
-
-stub_template_toolchain(
-    name = "template_x86_64_windows",
-    template_exe = "@runfiles_stub_x86_64_windows//file",
-)
-
-toolchain(
-    name = "template_x86_64_windows_toolchain",
-    target_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:windows",
-    ],
-    toolchain = ":template_x86_64_windows",
-    toolchain_type = "//launcher:template_toolchain_type",
-)
-
-toolchain(
-    name = "template_x86_64_windows_exec_toolchain",
-    exec_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:windows",
-    ],
-    toolchain = ":template_x86_64_windows",
-    toolchain_type = "//launcher:template_exec_toolchain_type",
-)
-
-stub_finalizer_toolchain(
-    name = "finalizer_aarch64_linux",
-    finalizer = "@finalize_stub_aarch64_linux//file",
-)
-
-toolchain(
-    name = "finalizer_aarch64_linux_toolchain",
-    exec_compatible_with = [
-        "@platforms//cpu:aarch64",
-        "@platforms//os:linux",
-    ],
-    toolchain = ":finalizer_aarch64_linux",
-    toolchain_type = "//launcher:finalizer_toolchain_type",
-)
-
-stub_finalizer_toolchain(
-    name = "finalizer_aarch64_macos",
-    finalizer = "@finalize_stub_aarch64_macos//file",
-)
-
-toolchain(
-    name = "finalizer_aarch64_macos_toolchain",
-    exec_compatible_with = [
-        "@platforms//cpu:aarch64",
-        "@platforms//os:macos",
-    ],
-    toolchain = ":finalizer_aarch64_macos",
-    toolchain_type = "//launcher:finalizer_toolchain_type",
-)
-
-stub_finalizer_toolchain(
-    name = "finalizer_x86_64_linux",
-    finalizer = "@finalize_stub_x86_64_linux//file",
-)
-
-toolchain(
-    name = "finalizer_x86_64_linux_toolchain",
-    exec_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:linux",
-    ],
-    toolchain = ":finalizer_x86_64_linux",
-    toolchain_type = "//launcher:finalizer_toolchain_type",
-)
-
-stub_finalizer_toolchain(
-    name = "finalizer_x86_64_macos",
-    finalizer = "@finalize_stub_x86_64_macos//file",
-)
-
-toolchain(
-    name = "finalizer_x86_64_macos_toolchain",
-    exec_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:macos",
-    ],
-    toolchain = ":finalizer_x86_64_macos",
-    toolchain_type = "//launcher:finalizer_toolchain_type",
-)
-
-stub_finalizer_toolchain(
-    name = "finalizer_x86_64_windows",
-    finalizer = "@finalize_stub_x86_64_windows//file",
-)
-
-toolchain(
-    name = "finalizer_x86_64_windows_toolchain",
-    exec_compatible_with = [
-        "@platforms//cpu:x86_64",
-        "@platforms//os:windows",
-    ],
-    toolchain = ":finalizer_x86_64_windows",
-    toolchain_type = "//launcher:finalizer_toolchain_type",
+# Toolchains backed by the prebuilt templates/finalizers downloaded from the
+# GitHub release (see //launcher/private:extensions.bzl). These are registered for
+# every module (root and downstream) via //launcher/private/prebuilt:all, and are
+# the default: they resolve when //launcher/private:stub_source is "prebuilt".
+launcher_stub_toolchains(
+    name = "prebuilt",
+    finalizers = {
+        "aarch64_linux": "@finalize_stub_aarch64_linux//file",
+        "aarch64_macos": "@finalize_stub_aarch64_macos//file",
+        "x86_64_linux": "@finalize_stub_x86_64_linux//file",
+        "x86_64_macos": "@finalize_stub_x86_64_macos//file",
+        "x86_64_windows": "@finalize_stub_x86_64_windows//file",
+    },
+    templates = {
+        "aarch64_linux": "@runfiles_stub_aarch64_linux//file",
+        "aarch64_macos": "@runfiles_stub_aarch64_macos//file",
+        "x86_64_linux": "@runfiles_stub_x86_64_linux//file",
+        "x86_64_macos": "@runfiles_stub_x86_64_macos//file",
+        "x86_64_windows": "@runfiles_stub_x86_64_windows//file",
+    },
 )

--- a/launcher/private/source_built/BUILD.bazel
+++ b/launcher/private/source_built/BUILD.bazel
@@ -1,0 +1,32 @@
+load("//launcher/private:toolchains.bzl", "launcher_stub_toolchains")
+
+package(default_visibility = ["//visibility:public"])
+
+# Toolchains backed by the templates/finalizers built from source in this repo
+# (//runfiles-stub, //finalize-stub), platform-transitioned to each target triple
+# and run through the release optimization pipeline — the same artifacts that ship
+# in a release (see //integration-tests:release-template).
+#
+# These are registered ONLY when hermetic_launcher is the root module (see
+# MODULE.bazel: `dev_dependency = True`), because building them needs the Rust
+# toolchains/crates that are dev dependencies. They resolve when
+# //launcher/private:stub_source is "source_built"; the in-repo e2e tests flip that
+# flag per-target with a transition so one `bazel test //e2e:all` covers both the
+# downloaded and the freshly-built launcher (see //e2e).
+launcher_stub_toolchains(
+    name = "source_built",
+    finalizers = {
+        "aarch64_linux": "//finalize-stub:finalize-stub_aarch64-unknown-linux-musl",
+        "aarch64_macos": "//finalize-stub:finalize-stub_aarch64-apple-darwin",
+        "x86_64_linux": "//finalize-stub:finalize-stub_x86_64-unknown-linux-musl",
+        "x86_64_macos": "//finalize-stub:finalize-stub_x86_64-apple-darwin",
+        "x86_64_windows": "//finalize-stub:finalize-stub_x86_64-pc-windows-gnullvm",
+    },
+    templates = {
+        "aarch64_linux": "//runfiles-stub:runfiles-stub_aarch64-unknown-linux-musl",
+        "aarch64_macos": "//runfiles-stub:runfiles-stub_aarch64-apple-darwin",
+        "x86_64_linux": "//runfiles-stub:runfiles-stub_x86_64-unknown-linux-musl",
+        "x86_64_macos": "//runfiles-stub:runfiles-stub_x86_64-apple-darwin",
+        "x86_64_windows": "//runfiles-stub:runfiles-stub_x86_64-pc-windows-gnullvm",
+    },
+)

--- a/launcher/private/toolchains.bzl
+++ b/launcher/private/toolchains.bzl
@@ -1,0 +1,96 @@
+"""Registers the launcher template + finalizer toolchains for one stub source.
+
+Both the prebuilt (downloaded) and the source-built stub toolchains are declared
+through this macro so the two sets stay in lockstep: same platforms, same
+constraints, differing only in where the template/finalizer binaries come from and
+in the `//launcher/private:stub_source` value that selects them.
+"""
+
+load(":stub_finalizer_toolchain.bzl", "stub_finalizer_toolchain")
+load(":stub_template_toolchain.bzl", "stub_template_toolchain")
+
+def _executable_file_impl(ctx):
+    # Re-expose only the executable as the single default output. The prebuilt
+    # finalizer is a downloaded file (single output already), but the source-built
+    # finalizer is a platform_data target whose default outputs include more than
+    # one file, which the toolchain's `allow_single_file` finalizer attr rejects.
+    return [DefaultInfo(files = depset([ctx.attr.src[DefaultInfo].files_to_run.executable]))]
+
+_executable_file = rule(
+    doc = "Exposes a target's executable as a single-file output.",
+    implementation = _executable_file_impl,
+    attrs = {"src": attr.label(mandatory = True)},
+)
+
+# The platforms toolchains are registered for. This is intentionally a subset of
+# the released triples: s390x and Windows/aarch64 ship for standalone use but have
+# no auto-registered Bazel toolchain (see README "Supported platforms").
+#
+# (name, cpu, os)
+PLATFORMS = [
+    ("aarch64_linux", "aarch64", "linux"),
+    ("aarch64_macos", "aarch64", "macos"),
+    ("x86_64_linux", "x86_64", "linux"),
+    ("x86_64_macos", "x86_64", "macos"),
+    ("x86_64_windows", "x86_64", "windows"),
+]
+
+def launcher_stub_toolchains(name, *, templates, finalizers):
+    """Declares and exposes the template + finalizer toolchains for one stub source.
+
+    Args:
+        name: The stub source, "prebuilt" or "source_built". Used both as the
+            target-name namespace and to select the matching
+            `//launcher/private:stub_source_<name>` config_setting via
+            `target_settings`, so exactly one source's toolchains resolve for a
+            given value of the `//launcher/private:stub_source` flag.
+        templates: dict mapping each platform name in `PLATFORMS` to the template
+            (runfiles-stub) label for that platform.
+        finalizers: dict mapping each platform name in `PLATFORMS` to the finalizer
+            (finalize-stub) label for that platform.
+    """
+    if name not in ("prebuilt", "source_built"):
+        fail("launcher_stub_toolchains name must be \"prebuilt\" or \"source_built\", got %r" % name)
+
+    target_settings = ["//launcher/private:stub_source_" + name]
+
+    for (platform, cpu, os) in PLATFORMS:
+        constraints = [
+            "@platforms//cpu:" + cpu,
+            "@platforms//os:" + os,
+        ]
+
+        stub_template_toolchain(
+            name = "template_%s_%s" % (platform, name),
+            template_exe = templates[platform],
+        )
+        native.toolchain(
+            name = "template_%s_%s_toolchain" % (platform, name),
+            target_compatible_with = constraints,
+            target_settings = target_settings,
+            toolchain = ":template_%s_%s" % (platform, name),
+            toolchain_type = "//launcher:template_toolchain_type",
+        )
+        native.toolchain(
+            name = "template_%s_%s_exec_toolchain" % (platform, name),
+            exec_compatible_with = constraints,
+            target_settings = target_settings,
+            toolchain = ":template_%s_%s" % (platform, name),
+            toolchain_type = "//launcher:template_exec_toolchain_type",
+        )
+
+        _executable_file(
+            name = "finalizer_file_%s_%s" % (platform, name),
+            src = finalizers[platform],
+        )
+        stub_finalizer_toolchain(
+            name = "finalizer_%s_%s" % (platform, name),
+            finalizer = ":finalizer_file_%s_%s" % (platform, name),
+        )
+        native.toolchain(
+            name = "finalizer_%s_%s_toolchain" % (platform, name),
+            exec_compatible_with = constraints,
+            target_settings = target_settings,
+            toolchain = ":finalizer_%s_%s" % (platform, name),
+            toolchain_type = "//launcher:finalizer_toolchain_type",
+        )


### PR DESCRIPTION
…tubs

The e2e launcher_binary chain previously ran only against the launcher stubs downloaded from the GitHub release. Add a source-built flavor so a single `bazel test //e2e:all` exercises the chain against both the downloaded stubs and the stubs built from source in this repo, and always runs both.

- //launcher/private:stub_source string_flag + config_settings select which toolchains resolve. The prebuilt (default) and source_built toolchains are declared by a shared launcher_stub_toolchains() macro and gated with matching target_settings, so exactly one set resolves.
- source_built toolchains point at //runfiles-stub + //finalize-stub and are registered dev-only, so downstream modules keep getting the prebuilt toolchains and never need the Rust build tooling. e2e/bzlmod (the BCR test module) is unchanged and stays prebuilt-only.
- e2e/defs.bzl's launcher_e2e_test() emits <name>_prebuilt and <name>_source_built tests via a per-target transition that flips the flag, so both flavors run in one `bazel test`.
- CI runs `bazel test --config=release //e2e:all` on Linux/macOS/Windows.