### PR TITLE
test: macos on x86

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -186,6 +186,15 @@ jobs:
       - env:
           BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
         run: bazel test ${BUILDBUDDY_API_KEY:+--config=cache} --config=release //integration-tests:integration_test
+      # The same suite against the x86_64 stub, which this Apple silicon runner
+      # executes under Rosetta. A register the kernel clobbers is only caught on the
+      # arch whose register allocation parks a live value in it, so the host-arch run
+      # above cannot see it (see integration-tests/BUILD.bazel). Idempotent: exits 0
+      # when Rosetta is already present.
+      - run: sudo softwareupdate --install-rosetta --agree-to-license
+      - env:
+          BUILDBUDDY_API_KEY: ${{ secrets.BUILDBUDDY_API_KEY }}
+        run: bazel test ${BUILDBUDDY_API_KEY:+--config=cache} --config=release //integration-tests:integration_test_x86_64_macos
       # End-to-end launcher_binary tests, run against BOTH the prebuilt (downloaded)
       # and the source-built stubs (see //e2e). --config=release builds the
       # source-built stubs exactly as they ship.

--- a/integration-tests/BUILD.bazel
+++ b/integration-tests/BUILD.bazel
@@ -130,3 +130,32 @@ rust_test(
     edition = "2021",
     use_libtest_harness = False,
 )
+
+# The same suite against the released x86_64 macOS stub, which an Apple silicon
+# host runs under Rosetta. The stub reaches the kernel through hand-written
+# `syscall` asm, so a register the kernel clobbers is only caught where that
+# arch's register allocation puts a live value in it — the host-arch suite cannot
+# see it. Optimization decides that allocation, so this needs --config=release.
+# The finalizer runs on the host, so it stays the host-arch one.
+rust_test(
+    name = "integration_test_x86_64_macos",
+    srcs = ["src/main.rs"],
+    args = [
+        "--template",
+        "$(rlocationpath //runfiles-stub:runfiles-stub_x86_64-apple-darwin)",
+        "--finalizer",
+        "$(rlocationpath :release-finalizer)",
+        "--test-binaries",
+        "$(rlocationpath :test-binaries)",
+    ],
+    data = [
+        ":release-finalizer",
+        ":test-binaries",
+        "//runfiles-stub:runfiles-stub_x86_64-apple-darwin",
+    ],
+    deps = ["@rules_rust//rust/runfiles"],
+    edition = "2021",
+    tags = ["requires-rosetta"],
+    target_compatible_with = ["@platforms//os:macos"],
+    use_libtest_harness = False,
+)

--- a/runfiles-stub/src/macos.rs
+++ b/runfiles-stub/src/macos.rs
@@ -141,7 +141,7 @@ mod sc {
             core::arch::asm!(
                 "svc #0x80",
                 inout("x16") $nr as i64 => _, inout("x0") $a1 as i64 => _,
-                options(nostack))
+                lateout("x1") _, options(nostack))
         };
     }
     macro_rules! syscall2 {
@@ -194,6 +194,8 @@ mod sc {
 // macOS x86_64: the BSD class selector is OR'd into the number, the `syscall`
 // instruction additionally clobbers rcx and r11, and the 4th argument goes in r10
 // (not rcx). Carry-clear (`jnc`) marks success; failure is negated to `-errno`.
+// The kernel returns a second value in rdx and zeroes it otherwise, so every macro
+// declares rdx written even when it passes no third argument.
 #[cfg(target_arch = "x86_64")]
 mod sc {
     // BSD (unix) syscall class selector OR'd into the call number. Inlined as a plain
@@ -212,7 +214,7 @@ mod sc {
             core::arch::asm!(
                 "syscall",
                 inout("rax") (0x2000000i64 | ($nr as i64)) => _, inout("rdi") $a1 as i64 => _,
-                lateout("rcx") _, lateout("r11") _, options(nostack))
+                lateout("rdx") _, lateout("rcx") _, lateout("r11") _, options(nostack))
         };
     }
     macro_rules! syscall2 {
@@ -225,7 +227,7 @@ mod sc {
                 "3:",
                 inout("rax") (0x2000000i64 | ($nr as i64)) => ret, inout("rdi") $a1 as i64 => _,
                 inout("rsi") $a2 as i64 => _,
-                lateout("rcx") _, lateout("r11") _, options(nostack));
+                lateout("rdx") _, lateout("rcx") _, lateout("r11") _, options(nostack));
             ret as $ty
         }};
     }


### PR DESCRIPTION
I'm getting errors on BCR CI when `hermetic-launcher` is used on an x86 mac: https://buildkite.com/bazel/bcr-presubmit/builds/39205#019fee4d-3091-47a2-b35a-caa2a834cec3 (failed test logs: https://storage.googleapis.com/bazel-untrusted-buildkite-artifacts/019fee4d-3091-47a2-b35a-caa2a834cec3/venv-manifest-runfiles-1378/test/test_attempts/attempt_1.log) but the main part is:

>  ERROR: Failed to initialize runfiles
Set RUNFILES_DIR or RUNFILES_MANIFEST_FILE, or ensure <executable>.runfiles/ directory exists

A robot claims:
> The kernel returns a second value in rdx and zeroes it otherwise, so rdx does
not survive a syscall — but syscall_void! and syscall2! declared only rax/rdi/
rsi plus rcx/r11 as written. In an optimized x86_64 build LLVM took that at its
word and parked the mmap result in rdx across the close() in load_manifest, so
every manifest read came back null:

    movq %rax, %rdx        ; mmap result
    movl $0x2000006, %eax  ; close(fd)
    syscall
    testq %rdx, %rdx       ; kernel zeroed it
    jle  <fail>

> A binary whose only runfiles source is RUNFILES_MANIFEST_FILE then failed to
initialize runfiles at all. Only optimized builds hit it, since register
allocation is what puts a live value in rdx, and only on x86_64 — arm64
allocates elsewhere, though its second return register x1 carries the same
hazard, so declare it too.