### PR TITLE
feat: wire s390x prebuilt binaries into toolchain registrations

### DIFF
--- a/launcher/private/prebuilt/BUILD.bazel
+++ b/launcher/private/prebuilt/BUILD.bazel
@@ -11,6 +11,7 @@ launcher_stub_toolchains(
     finalizers = {
         "aarch64_linux": "@finalize_stub_aarch64_linux//file",
         "aarch64_macos": "@finalize_stub_aarch64_macos//file",
+        "s390x_linux": "@finalize_stub_s390x_linux//file",
         "x86_64_linux": "@finalize_stub_x86_64_linux//file",
         "x86_64_macos": "@finalize_stub_x86_64_macos//file",
         "x86_64_windows": "@finalize_stub_x86_64_windows//file",
@@ -18,6 +19,7 @@ launcher_stub_toolchains(
     templates = {
         "aarch64_linux": "@runfiles_stub_aarch64_linux//file",
         "aarch64_macos": "@runfiles_stub_aarch64_macos//file",
+        "s390x_linux": "@runfiles_stub_s390x_linux//file",
         "x86_64_linux": "@runfiles_stub_x86_64_linux//file",
         "x86_64_macos": "@runfiles_stub_x86_64_macos//file",
         "x86_64_windows": "@runfiles_stub_x86_64_windows//file",

--- a/launcher/private/source_built/BUILD.bazel
+++ b/launcher/private/source_built/BUILD.bazel
@@ -18,6 +18,7 @@ launcher_stub_toolchains(
     finalizers = {
         "aarch64_linux": "//finalize-stub:finalize-stub_aarch64-unknown-linux-musl",
         "aarch64_macos": "//finalize-stub:finalize-stub_aarch64-apple-darwin",
+        "s390x_linux": "//finalize-stub:finalize-stub_s390x-unknown-linux-musl",
         "x86_64_linux": "//finalize-stub:finalize-stub_x86_64-unknown-linux-musl",
         "x86_64_macos": "//finalize-stub:finalize-stub_x86_64-apple-darwin",
         "x86_64_windows": "//finalize-stub:finalize-stub_x86_64-pc-windows-gnullvm",
@@ -25,6 +26,7 @@ launcher_stub_toolchains(
     templates = {
         "aarch64_linux": "//runfiles-stub:runfiles-stub_aarch64-unknown-linux-musl",
         "aarch64_macos": "//runfiles-stub:runfiles-stub_aarch64-apple-darwin",
+        "s390x_linux": "//runfiles-stub:runfiles-stub_s390x-unknown-linux-musl",
         "x86_64_linux": "//runfiles-stub:runfiles-stub_x86_64-unknown-linux-musl",
         "x86_64_macos": "//runfiles-stub:runfiles-stub_x86_64-apple-darwin",
         "x86_64_windows": "//runfiles-stub:runfiles-stub_x86_64-pc-windows-gnullvm",

--- a/launcher/private/toolchains.bzl
+++ b/launcher/private/toolchains.bzl
@@ -22,14 +22,15 @@ _executable_file = rule(
     attrs = {"src": attr.label(mandatory = True)},
 )
 
-# The platforms toolchains are registered for. This is intentionally a subset of
-# the released triples: s390x and Windows/aarch64 ship for standalone use but have
-# no auto-registered Bazel toolchain (see README "Supported platforms").
+# The platforms toolchains are registered for. Windows/aarch64 ships for
+# standalone use but has no auto-registered Bazel toolchain (see README
+# "Supported platforms").
 #
 # (name, cpu, os)
 PLATFORMS = [
     ("aarch64_linux", "aarch64", "linux"),
     ("aarch64_macos", "aarch64", "macos"),
+    ("s390x_linux", "s390x", "linux"),
     ("x86_64_linux", "x86_64", "linux"),
     ("x86_64_macos", "x86_64", "macos"),
     ("x86_64_windows", "x86_64", "windows"),

--- a/launcher/template/BUILD.bazel
+++ b/launcher/template/BUILD.bazel
@@ -32,9 +32,16 @@ file_binary(
     visibility = ["//visibility:public"],
 )
 
+file_binary(
+    name = "prebuilt_s390x_linux",
+    exe = "@runfiles_stub_s390x_linux//file",
+    visibility = ["//visibility:public"],
+)
+
 _select_arms = {
     "//launcher/private/platform_config_settings:aarch64_linux": ":prebuilt_aarch64_linux",
     "//launcher/private/platform_config_settings:aarch64_macos": ":prebuilt_aarch64_macos",
+    "//launcher/private/platform_config_settings:s390x_linux": ":prebuilt_s390x_linux",
     "//launcher/private/platform_config_settings:x86_64_linux": ":prebuilt_x86_64_linux",
     "//launcher/private/platform_config_settings:x86_64_macos": ":prebuilt_x86_64_macos",
     "//launcher/private/platform_config_settings:x86_64_windows": ":prebuilt_x86_64_windows",


### PR DESCRIPTION
The s390x platform support (binary builds, config_setting, CI) was added in #21, with prebuilt toolchain wiring deferred until binaries were published. Binaries have been shipping since binaries-20260508 and extensions.bzl already downloads them, but the prebuilt toolchains and template select were never updated to include s390x.

This causes "No matching toolchains found for finalizer_toolchain_type" and "configurable attribute doesn't match this configuration" errors when building or pushing container images on s390x.

- Add s390x_linux to prebuilt toolchain registrations (template + finalizer)
- Add prebuilt_s390x_linux file_binary and select arm to launcher/template