### PR TITLE
fix: refuse to launch when argv[0]'s runfiles path is unrecoverable

### DIFF
--- a/integration-tests/src/main.rs
+++ b/integration-tests/src/main.rs
@@ -1460,6 +1460,48 @@ fn test_relative_env_manifest_keeps_physical_argv0(config: &TestConfig) -> Resul
     Ok(())
 }
 
+/// Regression test: under `--nobuild_runfile_links` nothing can name the program's
+/// runfiles path, so a program locating anything from argv[0] would resolve against
+/// the wrong directory — fail instead of launching. `relative_manifest_symlinks`
+/// covers a manifest that names no tree and must still launch.
+/// See https://github.com/aspect-build/rules_py/issues/1378.
+fn test_unrecoverable_logical_argv0(config: &TestConfig) -> Result<(), String> {
+    println!("  Running test: unrecoverable_logical_argv0");
+
+    let test_dir = config.work_dir.join("test_unrecoverable_argv0");
+    fs::create_dir_all(&test_dir).map_err(|e| format!("Failed to create test dir: {}", e))?;
+
+    // The same wrapper tree, reached through a conventionally-named manifest whose
+    // own tree was never built.
+    let (mut runfiles, entry_key) = wrapper_runfiles(config, &test_dir, false)?;
+    let manifest_path = test_dir.join("nolinks.runfiles_manifest");
+    fs::copy(&runfiles.manifest_path, &manifest_path)
+        .map_err(|e| format!("Failed to place manifest: {}", e))?;
+    runfiles.manifest_path = manifest_path;
+
+    let stub_path = test_dir.join(format!("nolinks_stub{}", EXE_EXT));
+    finalize_stub(config, &stub_path, &[&entry_key], &[0])?;
+
+    let (stdout, _stderr, exit_code) = run_stub(&stub_path, &runfiles, &[], true)?;
+
+    if exit_code == 0 {
+        return Err(format!(
+            "Stub launched with an unrecoverable argv[0] instead of failing.\nstdout: {}",
+            stdout
+        ));
+    }
+    if !stdout.contains("Cannot preserve the program's runfiles path in argv[0]") {
+        return Err(format!(
+            "Stub failed without explaining why argv[0] could not be preserved.\nstdout: {}",
+            stdout
+        ));
+    }
+
+    println!("    PASS (refused to launch, diagnosed argv[0])");
+
+    Ok(())
+}
+
 /// Test: print-env to verify environment and argument passing
 fn test_print_env(config: &TestConfig) -> Result<(), String> {
     println!("  Running test: print_env");
@@ -1694,6 +1736,10 @@ fn main() -> ExitCode {
         (
             "relative_env_manifest_keeps_physical_argv0",
             test_relative_env_manifest_keeps_physical_argv0,
+        ),
+        (
+            "unrecoverable_logical_argv0",
+            test_unrecoverable_logical_argv0,
         ),
         ("print_env", test_print_env),
         ("large_manifest", test_large_manifest),

--- a/runfiles-stub/src/run.rs
+++ b/runfiles-stub/src/run.rs
@@ -149,9 +149,26 @@ pub fn main(rt: platform::RuntimeArgs) -> ! {
                 return None;
             }
             let arg0 = core::str::from_utf8(&arg0[..arg0_len]).ok()?;
-            let mut path = Vec::from(rf.argv0_rlocation(arg0)?.as_bytes());
-            path.push(0);
-            Some(path)
+            if let Some(logical) = rf.argv0_rlocation(arg0) {
+                let mut path = Vec::from(logical.as_bytes());
+                path.push(0);
+                return Some(path);
+            }
+            // Launching without that identity strands anything the program derives
+            // from argv[0], silently and far from the cause, so refuse to guess.
+            // A literal argument 0 never claimed a runfiles path, so it loses none.
+            if transform_flags & 1 != 0 && rf.logical_identity_lost(arg0) {
+                eline(b"ERROR: Cannot preserve the program's runfiles path in argv[0].");
+                platform::print(b"  program: ");
+                platform::print(arg0.as_bytes());
+                platform::print(platform::NEWLINE);
+                eline(b"The manifest reaches it through a relative target and its runfiles tree was");
+                eline(b"never built, so anything the program locates from argv[0] would resolve");
+                eline(b"against the wrong directory.");
+                eline(b"Set RUNFILES_DIR to the materialized tree, or build with runfile links.");
+                platform::exit(1);
+            }
+            None
         });
 
     let launch = Launch {

--- a/runfiles-stub/src/runfiles.rs
+++ b/runfiles-stub/src/runfiles.rs
@@ -109,6 +109,25 @@ impl Runfiles {
         }
     }
 
+    /// Whether nothing is left to name `path` for argv[0]: a relative manifest
+    /// target moves it off its runfiles path, and the tree that could still name
+    /// it was never built. A tree on disk is recoverable, not lost.
+    pub fn logical_identity_lost(&self, path: &str) -> bool {
+        match self {
+            Self::Directory { .. } => false,
+            Self::Manifest {
+                manifest,
+                logical_dir,
+                ..
+            } => {
+                matches!(logical_dir, Some(LogicalDir::Inferred(dir)) if !dir_exists(dir))
+                    && manifest
+                        .lookup(path)
+                        .is_some_and(|target| !platform::is_absolute(target))
+            }
+        }
+    }
+
     /// The runfiles path to launch `path` under. Consumed only where the launcher
     /// controls argv[0]; on Windows argv[0] comes from the command line, so nothing
     /// here reaches the child.


### PR DESCRIPTION
Resolution follows relative manifest targets to wherever the program actually lives, which is correct — but that location is not the runfiles path the caller asked for. When no tree can express that runfiles path as `argv[0]`, launching looks like success while anything the program locates from `argv[0]` resolves against the wrong directory: the runfiles libraries' `argv[0]` fallback, a relocatable `dirname(argv[0])/../share` lookup, or an interpreter deriving its prefix from it.

Report that instead of guessing, but only when it is genuinely unrecoverable: the manifest names a tree (the two layouts Bazel writes) and that tree is absent from disk, as under `--nobuild_runfile_links`. A named tree still on disk is
recoverable, an unconventionally-named manifest names no tree at all, and a relative manifest path already falls back to the physical location by design — none are reported, so resolving relative chains keeps working.

Refs: https://github.com/aspect-build/rules_py/issues/1378