### PR TITLE
fix: recover the runfiles tree an environment manifest names

### DIFF
--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -1405,6 +1405,61 @@ fn test_sparse_inferred_tree_keeps_physical_argv0(config: &TestConfig) -> Result
     Ok(())
 }
 
+/// Regression test: a relative `RUNFILES_MANIFEST_FILE` names a relative tree, and
+/// a relative argv[0] only holds while the child keeps the launcher's working
+/// directory. The manifest's own targets are absolute, so the physical path is
+/// strictly the safer identity here.
+fn test_relative_env_manifest_keeps_physical_argv0(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: relative_env_manifest_keeps_physical_argv0");
+
+    let test_dir = config.work_dir.join("test_relative_env_manifest");
+    fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {}", e))?;
+
+    // The tree is fully materialized: only the relative manifest path is at issue.
+    let (runfiles, entry_key) = wrapper_runfiles(config, &test_dir, true)?;
+
+    let stub_path = test_dir.join(format!("relative_manifest_stub{}", EXE_EXT));
+    finalize_stub(config, &stub_path, &[&entry_key], &[0])?;
+
+    // `RUNFILES_MANIFEST_FILE` resolved against the launcher's cwd, as the README's
+    // invocation example writes it.
+    fs::copy(&runfiles.manifest_path, test_dir.join("parent.runfiles_manifest"))
+        .map_err(|e| format!("Failed to place sibling manifest: {}", e))?;
+    let output = Command::new(&stub_path)
+        .current_dir(&test_dir)
+        .env("RUNFILES_MANIFEST_FILE", "parent.runfiles_manifest")
+        .env_remove("RUNFILES_DIR")
+        .output()
+        .map_err(|e| format!("Failed to run stub: {}", e))?;
+    if !output.status.success() {
+        return Err(format!(
+            "Stub failed: {}",
+            String::from_utf8_lossy(&output.stderr)
+        ));
+    }
+
+    #[cfg(unix)]
+    {
+        let stdout = String::from_utf8_lossy(&output.stdout);
+        let physical = runfiles
+            .runfiles_dir
+            .join(format!("tool_repo/bin/print-env{}", EXE_EXT).replace('/', &PATH_SEP.to_string()));
+        if reported_argv0(&stdout) != Some(physical.to_string_lossy().as_ref()) {
+            return Err(format!(
+                "argv[0] was overridden from a relative manifest path, so it only \
+                 resolves from the launcher's working directory.\n\
+                 expected the physical path: {}\nstdout: {}",
+                physical.display(),
+                stdout
+            ));
+        }
+    }
+
+    println!("    PASS (relative env manifest left argv[0] physical)");
+
+    Ok(())
+}
+
 /// Test: print-env to verify environment and argument passing
 fn test_print_env(config: &TestConfig) -> Result<(), String> {
     println!("  Running test: print_env");
@@ -1635,6 +1690,10 @@ fn main() -> ExitCode {
         (
             "sparse_inferred_tree_keeps_physical_argv0",
             test_sparse_inferred_tree_keeps_physical_argv0,
+        ),
+        (
+            "relative_env_manifest_keeps_physical_argv0",
+            test_relative_env_manifest_keeps_physical_argv0,
         ),
         ("print_env", test_print_env),
         ("large_manifest", test_large_manifest),

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -1248,6 +1248,90 @@ fn test_relative_manifest_symlinks(config: &TestConfig) -> Result<(), String> {
     Ok(())
 }
 
+/// Regression test: an environment manifest whose tree is still on disk must keep
+/// argv[0] logical, or a venv interpreter shim strands CPython outside its venv.
+/// See https://github.com/aspect-build/rules_py/issues/1378.
+fn test_env_manifest_logical_argv0(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: env_manifest_logical_argv0");
+
+    let test_dir = config.work_dir.join("test_env_manifest_argv0");
+    fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {}", e))?;
+
+    // The tree is the parent's; the stub has none of its own, so the environment is
+    // the only source the launcher can select.
+    let mut runfiles = RunfilesSetup::new(&test_dir, "parent")
+        .map_err(|e| format!("Failed to create runfiles: {}", e))?;
+    let interp_rlocation = format!("interpreter_repo/bin/print-env{}", EXE_EXT);
+    runfiles
+        .add_file(
+            &interp_rlocation,
+            &config.test_binaries_dir.join(format!("print-env{}", EXE_EXT)),
+        )
+        .map_err(|e| format!("Failed to add interpreter: {}", e))?;
+    runfiles
+        .write_manifest()
+        .map_err(|e| format!("Failed to write manifest: {}", e))?;
+
+    // A venv interpreter shim: relative for manifest portability, and landing
+    // outside the venv so the physical and logical paths differ.
+    let entry_key = format!("{}/venv/bin/python", WORKSPACE_NAME);
+    runfiles
+        .append_manifest_lines(&[(&entry_key, &format!("../../../{}", interp_rlocation))])
+        .map_err(|e| format!("Failed to append relative entry: {}", e))?;
+
+    let stub_path = test_dir.join(format!("child_stub{}", EXE_EXT));
+    finalize_stub(config, &stub_path, &[&entry_key], &[0])?;
+
+    let written_manifest = runfiles.manifest_path.clone();
+    let expected_argv0 = runfiles
+        .runfiles_dir
+        .join(entry_key.replace('/', &PATH_SEP.to_string()));
+
+    // Both layouts Bazel writes a manifest in name the same tree.
+    for (layout, manifest_path) in [
+        (
+            "<binary>.runfiles_manifest",
+            runfiles.runfiles_dir.with_extension("runfiles_manifest"),
+        ),
+        ("<tree>/MANIFEST", runfiles.runfiles_dir.join("MANIFEST")),
+    ] {
+        fs::copy(&written_manifest, &manifest_path)
+            .map_err(|e| format!("Failed to place {} manifest: {}", layout, e))?;
+        runfiles.manifest_path = manifest_path;
+
+        let (stdout, stderr, exit_code) = run_stub(&stub_path, &runfiles, &[], true)?;
+        if exit_code != 0 {
+            return Err(format!(
+                "Stub failed with exit code {} for {}.\nstdout: {}\nstderr: {}",
+                exit_code, layout, stdout, stderr
+            ));
+        }
+
+        // Windows derives argv[0] from the command line; the override is Unix-only.
+        #[cfg(unix)]
+        {
+            let actual = stdout
+                .lines()
+                .next()
+                .and_then(|line| line.strip_prefix("ARGS:"))
+                .and_then(|args| args.split('|').next());
+            if actual != Some(expected_argv0.to_string_lossy().as_ref()) {
+                return Err(format!(
+                    "Environment manifest ({}) did not preserve logical argv[0]; the \
+                     child was launched as the physical interpreter.\nexpected: {}\nstdout: {}",
+                    layout,
+                    expected_argv0.display(),
+                    stdout
+                ));
+            }
+        }
+    }
+
+    println!("    PASS (logical argv[0] preserved for both manifest layouts)");
+
+    Ok(())
+}
+
 /// Test: print-env to verify environment and argument passing
 fn test_print_env(config: &TestConfig) -> Result<(), String> {
     println!("  Running test: print_env");
@@ -1479,6 +1563,7 @@ fn main() -> ExitCode {
         ("fallback_runfiles_manifest", test_fallback_runfiles_manifest),
         ("run_runfiles_discovery", test_run_runfiles_discovery),
         ("relative_manifest_symlinks", test_relative_manifest_symlinks),
+        ("env_manifest_logical_argv0", test_env_manifest_logical_argv0),
         ("print_env", test_print_env),
         ("large_manifest", test_large_manifest),
     ];

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -1248,9 +1248,50 @@ fn test_relative_manifest_symlinks(config: &TestConfig) -> Result<(), String> {
     Ok(())
 }
 
+/// Build a tree whose manifest sends `_main/wrapper/bin/tool` out of its own
+/// directory, so the program's physical and logical paths differ. `materialize`
+/// controls whether that logical entry exists in the tree, as it would in a tree
+/// Bazel actually built.
+fn wrapper_runfiles(
+    config: &TestConfig,
+    test_dir: &Path,
+    materialize: bool,
+) -> Result<(RunfilesSetup, String), String> {
+    let mut runfiles = RunfilesSetup::new(test_dir, "parent")
+        .map_err(|e| format!("Failed to create runfiles: {}", e))?;
+    let target_rlocation = format!("tool_repo/bin/print-env{}", EXE_EXT);
+    runfiles
+        .add_file(
+            &target_rlocation,
+            &config.test_binaries_dir.join(format!("print-env{}", EXE_EXT)),
+        )
+        .map_err(|e| format!("Failed to add target: {}", e))?;
+    runfiles
+        .write_manifest()
+        .map_err(|e| format!("Failed to write manifest: {}", e))?;
+
+    // A relative target keeps the manifest portable and still lands outside the
+    // entry's own directory.
+    let entry_key = format!("{}/wrapper/bin/tool", WORKSPACE_NAME);
+    runfiles
+        .append_manifest_lines(&[(&entry_key, &format!("../../../{}", target_rlocation))])
+        .map_err(|e| format!("Failed to append relative entry: {}", e))?;
+
+    if materialize {
+        let entry = runfiles
+            .runfiles_dir
+            .join(entry_key.replace('/', &PATH_SEP.to_string()));
+        fs::create_dir_all(entry.parent().unwrap())
+            .map_err(|e| format!("Failed to create entry dir: {}", e))?;
+        fs::write(&entry, b"").map_err(|e| format!("Failed to materialize entry: {}", e))?;
+    }
+
+    Ok((runfiles, entry_key))
+}
+
 /// Regression test: an environment manifest whose tree is still on disk must keep
-/// argv[0] logical, or a venv interpreter shim strands CPython outside its venv.
-/// See https://github.com/aspect-build/rules_py/issues/1378.
+/// argv[0] on the program's runfiles path, not the physical location the manifest
+/// resolved to. See https://github.com/aspect-build/rules_py/issues/1378.
 fn test_env_manifest_logical_argv0(config: &TestConfig) -> Result<(), String> {
     println!("  Running test: env_manifest_logical_argv0");
 
@@ -1259,25 +1300,7 @@ fn test_env_manifest_logical_argv0(config: &TestConfig) -> Result<(), String> {
 
     // The tree is the parent's; the stub has none of its own, so the environment is
     // the only source the launcher can select.
-    let mut runfiles = RunfilesSetup::new(&test_dir, "parent")
-        .map_err(|e| format!("Failed to create runfiles: {}", e))?;
-    let interp_rlocation = format!("interpreter_repo/bin/print-env{}", EXE_EXT);
-    runfiles
-        .add_file(
-            &interp_rlocation,
-            &config.test_binaries_dir.join(format!("print-env{}", EXE_EXT)),
-        )
-        .map_err(|e| format!("Failed to add interpreter: {}", e))?;
-    runfiles
-        .write_manifest()
-        .map_err(|e| format!("Failed to write manifest: {}", e))?;
-
-    // A venv interpreter shim: relative for manifest portability, and landing
-    // outside the venv so the physical and logical paths differ.
-    let entry_key = format!("{}/venv/bin/python", WORKSPACE_NAME);
-    runfiles
-        .append_manifest_lines(&[(&entry_key, &format!("../../../{}", interp_rlocation))])
-        .map_err(|e| format!("Failed to append relative entry: {}", e))?;
+    let (mut runfiles, entry_key) = wrapper_runfiles(config, &test_dir, true)?;
 
     let stub_path = test_dir.join(format!("child_stub{}", EXE_EXT));
     finalize_stub(config, &stub_path, &[&entry_key], &[0])?;
@@ -1318,7 +1341,7 @@ fn test_env_manifest_logical_argv0(config: &TestConfig) -> Result<(), String> {
             if actual != Some(expected_argv0.to_string_lossy().as_ref()) {
                 return Err(format!(
                     "Environment manifest ({}) did not preserve logical argv[0]; the \
-                     child was launched as the physical interpreter.\nexpected: {}\nstdout: {}",
+                     child was launched as its physical path.\nexpected: {}\nstdout: {}",
                     layout,
                     expected_argv0.display(),
                     stdout
@@ -1328,6 +1351,61 @@ fn test_env_manifest_logical_argv0(config: &TestConfig) -> Result<(), String> {
     }
 
     println!("    PASS (logical argv[0] preserved for both manifest layouts)");
+
+    Ok(())
+}
+
+/// Regression test: an inferred tree that was never materialized must not be used
+/// for argv[0]. `<tree>/MANIFEST` is the case that hides this — opening the manifest
+/// already proves its parent directory exists, so probing the directory says nothing
+/// about whether the tree was built. Overriding argv[0] from it would name a path
+/// that does not exist, which is worse than leaving the physical path alone.
+fn test_sparse_inferred_tree_keeps_physical_argv0(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: sparse_inferred_tree_keeps_physical_argv0");
+
+    let test_dir = config.work_dir.join("test_sparse_inferred_tree");
+    fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {}", e))?;
+
+    // Same tree, except the logical entry is absent — a sparse or unbuilt tree.
+    let (mut runfiles, entry_key) = wrapper_runfiles(config, &test_dir, false)?;
+
+    let stub_path = test_dir.join(format!("sparse_stub{}", EXE_EXT));
+    finalize_stub(config, &stub_path, &[&entry_key], &[0])?;
+
+    let in_tree_manifest = runfiles.runfiles_dir.join("MANIFEST");
+    fs::copy(&runfiles.manifest_path, &in_tree_manifest)
+        .map_err(|e| format!("Failed to place in-tree manifest: {}", e))?;
+    runfiles.manifest_path = in_tree_manifest;
+
+    let (stdout, stderr, exit_code) = run_stub(&stub_path, &runfiles, &[], true)?;
+    if exit_code != 0 {
+        return Err(format!(
+            "Stub failed with exit code {}.\nstdout: {}\nstderr: {}",
+            exit_code, stdout, stderr
+        ));
+    }
+
+    #[cfg(unix)]
+    {
+        let physical = runfiles
+            .runfiles_dir
+            .join(format!("tool_repo/bin/print-env{}", EXE_EXT).replace('/', &PATH_SEP.to_string()));
+        let actual = stdout
+            .lines()
+            .next()
+            .and_then(|line| line.strip_prefix("ARGS:"))
+            .and_then(|args| args.split('|').next());
+        if actual != Some(physical.to_string_lossy().as_ref()) {
+            return Err(format!(
+                "argv[0] was overridden from a tree that was never materialized.\n\
+                 expected the physical path: {}\nstdout: {}",
+                physical.display(),
+                stdout
+            ));
+        }
+    }
+
+    println!("    PASS (sparse inferred tree left argv[0] physical)");
 
     Ok(())
 }
@@ -1564,6 +1642,10 @@ fn main() -> ExitCode {
         ("run_runfiles_discovery", test_run_runfiles_discovery),
         ("relative_manifest_symlinks", test_relative_manifest_symlinks),
         ("env_manifest_logical_argv0", test_env_manifest_logical_argv0),
+        (
+            "sparse_inferred_tree_keeps_physical_argv0",
+            test_sparse_inferred_tree_keeps_physical_argv0,
+        ),
         ("print_env", test_print_env),
         ("large_manifest", test_large_manifest),
     ];

--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -66,6 +66,16 @@ fn resolve_runfile_path(runfiles: &Runfiles, path: PathBuf) -> PathBuf {
     rlocation!(runfiles, runfiles_key.as_str()).unwrap_or(path)
 }
 
+/// argv[0] as print-env reported it: the first `|`-separated field of `ARGS:`.
+#[cfg(unix)]
+fn reported_argv0(stdout: &str) -> Option<&str> {
+    stdout
+        .lines()
+        .next()
+        .and_then(|line| line.strip_prefix("ARGS:"))
+        .and_then(|args| args.split('|').next())
+}
+
 fn environment_path<'a>(stdout: &'a str, name: &str) -> Option<&'a Path> {
     let prefix = format!("ENV:{}=", name);
     stdout
@@ -1040,12 +1050,7 @@ fn test_fallback_runfiles_manifest(config: &TestConfig) -> Result<(), String> {
     #[cfg(unix)]
     {
         let expected = runfiles_dir.join(&print_env_rlocation);
-        let actual = stdout
-            .lines()
-            .next()
-            .and_then(|line| line.strip_prefix("ARGS:"))
-            .and_then(|args| args.split('|').next());
-        if actual != Some(expected.to_string_lossy().as_ref()) {
+        if reported_argv0(&stdout) != Some(expected.to_string_lossy().as_ref()) {
             return Err(format!(
                 "Adjacent manifest did not preserve logical argv[0].\nexpected: {}\nstdout: {}",
                 expected.display(),
@@ -1306,9 +1311,6 @@ fn test_env_manifest_logical_argv0(config: &TestConfig) -> Result<(), String> {
     finalize_stub(config, &stub_path, &[&entry_key], &[0])?;
 
     let written_manifest = runfiles.manifest_path.clone();
-    let expected_argv0 = runfiles
-        .runfiles_dir
-        .join(entry_key.replace('/', &PATH_SEP.to_string()));
 
     // Both layouts Bazel writes a manifest in name the same tree.
     for (layout, manifest_path) in [
@@ -1333,12 +1335,10 @@ fn test_env_manifest_logical_argv0(config: &TestConfig) -> Result<(), String> {
         // Windows derives argv[0] from the command line; the override is Unix-only.
         #[cfg(unix)]
         {
-            let actual = stdout
-                .lines()
-                .next()
-                .and_then(|line| line.strip_prefix("ARGS:"))
-                .and_then(|args| args.split('|').next());
-            if actual != Some(expected_argv0.to_string_lossy().as_ref()) {
+            let expected_argv0 = runfiles
+                .runfiles_dir
+                .join(entry_key.replace('/', &PATH_SEP.to_string()));
+            if reported_argv0(&stdout) != Some(expected_argv0.to_string_lossy().as_ref()) {
                 return Err(format!(
                     "Environment manifest ({}) did not preserve logical argv[0]; the \
                      child was launched as its physical path.\nexpected: {}\nstdout: {}",
@@ -1390,12 +1390,7 @@ fn test_sparse_inferred_tree_keeps_physical_argv0(config: &TestConfig) -> Result
         let physical = runfiles
             .runfiles_dir
             .join(format!("tool_repo/bin/print-env{}", EXE_EXT).replace('/', &PATH_SEP.to_string()));
-        let actual = stdout
-            .lines()
-            .next()
-            .and_then(|line| line.strip_prefix("ARGS:"))
-            .and_then(|args| args.split('|').next());
-        if actual != Some(physical.to_string_lossy().as_ref()) {
+        if reported_argv0(&stdout) != Some(physical.to_string_lossy().as_ref()) {
             return Err(format!(
                 "argv[0] was overridden from a tree that was never materialized.\n\
                  expected the physical path: {}\nstdout: {}",
@@ -1456,12 +1451,7 @@ fn test_print_env(config: &TestConfig) -> Result<(), String> {
         let expected = runfiles
             .get_path(&print_env_rlocation)
             .ok_or_else(|| format!("Missing manifest entry for {}", print_env_rlocation))?;
-        let actual = stdout
-            .lines()
-            .next()
-            .and_then(|line| line.strip_prefix("ARGS:"))
-            .and_then(|args| args.split('|').next());
-        if actual != Some(expected.to_string_lossy().as_ref()) {
+        if reported_argv0(&stdout) != Some(expected.to_string_lossy().as_ref()) {
             return Err(format!(
                 "Environment manifest changed argv[0].\nexpected: {}\nstdout: {}",
                 expected.display(),

--- a/runfiles-stub/src/runfiles.rs
+++ b/runfiles-stub/src/runfiles.rs
@@ -38,8 +38,10 @@ impl Runfiles {
                     .and_then(|path| {
                         load_manifest(&path).map(|manifest| Self::Manifest {
                             manifest,
+                            // A manifest source does not imply the tree is
+                            // absent; recover it so argv[0] stays logical.
+                            logical_dir: sibling_runfiles_dir(&path),
                             path,
-                            logical_dir: None,
                         })
                     })
             },
@@ -148,6 +150,25 @@ fn dir_exists(path: &str) -> bool {
     let mut path_with_null = Vec::from(path_with_separator.as_bytes());
     path_with_null.push(0);
     platform::path_exists(&path_with_null)
+}
+
+/// The runfiles tree a manifest path names, if materialized. Bazel writes the
+/// manifest as `<binary>.runfiles_manifest` or as `MANIFEST` inside the tree.
+fn sibling_runfiles_dir(manifest_path: &str) -> Option<String> {
+    let dir = manifest_path
+        .strip_suffix("_manifest")
+        .filter(|dir| dir.ends_with(".runfiles"))
+        .or_else(|| manifest_dir(manifest_path))?;
+    dir_exists(dir).then(|| String::from(dir))
+}
+
+/// The directory holding a `MANIFEST` file, for either path separator.
+fn manifest_dir(path: &str) -> Option<&str> {
+    let parent = path.strip_suffix("MANIFEST")?;
+    let parent = parent
+        .strip_suffix('/')
+        .or_else(|| parent.strip_suffix(platform::SEP))?;
+    (!parent.is_empty()).then_some(parent)
 }
 
 fn load_manifest(path: &str) -> Option<Manifest> {

--- a/runfiles-stub/src/runfiles.rs
+++ b/runfiles-stub/src/runfiles.rs
@@ -109,6 +109,9 @@ impl Runfiles {
         }
     }
 
+    /// The runfiles path to launch `path` under. Consumed only where the launcher
+    /// controls argv[0]; on Windows argv[0] comes from the command line, so nothing
+    /// here reaches the child.
     pub fn argv0_rlocation(&self, path: &str) -> Option<String> {
         match self {
             Self::Directory { path: dir } => Some(join_runfiles_path(dir, path)),

--- a/runfiles-stub/src/runfiles.rs
+++ b/runfiles-stub/src/runfiles.rs
@@ -181,6 +181,12 @@ fn dir_exists(path: &str) -> bool {
 /// `<binary>.runfiles_manifest` or as `MANIFEST` inside the tree. Whether that
 /// tree is materialized is settled per entry, in `argv0_rlocation`.
 fn inferred_runfiles_dir(manifest_path: &str) -> Option<LogicalDir> {
+    // A relative manifest names a relative tree, so the argv[0] built from it
+    // holds only while the child keeps our working directory. Manifest targets
+    // are absolute, making the physical path the safer identity.
+    if !platform::is_absolute(manifest_path) {
+        return None;
+    }
     manifest_path
         .strip_suffix("_manifest")
         .filter(|dir| dir.ends_with(".runfiles"))

--- a/runfiles-stub/src/runfiles.rs
+++ b/runfiles-stub/src/runfiles.rs
@@ -14,11 +14,22 @@ pub enum Runfiles {
     Manifest {
         manifest: Manifest,
         path: String,
-        logical_dir: Option<String>,
+        logical_dir: Option<LogicalDir>,
     },
     Directory {
         path: String,
     },
+}
+
+/// The tree used to give argv[0] a runfiles path when a manifest is the source.
+pub enum LogicalDir {
+    /// Named by the executable's own location, so correct whether or not it was
+    /// materialized.
+    Adjacent(String),
+    /// Inferred from the manifest's path, which proves nothing about the tree:
+    /// for `<tree>/MANIFEST` it is just the file's own parent. Usable only where
+    /// the entry it would name is materialized.
+    Inferred(String),
 }
 
 impl Runfiles {
@@ -40,7 +51,7 @@ impl Runfiles {
                             manifest,
                             // A manifest source does not imply the tree is
                             // absent; recover it so argv[0] stays logical.
-                            logical_dir: sibling_runfiles_dir(&path),
+                            logical_dir: inferred_runfiles_dir(&path),
                             path,
                         })
                     })
@@ -74,7 +85,7 @@ impl Runfiles {
                             // Preserve the logical path even though the sibling
                             // tree is absent; the manifest selected the actual
                             // executable.
-                            logical_dir: Some(runfiles_dir.clone()),
+                            logical_dir: Some(LogicalDir::Adjacent(runfiles_dir.clone())),
                         })
                     },
                 ) {
@@ -99,11 +110,18 @@ impl Runfiles {
     }
 
     pub fn argv0_rlocation(&self, path: &str) -> Option<String> {
-        let dir = match self {
-            Self::Directory { path } => path,
-            Self::Manifest { logical_dir, .. } => logical_dir.as_ref()?,
-        };
-        Some(join_runfiles_path(dir, path))
+        match self {
+            Self::Directory { path: dir } => Some(join_runfiles_path(dir, path)),
+            Self::Manifest { logical_dir, .. } => match logical_dir.as_ref()? {
+                LogicalDir::Adjacent(dir) => Some(join_runfiles_path(dir, path)),
+                // Only an entry that is really there can stand in for argv[0];
+                // a sparse or unbuilt tree would name a path that does not exist.
+                LogicalDir::Inferred(dir) => {
+                    let entry = join_runfiles_path(dir, path);
+                    exists(&entry).then_some(entry)
+                }
+            },
+        }
     }
 
     pub fn manifest_path(&self) -> Option<&str> {
@@ -140,6 +158,12 @@ fn select_source(
     }
 }
 
+fn exists(path: &str) -> bool {
+    let mut path_with_null = Vec::from(path.as_bytes());
+    path_with_null.push(0);
+    platform::path_exists(&path_with_null)
+}
+
 fn dir_exists(path: &str) -> bool {
     // A trailing separator makes the existing-path probe directory-specific on
     // Unix and Windows: regular files cannot be traversed as directories.
@@ -147,19 +171,18 @@ fn dir_exists(path: &str) -> bool {
     if !path.ends_with('/') && !path.ends_with(platform::SEP) {
         path_with_separator.push(platform::SEP);
     }
-    let mut path_with_null = Vec::from(path_with_separator.as_bytes());
-    path_with_null.push(0);
-    platform::path_exists(&path_with_null)
+    exists(&path_with_separator)
 }
 
-/// The runfiles tree a manifest path names, if materialized. Bazel writes the
-/// manifest as `<binary>.runfiles_manifest` or as `MANIFEST` inside the tree.
-fn sibling_runfiles_dir(manifest_path: &str) -> Option<String> {
-    let dir = manifest_path
+/// The runfiles tree a manifest path names. Bazel writes the manifest as
+/// `<binary>.runfiles_manifest` or as `MANIFEST` inside the tree. Whether that
+/// tree is materialized is settled per entry, in `argv0_rlocation`.
+fn inferred_runfiles_dir(manifest_path: &str) -> Option<LogicalDir> {
+    manifest_path
         .strip_suffix("_manifest")
         .filter(|dir| dir.ends_with(".runfiles"))
-        .or_else(|| manifest_dir(manifest_path))?;
-    dir_exists(dir).then(|| String::from(dir))
+        .or_else(|| manifest_dir(manifest_path))
+        .map(|dir| LogicalDir::Inferred(String::from(dir)))
 }
 
 /// The directory holding a `MANIFEST` file, for either path separator.


### PR DESCRIPTION
A parent that exports only `RUNFILES_MANIFEST_FILE` — runfiles_export_envvars under `--nobuild_runfile_links`, or a wrapper that drops `RUNFILES_DIR` — hands its child a manifest while the tree it names is still materialized. That tier left `logical_dir` unset, so `argv[0]` fell back to the physical path the manifest resolved to.

`argv[0]` is how a launched program finds what its runfiles tree places beside it: the runfiles libraries derive their own tree from it, and interpreter shims read the config file next to them to select the environment they run under. The
physical path a manifest resolves to is where the file is stored — an output base, a cache, another repository's directory — and none of those neighbours are there. The program starts anyway, with an empty or wrong view of its own environment.

Recover the tree from either manifest layout Bazel writes (`<binary>.runfiles_manifest` and `<tree>/MANIFEST`), splitting `logical_dir` into `Adjacent` and `Inferred`. An adjacent tree is named by the executable's own location, so it holds whether or not the tree was built; an inferred one is only read off the manifest path, and carries two conditions the adjacent case does not need.

The entry it would name must be on disk: under `--nobuild_runfile_links` the manifest really is all there is, and `<tree>/MANIFEST` hides that, since opening the manifest already proves its parent directory exists. And the manifest path must be absolute: a relative one names a relative tree, so the `argv[0]` built from it would hold only while the child kept our working directory, while the manifest's own targets are absolute either way. Both conditions fall back to the physical path, which is what shipped before.

Refs: https://github.com/aspect-build/rules_py/issues/1378, https://github.com/aspect-build/rules_py/pull/1385